### PR TITLE
Streamline conversion from s3 pipeline

### DIFF
--- a/py_gtfs_rt_ingestion/ingest.py
+++ b/py_gtfs_rt_ingestion/ingest.py
@@ -3,20 +3,20 @@
 import argparse
 import json
 import os
-import pyarrow.parquet as pq
+import pyarrow as pa
 import sys
-import tempfile
 
-from pathlib import Path
+from multiprocessing import Pool
 
-from py_gtfs_rt_ingestion import (Configuration,
-                                  convert_files,
-                                  download_file_from_s3)
+from py_gtfs_rt_ingestion import Configuration, gz_to_pyarrow, s3_to_pyarrow
 
 import logging
 logging.basicConfig(level=logging.INFO)
 
 DESCRIPTION = "Convert a json file into a parquet file. Used for testing."
+
+# TODO this is fine for now, but maybe an environ variable?
+MULTIPROCESSING_POOL_SIZE = 4
 
 def parseArgs(args) -> dict:
     """
@@ -55,7 +55,7 @@ def parseArgs(args) -> dict:
         return events
 
     return {
-        'files': [Path(parsed_args.input_file)]
+        'files': [(parsed_args.input_file)]
     }
 
 def lambda_handler(event: dict, context) -> None:
@@ -83,26 +83,52 @@ def lambda_handler(event: dict, context) -> None:
     batch files should all be of same ConfigType
     """
     logging.info("Processing event:\n%s" % json.dumps(event, indent=2))
-    temp_dir = None
-    if 'files' not in event:
-        temp_dir = tempfile.TemporaryDirectory()
-        files = [download_file_from_s3(event['bucket'], file, temp_dir.name)
-                 for file in event['s3_files']]
 
-    else:
+    # get files and function to read them based on the event. for local files,
+    # use gzip reading, for s3 files use pyarrow to read directly from s3
+    if 'files' in event:
         files = event['files']
+        conversion_func = gz_to_pyarrow
+    elif 's3_files' in event:
+        files = event['s3_files']
+        conversion_func = s3_to_pyarrow
+    else:
+        raise Exception("poorly formatted event")
 
-    config = Configuration(filename=files[0].name)
+    config = Configuration(filename=files[0])
 
-    pa_table = convert_files(files, config)
+    logging.info("Creating pool with %d threads" % MULTIPROCESSING_POOL_SIZE)
 
-    if pa_table is not None:
-        logging.info("Writing Table for %s" % config.config_type)
-        pq.write_to_dataset(
-            pa_table,
-            root_path=os.environ['OUTPUT_DIR'],
-            partition_cols=['year','month','day','hour']
-        )
+    pool = Pool(MULTIPROCESSING_POOL_SIZE)
+    workers = pool.starmap_async(conversion_func, [(f, config) for f in files])
+
+    pa_table = pa.table(config.empty_table(), schema=config.export_schema)
+    failed_ingestion = []
+
+    for result in workers.get():
+        if isinstance(result, pa.Table):
+            if pa_table is not None:
+                pa_table = pa.concat_tables([pa_table, result])
+            else:
+                pa_table = result
+        else:
+            failed_ingestion.append(result)
+
+    logging.info(
+        "Completed converting %d files with config %s" % (len(files),
+                                                          config.config_type))
+
+    if len(failed_ingestion) > 0:
+        logging.warning("Unable to process %d files" % len(failed_ingestion))
+
+    return (pa_table, failed_ingestion)
+
+    logging.info("Writing Table to %s" % os.environ['OUTPUT_DIR'])
+    pa.parquet.write_to_dataset(
+        pa_table,
+        root_path=os.environ['OUTPUT_DIR'],
+        partition_cols=['year','month','day','hour']
+    )
 
 if __name__ == '__main__':
     event = parseArgs(sys.argv[1:])

--- a/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/__init__.py
+++ b/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/__init__.py
@@ -4,4 +4,5 @@ from .batcher import batch_files
 from .config_base import ConfigType
 from .configuration import Configuration
 from .convert import gz_to_pyarrow, s3_to_pyarrow
