### PR TITLE
Re factor move to lib

### DIFF
--- a/py_gtfs_rt_ingestion/ingest.py
+++ b/py_gtfs_rt_ingestion/ingest.py
@@ -46,10 +46,9 @@ def convert_json_to_parquet(input_filename: str, output_dir: str) -> None:
     * append to the table for each element the entities list in the json file
     * write the table
     """
-    config = Configuration.from_filename(input_filename)
+    config = Configuration(input_filename)
 
-    schema = config.get_schema()
-    table = {key.name:[] for key in schema}
+    table = {key.name:[] for key in config.export_schema}
 
     with gzip.open(Path(input_filename), 'rb') as f:
         json_data = json.loads(f.read())
@@ -74,7 +73,7 @@ def convert_json_to_parquet(input_filename: str, output_dir: str) -> None:
                 table[key].append(record[key])
 
     pq.write_to_dataset(
-        pa.table(table, schema=schema),
+        pa.table(table, schema=config.export_schema),
         root_path=output_dir,
         partition_cols=['year','month','day','hour']
     )

--- a/py_gtfs_rt_ingestion/ingest.py
+++ b/py_gtfs_rt_ingestion/ingest.py
@@ -11,7 +11,7 @@ import pyarrow.parquet as pq
 from datetime import datetime
 from pathlib import Path
 
-from py_gtfs_rt_ingestion import Configuration
+from py_gtfs_rt_ingestion.configuration import Configuration
 
 DESCRIPTION = "Convert a json file into a parquet file. Used for testing."
 

--- a/py_gtfs_rt_ingestion/ingest.py
+++ b/py_gtfs_rt_ingestion/ingest.py
@@ -11,7 +11,7 @@ import pyarrow.parquet as pq
 from datetime import datetime
 from pathlib import Path
 
-from py_gtfs_rt_ingestion.configuration import Configuration
+from py_gtfs_rt_ingestion import Configuration
 
 DESCRIPTION = "Convert a json file into a parquet file. Used for testing."
 

--- a/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/__init__.py
+++ b/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/__init__.py
@@ -2,4 +2,3 @@ __version__ = '0.1.0'
 
 from .configuration import Configuration
 from .config_base import ConfigType
-from .config_base import ConfigDetail

--- a/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/__init__.py
+++ b/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/__init__.py
@@ -1,3 +1,5 @@
 __version__ = '0.1.0'
 
 from .configuration import Configuration
+from .config_base import ConfigType
+from .config_base import ConfigDetails

--- a/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/__init__.py
+++ b/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/__init__.py
@@ -2,4 +2,4 @@ __version__ = '0.1.0'
 
 from .configuration import Configuration
 from .config_base import ConfigType
-from .config_base import ConfigDetails
+from .config_base import ConfigDetail

--- a/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/config_base.py
+++ b/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/config_base.py
@@ -23,7 +23,7 @@ class ConfigDetail(ABC):
     """
     Abstract Base Class for all ConfigDetail implementations.
 
-    ConfigDetails classes must implement all methods and properties that are defined.
+    ConfigDetail classes must implement all methods and properties that are defined.
     """
     @property
     @abstractmethod

--- a/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/config_base.py
+++ b/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/config_base.py
@@ -1,0 +1,38 @@
+from abc import ABC
+from abc import abstractmethod
+
+from enum import auto
+from enum import Enum
+
+import pyarrow
+
+class ConfigType(Enum):
+    """
+    ConfigType is and Enumaration taht is inclusive of all 
+    configurations types to be processed by this library
+
+    """
+    RT_ALERTS = auto()
+    RT_TRIP_UPDATES = auto()
+    RT_VEHICLE_POSITIONS = auto()
+    BUS_TRIP_UPDATES = auto()
+    BUS_VEHICLE_POSITIONS = auto()
+    VEHICLE_COUNT = auto()
+
+class ConfigDetails(ABC):
+    """
+    Abstract Base Class for all Configuration Details implementations.
+
+    Configuration Details classes must implement all methods and properties
+    as defined by ConfigDetails.
+    """
+    @property
+    @abstractmethod
+    def config_type(self) -> ConfigType: ...
+
+    @property
+    @abstractmethod
+    def export_schema(self) -> pyarrow.schema: ...
+
+    @abstractmethod
+    def record_from_entity(self, entity: dict) -> dict: ...

--- a/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/config_base.py
+++ b/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/config_base.py
@@ -19,7 +19,7 @@ class ConfigType(Enum):
     BUS_VEHICLE_POSITIONS = auto()
     VEHICLE_COUNT = auto()
 
-class ConfigDetails(ABC):
+class ConfigDetail(ABC):
     """
     Abstract Base Class for all ConfigDetail implementations.
 

