### PR TITLE
Ingest multiprocess

### DIFF
--- a/py_gtfs_rt_ingestion/ingest.py
+++ b/py_gtfs_rt_ingestion/ingest.py
@@ -9,11 +9,120 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 
 from datetime import datetime
+from multiprocessing import Pool
+from multiprocessing import Queue
 from pathlib import Path
 
 from py_gtfs_rt_ingestion import Configuration
 
+
 DESCRIPTION = "Convert a json file into a parquet file. Used for testing."
+MULTIPROCESSING_POOL_SIZE = 4
+
+def gz_to_pyarrow(filename: str, config: Configuration, return_queue: Queue) -> None:
+    """
+    Accepts filename as string for gzip json to pyarrow table parsing. 
+
+    Converted pyarrow table sent back to main process using return_queue.
+    If conversion failes, returns filename of failed conversion.
+    """
+    # Enclose entire function in try block, Process can't fail silently.
+    try:
+        with gzip.open(filename, 'rb') as f:
+            json_data = json.loads(f.read())
+
+        # parse timestamp info out of the header
+        header = json_data['header']
+        feed_timestamp = header['timestamp']
+        timestamp = datetime.utcfromtimestamp(feed_timestamp)
+
+        # create dict of lists 
+        ret_obj = {key.name:[] for key in config.export_schema}
+
+        # for each entity in the list, create a record and add it to the table
+        for entity in json_data['entity']:
+            record = config.record_from_entity(entity=entity)
+            record.update({
+                'year': timestamp.year,
+                'month': timestamp.month,
+                'day': timestamp.day,
+                'hour': timestamp.hour,
+                'feed_timestamp': feed_timestamp
+            })
+
+            for key in record:
+                ret_obj[key].append(record[key])
+
+        ret_obj = pa.table(ret_obj, schema=config.export_schema)
+
+    # Catch Process failure, send back filename for handling
+    except Exception as e:
+        print(e, flush=True)
+        ret_obj = filename
+
+    # Send pyarrow table or None back to main Process for concatenation
+    Queue.put(ret_obj)
+    return_queue.close()
+
+def lambda_handler(event: dict, context) -> None:
+    """
+    AWS Lambda Python handled function as described in AWS Developer Guide:
+    https://docs.aws.amazon.com/lambda/latest/dg/python-handler.html
+    :param event: The event dict sent by Amazon API Gateway that contains all of the
+                  request data.
+    :param context: The context in which the function is called.
+    :return: A response that is sent to Amazon API Gateway, to be wrapped into
+             an HTTP response. The 'statusCode' field is the HTTP status code
+             and the 'body' field is the body of the response.
+
+    expected event structure:
+    {
+        file_batch: [file_name_1, file_name_2, ...],
+    }
+    batch files should all be of same ConfigType
+    """
+    if 'file_batch' not in event:
+        raise Exception("Lambda event missing 'file_batch' keys.")
+
+    file_batch = event['file_batch']
+
+    config = Configuration(file_batch[0])
+
+    return_queue = Queue()
+
+    pool = Pool(MULTIPROCESSING_POOL_SIZE)
+    pool.starmap_async(gz_to_pyarrow, [(f, config, return_queue) for f in file_batch])
+
+    # Collect pyarrow tables from Processes and concat
+    pa_table = None
+    failed_ingestion = []
+    for _ in range(len(file_batch)):
+        ret_obj = return_queue.get()
+        if pa_table is None and not isinstance(ret_obj, str):
+            pa_table = ret_obj
+        elif not isinstance(ret_obj, str):
+            pa.concat_tables([pa_table,ret_obj])
+        else:
+            failed_ingestion.append(ret_obj)
+
+    # Clean up return_queue and pool
+    return_queue.close()
+    return_queue.join_thread()
+    pool.close()
+    pool.join()
+
+    # TODO:
+    # 1. Implement output direction as environmental variable for lamda function.
+    # 2. Do something with failed conversion files.
+    OUTPUT_DIR = ''
+
+    pq.write_to_dataset(
+        pa.table(pa_table, schema=config.export_schema),
+        root_path=OUTPUT_DIR,
+        partition_cols=['year','month','day','hour']
+    )
+
+    return None
 
 def parseArgs(args) -> dict:
     parser = argparse.ArgumentParser(description=DESCRIPTION)


### PR DESCRIPTION
Add `gz_to_pyarrow` function. Responsible for threaded conversion of gzip json to pyarrow table.
- Must return either pyarrow table or filename (on conversion failure)

Added `lambda_handler` as entry point for lambda function. Launches multiprocessing conversion is async call to `gz_to_pyarrow`. 