+from .error import ArgumentException
 from .s3_utils import file_list_from_s3

--- a/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/__init__.py
+++ b/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/__init__.py
@@ -3,5 +3,5 @@ __version__ = '0.1.0'
 from .batcher import batch_files
 from .config_base import ConfigType
 from .configuration import Configuration
-from .convert import convert_files
-from .s3_utils import download_file_from_s3, file_list_from_s3
+from .convert import gz_to_pyarrow, s3_to_pyarrow
+from .s3_utils import file_list_from_s3

--- a/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/configuration.py
+++ b/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/configuration.py
@@ -1,12 +1,9 @@
-from ipaddress import v4_int_to_packed
-from pathlib import Path
-
 import pyarrow
 
 from .config_base import ConfigType
-from .config_rt_vehicle import RtVehicleDetail
 from .config_rt_alerts import RtAlertsDetail
 from .config_rt_trip import RtTripDetail
+from .config_rt_vehicle import RtVehicleDetail
 from .error import NoImplException
 
 class Configuration:
@@ -49,3 +46,7 @@ class Configuration:
 
     def record_from_entity(self, entity: dict) -> dict:
         return self.detail.record_from_entity(entity)
+
+    def empty_table(self) -> dict:
+        return {key.name:[] for key in self.export_schema}
+

--- a/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/convert.py
+++ b/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/convert.py
@@ -8,7 +8,7 @@ from pyarrow import fs
 
 from .configuration import Configuration
 
-def gz_to_pyarrow(filename: str, config: Configuration) -> pa.Table:
+def gz_to_pyarrow(filename: str, config: Configuration):
     """
     Accepts filename as string. Converts gzipped json -> pyarrow table.
     """
@@ -25,7 +25,7 @@ def gz_to_pyarrow(filename: str, config: Configuration) -> pa.Table:
         return filename
 
 
-def s3_to_pyarrow(filename: str, config: Configuration) -> pa.Table:
+def s3_to_pyarrow(filename: str, config: Configuration):
     logging.info("Converting %s to Parquet Table" % filename)
     try:
         s3_fs = fs.S3FileSystem()

--- a/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/convert.py
+++ b/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/convert.py
@@ -4,81 +4,63 @@ import logging
 import pyarrow as pa
 
 from datetime import datetime
-from multiprocessing import Pool
-from pathlib import Path
+from pyarrow import fs
 
 from .configuration import Configuration
 
-# TODO this is fine for now, but maybe an environ variable?
-MULTIPROCESSING_POOL_SIZE = 4
-
-def gz_to_pyarrow(filename: Path, config: Configuration):
+def gz_to_pyarrow(filename: str, config: Configuration) -> pa.Table:
     """
     Accepts filename as string. Converts gzipped json -> pyarrow table.
     """
-    logging.info("Converting %s to Parquet Table" % filename.name)
-
-    # Enclose entire function in try block, Process can't fail silently.
-    # Must return either pyarrow table or filename
+    logging.info("Converting %s to Parquet Table" % filename)
     try:
-        table = {key.name:[] for key in config.export_schema}
-
         with gzip.open(filename, 'rb') as f:
-            json_data = json.loads(f.read())
+            json_data = json.load(f)
+            pa_table = _json_to_pyarrow(json_data=json_data, config=config)
 
-            # parse timestamp info out of the header
-            header = json_data['header']
-            feed_timestamp = header['timestamp']
-            timestamp = datetime.utcfromtimestamp(feed_timestamp)
+        return pa_table
 
-            # for each entity in the list, create a record, add it to the table
-            for entity in json_data['entity']:
-                record = config.record_from_entity(entity=entity)
-                record.update({
-                    'year': timestamp.year,
-                    'month': timestamp.month,
-                    'day': timestamp.day,
-                    'hour': timestamp.hour,
-                    'feed_timestamp': feed_timestamp
-                })
+    except Exception as exception:
+        logging.exception("Error converting %s" % filename)
+        return filename
 
-                for key in record:
-                    table[key].append(record[key])
 