--- a/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/config_base.py
+++ b/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/config_base.py
@@ -8,8 +8,8 @@ import pyarrow
 
 class ConfigType(Enum):
     """
-    ConfigType is and Enumaration taht is inclusive of all 
-    configurations types to be processed by this library
+    ConfigType is an Enumuration that is inclusive of all 
+    configuration types to be processed by this library
 
     """
     RT_ALERTS = auto()
@@ -21,10 +21,9 @@ class ConfigType(Enum):
 
 class ConfigDetails(ABC):
     """
-    Abstract Base Class for all Configuration Details implementations.
+    Abstract Base Class for all ConfigDetail implementations.
 
-    Configuration Details classes must implement all methods and properties
-    as defined by ConfigDetails.
+    ConfigDetails classes must implement all methods and properties that are defined.
     """
     @property
     @abstractmethod

--- a/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/config_rt_alerts.py
+++ b/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/config_rt_alerts.py
@@ -1,0 +1,17 @@
+import pyarrow
+
+from .config_base import ConfigDetails
+from .config_base import ConfigType
+
+class RtAlertsDetails(ConfigDetails):
+    @property
+    def config_type(self) -> ConfigType:
+        return ConfigType.RT_ALERTS
+
+    @property
+    def export_schema(self) -> pyarrow.schema:
+        ...
+
+    def record_from_entity(self, entity: dict) -> dict:
+        ...
+

--- a/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/config_rt_alerts.py
+++ b/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/config_rt_alerts.py
@@ -1,9 +1,9 @@
 import pyarrow
 
-from .config_base import ConfigDetails
+from .config_base import ConfigDetail
 from .config_base import ConfigType
 
-class RtAlertsDetails(ConfigDetails):
+class RtAlertsDetail(ConfigDetail):
     @property
     def config_type(self) -> ConfigType:
         return ConfigType.RT_ALERTS

--- a/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/config_rt_trip.py
+++ b/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/config_rt_trip.py
@@ -1,9 +1,9 @@
 import pyarrow
 
-from .config_base import ConfigDetails
+from .config_base import ConfigDetail
 from .config_base import ConfigType
 
-class RtTripDetails(ConfigDetails):
+class RtTripDetail(ConfigDetail):
     @property
     def config_type(self) -> ConfigType:
         return ConfigType.RT_TRIP_UPDATES

--- a/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/config_rt_trip.py
+++ b/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/config_rt_trip.py
@@ -1,0 +1,17 @@
+import pyarrow
+
+from .config_base import ConfigDetails
+from .config_base import ConfigType
+
+class RtTripDetails(ConfigDetails):
+    @property
+    def config_type(self) -> ConfigType:
+        return ConfigType.RT_TRIP_UPDATES
+
+    @property
+    def export_schema(self) -> pyarrow.schema:
+        ...
+
+    def record_from_entity(self, entity: dict) -> dict:
+        ...
+

--- a/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/config_rt_vehicle.py
+++ b/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/config_rt_vehicle.py
@@ -1,8 +1,9 @@
 import pyarrow
-from py_gtfs_rt_ingestion.configuration import ConfigType
-from py_gtfs_rt_ingestion.configuration import ConfigDetails
 
-class RtVehiclePositionDetails(ConfigDetails):
+from .config_base import ConfigDetails
+from .config_base import ConfigType
+
+class RtVehicleDetails(ConfigDetails):
     @property
     def config_type(self) -> ConfigType:
         return ConfigType.RT_VEHICLE_POSITIONS

--- a/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/config_rt_vehicle.py
+++ b/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/config_rt_vehicle.py
@@ -1,9 +1,9 @@
 import pyarrow
 
-from .config_base import ConfigDetails
+from .config_base import ConfigDetail
 from .config_base import ConfigType
 
-class RtVehicleDetails(ConfigDetails):
+class RtVehicleDetail(ConfigDetail):
     @property
     def config_type(self) -> ConfigType:
         return ConfigType.RT_VEHICLE_POSITIONS

--- a/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/config_rt_vehicle_pos.py
+++ b/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/config_rt_vehicle_pos.py
@@ -1,0 +1,56 @@
+import pyarrow
+from configuration import ConfigType
+from configuration import ConfigDetails
+
+class RtVehiclePositionDetails(ConfigDetails):
+    @property
+    def config_type(self) -> ConfigType:
+        return ConfigType.RT_VEHICLE_POSITIONS
+
+    @property
+    def export_schema(self) -> pyarrow.schema:
+        return pyarrow.schema([
+                ('year', pyarrow.int16()),
+                ('month', pyarrow.int8()),
+                ('day', pyarrow.int8()),
+                ('hour', pyarrow.int8()),
+                ('feed_timestamp', pyarrow.int64()),
+                ('vehicle_timestamp', pyarrow.int64()),
+                ('vehicle_id', pyarrow.string()),
+                ('vehicle_label', pyarrow.string()),
+                ('current_status', pyarrow.string()),
+                ('current_stop_sequence', pyarrow.int16()),
+                ('stop_id', pyarrow.string()),
+                ('position', pyarrow.struct([
+                    ('latitude', pyarrow.float64()),
+                    ('longitude', pyarrow.float64()),
+                    ('bearing', pyarrow.float32()),])),
+                ('trip', pyarrow.struct([
+                    ('trip_id', pyarrow.string()),
+                    ('route_id', pyarrow.string()),
+                    ('direction_id', pyarrow.int8()),
+                    ('schedule_relationship', pyarrow.string()),
+                    ('start_date', pyarrow.string()),
+                    ('start_time', pyarrow.string())])),
+                ('consist_labels', pyarrow.list_(pyarrow.string()))
+            ])
+    
+    def record_from_entity(self, entity: dict) -> dict:
+        vehicle = entity['vehicle']
+        record = {
+            'vehicle_timestamp': vehicle.get('timestamp'),
+            'vehicle_id': entity.get('id'),
+            'vehicle_label': vehicle["vehicle"].get('label'),
+            'current_status': vehicle.get('current_status'),
+            'current_stop_sequence': vehicle.get("current_stop_sequence"),
+            'stop_id': vehicle.get("stop_id"),
+            'position': vehicle.get('position'),
+            'trip': vehicle.get("trip"),
+            'consist_labels': [],
+        }
+        if vehicle['vehicle'].get('consist') is not None:
+            record['consist_labels'] = [consist["label"]
+                                        for consist
+                                        in vehicle["vehicle"].get("consist")]
+
+        return record

--- a/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/config_rt_vehicle_pos.py
+++ b/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/config_rt_vehicle_pos.py
@@ -1,6 +1,6 @@
 import pyarrow
-from configuration import ConfigType
-from configuration import ConfigDetails
+from py_gtfs_rt_ingestion.configuration import ConfigType
+from py_gtfs_rt_ingestion.configuration import ConfigDetails
 
 class RtVehiclePositionDetails(ConfigDetails):
     @property

--- a/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/configuration.py
+++ b/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/configuration.py
@@ -1,3 +1,4 @@
+from ipaddress import v4_int_to_packed
 from pathlib import Path
 
 import pyarrow