-        ret_obj = pa.table(table, schema=config.export_schema)
+def s3_to_pyarrow(filename: str, config: Configuration) -> pa.Table:
+    logging.info("Converting %s to Parquet Table" % filename)
+    try:
+        s3_fs = fs.S3FileSystem()
+        with s3_fs.open_input_stream(filename) as f:
+            json_data = json.load(f)
+            pa_table = _json_to_pyarrow(json_data=json_data, config=config)
 
-    except Exception as e:
-        logging.exception(
-            "Error occured converting %s to Parquet File." % filename.name)
-        ret_obj = filename
+        return pa_table
 
-    # Send pyarrow table or filename back to main Process for concatenation
-    return ret_obj
+    except Exception as exception:
+        logging.exception("Error converting %s" % filename)
+        return filename
 
-def convert_files(filepaths: list[Path], config: Configuration) -> pa.Table:
-    logging.info("Creating pool with %d threads" % MULTIPROCESSING_POOL_SIZE)
-    pool = Pool(MULTIPROCESSING_POOL_SIZE)
-    workers = pool.starmap_async(gz_to_pyarrow,
-                                 [(f, config) for f in filepaths])
 
-    # Collect pyarrow tables from Processes and concat
-    pa_table = None
-    failed_ingestion = []
+def _json_to_pyarrow(json_data: dict, config: Configuration) -> pa.Table:
+    # table = {key.name:[] for key in config.export_schema}
+    table = config.empty_table()
 
-    for ret_obj in workers.get():
-        if isinstance(ret_obj, pa.Table):
-            if pa_table is None:
-                pa_table = ret_obj
-            else:
-                pa_table = pa.concat_tables([pa_table,ret_obj])
-        else:
-            failed_ingestion.append(ret_obj)
+    # parse timestamp info out of the header
+    header = json_data['header']
+    feed_timestamp = header['timestamp']
+    timestamp = datetime.utcfromtimestamp(feed_timestamp)
 
-    logging.info(
-        "Completed converting %d files with config %s" % (len(filepaths),
-                                                          config.config_type))
+    # for each entity in the list, create a record, add it to the table
+    for entity in json_data['entity']:
+        record = config.record_from_entity(entity=entity)
+        record.update({
+            'year': timestamp.year,
+            'month': timestamp.month,
+            'day': timestamp.day,
+            'hour': timestamp.hour,
+            'feed_timestamp': feed_timestamp
+        })
 
-    if len(failed_ingestion) > 0:
-        logging.warning("Unable to process %d files" % len(failed_ingestion))
+        for key in record:
+            table[key].append(record[key])
 
-    return pa_table
+    return pa.table(table, schema=config.export_schema)

--- a/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/error.py
+++ b/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/error.py
@@ -13,18 +13,6 @@ class ConfigTypeFromFilenameException(GTFSIngestException):
         self.message = \
             "Unable to deduce Configuration Type from filename %s" % filename
 
-class ConversionExceptioon(GTFSIngestException):
-    """
-    General Error to be used durring Conversion Failures
-    """
-    pass
-
-class S3Exception(GTFSIngestException):
-    """
-    General Error to be chained with boto3 Errors
-    """
-    pass
-
 class NoImplException(GTFSIngestException):
     """
     General Error for things we haven't done yet.

--- a/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/error.py
+++ b/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/error.py
@@ -13,6 +13,9 @@ class ConfigTypeFromFilenameException(GTFSIngestException):
         self.message = \
             "Unable to deduce Configuration Type from filename %s" % filename
 
+class ArgumentException(GTFSIngestException):
+    pass
+
 class NoImplException(GTFSIngestException):
     """
     General Error for things we haven't done yet.

--- a/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/s3_utils.py
+++ b/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/s3_utils.py
@@ -1,11 +1,7 @@
 import boto3
 import logging
-import os
 
 from collections.abc import Iterable
-from pathlib import Path
-
-from .error import S3Exception
 
 def file_list_from_s3(bucket_name: str='mbta-gtfs-s3',
                       file_prefix: str=None) -> Iterable[(str, int)]:
@@ -24,26 +20,3 @@ def file_list_from_s3(bucket_name: str='mbta-gtfs-s3',
 
     for bucket_object in bucket.objects.filter(Prefix=file_prefix):
         yield (bucket_object.key, bucket_object.size)
-
-def download_file_from_s3(bucket_name: str,
-                          filename: str,
-                          destination_dir: str) -> Path:
-    """
-    simple wrapper to download a file from s3 to a directory.
-    """
-    logging.info(
-        "Downloading %s from s3 bucket %s to %s" % (filename,
-                                                    bucket_name,
-                                                    destination_dir))
-    try:
-        s3 = boto3.resource('s3')
-
-        # have to convert filenames, deliminating with . instead of /, or else the
-        # move method in the download_file method errors out with "no directory".
-        deliminated_filename = filename.replace("/", ".")
-
-        destination = os.path.join(destination_dir, deliminated_filename)
-        s3.Bucket(bucket_name).download_file(filename, destination)
-        return Path(destination)
-    except Exception as exception:
-        raise S3Exception("Failed to download %s" % filename) from exception

--- a/py_gtfs_rt_ingestion/tests/test_convert.py
+++ b/py_gtfs_rt_ingestion/tests/test_convert.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from py_gtfs_rt_ingestion import Configuration, convert_files
+from py_gtfs_rt_ingestion import Configuration, gz_to_pyarrow
 
 TEST_FILE_DIR = Path(__file__).parent.joinpath("test_files")
 
@@ -12,9 +12,7 @@ def test_vehicle_positions_file_conversion(tmpdir):
     rt_vehicle_positions_file = TEST_FILE_DIR.joinpath(
         "2022-01-01T00:00:03Z_https_cdn.mbta.com_realtime_VehiclePositions_enhanced.json.gz")
     config = Configuration(filename=rt_vehicle_positions_file.name)
-
-    table = convert_files(filepaths=[rt_vehicle_positions_file],
-                          config=config)
+    table = gz_to_pyarrow(filename=rt_vehicle_positions_file, config=config)
     np_df = table.to_pandas()
 
     # tuple(na count, dtype, min, max)
@@ -73,7 +71,7 @@ def test_rt_alert_file_conversion(tmpdir):
         "2022-05-04T15:59:48Z_https_cdn.mbta.com_realtime_Alerts_enhanced.json.gz")
 
     config = Configuration(filename=alerts_file.name)
-    table = convert_files(filepaths=[alerts_file], config=config)
+    table = gz_to_pyarrow(filename=alerts_file, config=config)
     np_df = table.to_pandas()
 
     # tuple(na count, dtype, min, max)
@@ -137,7 +135,7 @@ def test_rt_trip_file_conversion(tmpdir):
         "2022-05-08T06:04:57Z_https_cdn.mbta.com_realtime_TripUpdates_enhanced.json.gz")
 
     config = Configuration(filename=trip_updates_file.name)
-    table = convert_files(filepaths=[trip_updates_file], config=config)
+    table = gz_to_pyarrow(filename=trip_updates_file, config=config)
     np_df = table.to_pandas()
 
     # tuple(na count, dtype, min, max)

--- a/py_gtfs_rt_ingestion/tests/test_ingest.py
+++ b/py_gtfs_rt_ingestion/tests/test_ingest.py
@@ -1,5 +1,4 @@
 import os
-from pathlib import Path
 
 from ingest import parseArgs
 
@@ -15,4 +14,4 @@ def test_argparse():
     event = parseArgs(dummy_arguments)
 
     assert os.environ['OUTPUT_DIR'] == dummy_output_dir
-    assert event['files'][0] == Path(dummy_file_path)
+    assert event['files'][0] == dummy_file_path


### PR DESCRIPTION
Move threading back to the ingest script. It now takes a single
conversion function, that can read from either local json dot gz files
or uri paths to files hosted on s3. The conversion function is chosen
based on the input event.

* remove s3 utility to download s3 files to a temp directory. just read
  the data directly using pyarrow now.
* in convert dot py, move the json -> pa.table to its own function and
  add in functions using it to read json from local files and s3.
* add Configuration.empty_table to generate the base table that will be
  filled in, simplifying our concat functions.