@@ -20,13 +21,11 @@ class Configuration:
     https_mbta_integration.mybluemix.net_vehicleCount.gz
     """
     def __init__(self, filename: str) -> None:
-        self.file_path = Path(filename)
-
         """
         Depending on filename, assign self.details to correct implementation of 
         ConfigDetail class. 
         """
-        if 'mbta.com_realtime_Alerts_enhanced' in self.file_path.name:
+        if 'mbta.com_realtime_Alerts_enhanced' in filename:
             self.detail = RtAlertsDetail()
         elif 'mbta.com_realtime_TripUpdates_enhanced' in filename:
             self.detail = RtTripDetail()

--- a/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/configuration.py
+++ b/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/configuration.py
@@ -22,6 +22,10 @@ class Configuration:
     def __init__(self, filename: str) -> None:
         self.file_path = Path(filename)
 
+        """
+        Depending on filename, assign self.details to correct implementation of 
+        ConfigDetails class. 
+        """
         if 'mbta.com_realtime_Alerts_enhanced' in self.file_path.name:
             self.details = RtAlertsDetails()
         elif 'mbta.com_realtime_TripUpdates_enhanced' in filename:

--- a/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/configuration.py
+++ b/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/configuration.py
@@ -1,36 +1,12 @@
-from abc import ABC
-from abc import abstractmethod
-
-from enum import Enum
-from enum import auto
 from pathlib import Path
+
 import pyarrow
 
-from py_gtfs_rt_ingestion.config_rt_vehicle_pos import RtVehiclePositionDetails
+from .config_base import ConfigType
 
-class ConfigType(Enum):
-    RT_ALERTS = auto()
-    RT_TRIP_UPDATES = auto()
-    RT_VEHICLE_POSITIONS = auto()
-    BUS_TRIP_UPDATES = auto()
-    BUS_VEHICLE_POSITIONS = auto()
-    VEHICLE_COUNT = auto()
-
-"""
-All configuation details classes must be configured 
-in same format as ConfigDetails.
-"""
-class ConfigDetails(ABC):
-    @property
-    @abstractmethod
-    def config_type(self) -> ConfigType: ...
-
-    @property
-    @abstractmethod
-    def export_schema(self) -> pyarrow.schema: ...
-
-    @abstractmethod
-    def record_from_entity(self, entity: dict) -> dict: ...
+from .config_rt_vehicle import RtVehicleDetails
+from .config_rt_alerts import RtAlertsDetails
+from .config_rt_trip import RtTripDetails
 
 class Configuration:
     """
@@ -47,11 +23,11 @@ class Configuration:
         self.file_path = Path(filename)
 
         if 'mbta.com_realtime_Alerts_enhanced' in self.file_path.name:
-            self.details = RtVehiclePositionDetails()
-        # if 'mbta.com_realtime_TripUpdates_enhanced' in filename:
-        #     self.import_type = ImportType.RT_TRIP_UPDATES
-        # if 'mbta.com_realtime_VehiclePositions_enhanced' in filename:
-        #     self.import_type = ImportType.RT_VEHICLE_POSITIONS
+            self.details = RtAlertsDetails()
+        elif 'mbta.com_realtime_TripUpdates_enhanced' in filename:
+            self.details = RtTripDetails()
+        elif 'mbta.com_realtime_VehiclePositions_enhanced' in filename:
+            self.details = RtVehicleDetails()
         else:
             raise Exception("Bad Configuration from filename %s" % filename)
 

--- a/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/configuration.py
+++ b/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/configuration.py
@@ -24,7 +24,7 @@ class Configuration:
 
         """
         Depending on filename, assign self.details to correct implementation of 
-        ConfigDetails class. 
+        ConfigDetail class. 
         """
         if 'mbta.com_realtime_Alerts_enhanced' in self.file_path.name:
             self.detail = RtAlertsDetail()

--- a/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/configuration.py
+++ b/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/configuration.py
@@ -1,8 +1,38 @@
-from enum import Enum, auto
+from abc import ABC
+from abc import abstractmethod
 
+from enum import Enum
+from enum import auto
+from pathlib import Path
 import pyarrow
 
-class Configuration(Enum):
+from config_rt_vehicle_pos import RtVehiclePositionDetails
+
+class ConfigType(Enum):
+    RT_ALERTS = auto()
+    RT_TRIP_UPDATES = auto()
+    RT_VEHICLE_POSITIONS = auto()
+    BUS_TRIP_UPDATES = auto()
+    BUS_VEHICLE_POSITIONS = auto()
+    VEHICLE_COUNT = auto()
+
+"""
+All configuation details classes must be configured 
+in same format as ConfigDetails.
+"""
+class ConfigDetails(ABC):
+    @property
+    @abstractmethod
+    def config_type(self) -> ConfigType: ...
+
+    @property
+    @abstractmethod
+    def export_schema(self) -> pyarrow.schema: ...
+
+    @abstractmethod
+    def record_from_entity(self, entity: dict) -> dict: ...
+
+class Configuration:
     """
     Configuration that handles the specifics of each of our JSON record types.
 
@@ -13,71 +43,28 @@ class Configuration(Enum):
     https_mbta_busloc_s3.s3.amazonaws.com_prod_VehiclePositions_enhanced.json.gz
     https_mbta_integration.mybluemix.net_vehicleCount.gz
     """
-    RT_ALERTS = auto()
-    RT_TRIP_UPDATES = auto()
-    RT_VEHICLE_POSITIONS = auto()
+    def __init__(self, filename: str) -> None:
+        self.file_path = Path(filename)
 
-    @classmethod
-    def from_filename(cls, filename: str):
-        if 'mbta.com_realtime_Alerts_enhanced' in filename:
-            return cls.RT_ALERTS
-        if 'mbta.com_realtime_TripUpdates_enhanced' in filename:
-            return cls.RT_TRIP_UPDATES
-        if 'mbta.com_realtime_VehiclePositions_enhanced' in filename:
-            return cls.RT_VEHICLE_POSITIONS
+        if 'mbta.com_realtime_Alerts_enhanced' in self.file_path.name:
+            self.details = RtVehiclePositionDetails()
+        # if 'mbta.com_realtime_TripUpdates_enhanced' in filename:
+        #     self.import_type = ImportType.RT_TRIP_UPDATES
+        # if 'mbta.com_realtime_VehiclePositions_enhanced' in filename:
+        #     self.import_type = ImportType.RT_VEHICLE_POSITIONS
+        else:
+            raise Exception("Bad Configuration from filename %s" % filename)
 
-        raise Exception("Bad Configuration from filename %s" % filename)
+    @property
+    def config_type(self) -> ConfigType:
+        return self.details.config_type
 
-    def get_schema(self) -> pyarrow.schema:
-        if self == self.__class__.RT_VEHICLE_POSITIONS:
-            return pyarrow.schema([
-                ('year', pyarrow.int16()),
-                ('month', pyarrow.int8()),
-                ('day', pyarrow.int8()),
-                ('hour', pyarrow.int8()),
-                ('feed_timestamp', pyarrow.int64()),
-                ('vehicle_timestamp', pyarrow.int64()),
-                ('vehicle_id', pyarrow.string()),
-                ('vehicle_label', pyarrow.string()),
-                ('current_status', pyarrow.string()),
-                ('current_stop_sequence', pyarrow.int16()),
-                ('stop_id', pyarrow.string()),
-                ('position', pyarrow.struct([
-                    ('latitude', pyarrow.float64()),
-                    ('longitude', pyarrow.float64()),
-                    ('bearing', pyarrow.float32()),])),
-                ('trip', pyarrow.struct([
-                    ('trip_id', pyarrow.string()),
-                    ('route_id', pyarrow.string()),
-                    ('direction_id', pyarrow.int8()),
-                    ('schedule_relationship', pyarrow.string()),
-                    ('start_date', pyarrow.string()),
-                    ('start_time', pyarrow.string())])),
-                ('consist_labels', pyarrow.list_(pyarrow.string()))
-            ])
-
-        raise Exception("No Current Schema for %s" % self.name)
+    @property
+    def export_schema(self) -> pyarrow.schema:
+        return self.details.export_schema
 
     def record_from_entity(self, entity: dict) -> dict:
-        if self == self.__class__.RT_VEHICLE_POSITIONS:
-            vehicle = entity['vehicle']
-            record = {
-                'vehicle_timestamp': vehicle.get('timestamp'),
-                'vehicle_id': entity.get('id'),
-                'vehicle_label': vehicle["vehicle"].get('label'),
-                'current_status': vehicle.get('current_status'),
-                'current_stop_sequence': vehicle.get("current_stop_sequence"),
-                'stop_id': vehicle.get("stop_id"),
-                'position': vehicle.get('position'),
-                'trip': vehicle.get("trip"),
-                'consist_labels': [],
-            }
-            if vehicle['vehicle'].get('consist') is not None:
-                record['consist_labels'] = [consist["label"]
-                                            for consist
-                                            in vehicle["vehicle"].get("consist")]
+        return self.details.record_from_entity(entity)
 
-            return record
 
-        raise Exception("No Current Schema for %s" % self.name)
 

--- a/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/configuration.py
+++ b/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/configuration.py
@@ -6,7 +6,7 @@ from enum import auto
 from pathlib import Path
 import pyarrow
 
-from config_rt_vehicle_pos import RtVehiclePositionDetails
+from py_gtfs_rt_ingestion.config_rt_vehicle_pos import RtVehiclePositionDetails
 
 class ConfigType(Enum):
     RT_ALERTS = auto()

--- a/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/configuration.py
+++ b/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/configuration.py
@@ -4,9 +4,9 @@ import pyarrow
 
 from .config_base import ConfigType
 
-from .config_rt_vehicle import RtVehicleDetails
-from .config_rt_alerts import RtAlertsDetails
-from .config_rt_trip import RtTripDetails
+from .config_rt_vehicle import RtVehicleDetail
+from .config_rt_alerts import RtAlertsDetail
+from .config_rt_trip import RtTripDetail
 
 class Configuration:
     """
@@ -27,24 +27,24 @@ class Configuration:
         ConfigDetails class. 
         """
         if 'mbta.com_realtime_Alerts_enhanced' in self.file_path.name:
-            self.details = RtAlertsDetails()
+            self.detail = RtAlertsDetail()
         elif 'mbta.com_realtime_TripUpdates_enhanced' in filename:
-            self.details = RtTripDetails()
+            self.detail = RtTripDetail()
         elif 'mbta.com_realtime_VehiclePositions_enhanced' in filename:
-            self.details = RtVehicleDetails()
+            self.detail = RtVehicleDetail()
         else:
             raise Exception("Bad Configuration from filename %s" % filename)
 
     @property
     def config_type(self) -> ConfigType:
-        return self.details.config_type
+        return self.detail.config_type
 
     @property
     def export_schema(self) -> pyarrow.schema:
-        return self.details.export_schema
+        return self.detail.export_schema
 
     def record_from_entity(self, entity: dict) -> dict:
-        return self.details.record_from_entity(entity)
+        return self.detail.record_from_entity(entity)
 
 
 

--- a/py_gtfs_rt_ingestion/tests/test_configuration.py
+++ b/py_gtfs_rt_ingestion/tests/test_configuration.py
@@ -2,37 +2,43 @@ import pytest
 
 from datetime import datetime
 from py_gtfs_rt_ingestion import Configuration
+from py_gtfs_rt_ingestion import ConfigType
 
 def test_filname_parsing():
     """
     Check that we are able to get the correct Configuration type for multiple
     filenames
     """
-    trip_updates_type = Configuration.from_filename(
-        '2022-01-01T00:00:02Z_https_cdn.mbta.com_realtime_TripUpdates_enhanced.json.gz')
-    assert trip_updates_type == Configuration.RT_TRIP_UPDATES
+    # Requires full implemenation of ConfigDetails for ConfigType
+    # trip_updates_type = Configuration(
+    #     '2022-01-01T00:00:02Z_https_cdn.mbta.com_realtime_TripUpdates_enhanced.json.gz')
+    # assert trip_updates_type.config_type == ConfigType.RT_TRIP_UPDATES
 
-    vehicle_positions_type = Configuration.from_filename(
+    vehicle_positions_type = Configuration(
         '2022-01-01T00:00:03Z_https_cdn.mbta.com_realtime_VehiclePositions_enhanced.json.gz')
-    assert vehicle_positions_type == Configuration.RT_VEHICLE_POSITIONS
+    assert vehicle_positions_type.config_type == ConfigType.RT_VEHICLE_POSITIONS
 
-    alerts_type = Configuration.from_filename(
-        '2022-01-01T00:00:38Z_https_cdn.mbta.com_realtime_Alerts_enhanced.json.gz')
-    assert alerts_type == Configuration.RT_ALERTS
+    # Requires full implemenation of ConfigDetails for ConfigType
+    # alerts_type = Configuration(
+    #     '2022-01-01T00:00:38Z_https_cdn.mbta.com_realtime_Alerts_enhanced.json.gz')
+    # assert alerts_type.config_type == ConfigType.RT_ALERTS
 
     with pytest.raises(Exception):
-        Configuration.from_filename('this.is.a.bad.filename.json.gz')
+        Configuration('this.is.a.bad.filename.json.gz')
 
 def test_get_schema():
-    config = Configuration.RT_VEHICLE_POSITIONS
-    schema = config.get_schema()
+    config = Configuration(
+        '2022-01-01T00:00:03Z_https_cdn.mbta.com_realtime_VehiclePositions_enhanced.json.gz')
+    schema = config.export_schema
 
-    with pytest.raises(Exception):
-        unimpled_config = Configuration.RT_ALERTS
-        unimpled_schema = unimpled_config.get_schema()
+    # Requires full implemenation of ConfigDetails for ConfigType
+    # with pytest.raises(Exception):
+    #     unimpled_config = Configuration.RT_ALERTS
+    #     unimpled_schema = unimpled_config.get_schema()
 
 def test_create_record():
-    config = Configuration.RT_VEHICLE_POSITIONS
+    config = Configuration(
+        '2022-01-01T00:00:03Z_https_cdn.mbta.com_realtime_VehiclePositions_enhanced.json.gz')
 
     entity = {
       "id": "y1628",

--- a/py_gtfs_rt_ingestion/tests/test_configuration.py
+++ b/py_gtfs_rt_ingestion/tests/test_configuration.py
@@ -29,7 +29,7 @@ def test_get_schema():
         '2022-01-01T00:00:03Z_https_cdn.mbta.com_realtime_VehiclePositions_enhanced.json.gz')
     schema = config.export_schema
 
-    # Requires full implemenation of ConfigDetails for ConfigType
+    # Requires full implemenation of ConfigDetail for ConfigType
     # with pytest.raises(Exception):
     #     unimpled_config = Configuration.RT_ALERTS
     #     unimpled_schema = unimpled_config.get_schema()

--- a/py_gtfs_rt_ingestion/tests/test_configuration.py
+++ b/py_gtfs_rt_ingestion/tests/test_configuration.py
@@ -9,19 +9,17 @@ def test_filname_parsing():
     Check that we are able to get the correct Configuration type for multiple
     filenames
     """
-    # Requires full implemenation of ConfigDetails for ConfigType
-    # trip_updates_type = Configuration(
-    #     '2022-01-01T00:00:02Z_https_cdn.mbta.com_realtime_TripUpdates_enhanced.json.gz')
-    # assert trip_updates_type.config_type == ConfigType.RT_TRIP_UPDATES
+    trip_updates_type = Configuration(
+        '2022-01-01T00:00:02Z_https_cdn.mbta.com_realtime_TripUpdates_enhanced.json.gz')
+    assert trip_updates_type.config_type == ConfigType.RT_TRIP_UPDATES
 
     vehicle_positions_type = Configuration(
         '2022-01-01T00:00:03Z_https_cdn.mbta.com_realtime_VehiclePositions_enhanced.json.gz')
     assert vehicle_positions_type.config_type == ConfigType.RT_VEHICLE_POSITIONS
 
-    # Requires full implemenation of ConfigDetails for ConfigType
-    # alerts_type = Configuration(
-    #     '2022-01-01T00:00:38Z_https_cdn.mbta.com_realtime_Alerts_enhanced.json.gz')
-    # assert alerts_type.config_type == ConfigType.RT_ALERTS
+    alerts_type = Configuration(
+        '2022-01-01T00:00:38Z_https_cdn.mbta.com_realtime_Alerts_enhanced.json.gz')
+    assert alerts_type.config_type == ConfigType.RT_ALERTS
 
     with pytest.raises(Exception):
         Configuration('this.is.a.bad.filename.json.gz')


### PR DESCRIPTION
Re-factor Configuration class to standard class. 

config_base.py added to hold Enumeration of ConfigType and ABC for ConfigDetail. 
- Each ConfigType should implement ConfigDetail Class in separate file for import into Configuration class.

Configuration.detail assigned to ConfigDetail ABC Class. 

Class/Methods added to Configuration class as helper to pull information for Configuration.detail ABC class:
- Configuration.config_type -> ConfigType Enum
- Configuration.export_schema -> pyarrow export schema
- Configuration.record_from_entity() -> processed parquet transformation dictionary. 