### PR TITLE
Batch lambda

### DIFF
--- a/py_gtfs_rt_ingestion/batch_files.py
+++ b/py_gtfs_rt_ingestion/batch_files.py
@@ -7,7 +7,9 @@ import sys
 from collections.abc import Iterable
 from typing import NamedTuple
 
-from py_gtfs_rt_ingestion import batch_files, file_list_from_s3
+from py_gtfs_rt_ingestion import ArgumentException
+from py_gtfs_rt_ingestion import batch_files
+from py_gtfs_rt_ingestion import file_list_from_s3
 
 import logging
 logging.basicConfig(level=logging.INFO)
@@ -15,24 +17,25 @@ logging.basicConfig(level=logging.INFO)
 DESCRIPTION = "Generate batches of json files that should be processed"
 
 class BatchArgs(NamedTuple):
-    input_file: str
     s3_prefix: str
+    s3_bucket: str
     filesize_threshold: int
-    output: str
     pretty: bool
 
-def parseArgs(args) -> BatchArgs:
+def parseArgs(args) -> dict:
     parser = argparse.ArgumentParser(description=DESCRIPTION)
-    parser.add_argument(
-        '--input',
-        dest='input_file',
-        type=str,
-        help='text file of AWS S3 ls call')
-
     parser.add_argument(
         '--s3-prefix',
         dest='s3_prefix',
         type=str,
+        default='',
+        help='prefix to files in the mbta-gtfs-s3 bucket')
+
+    parser.add_argument(
+        '--s3-bucket',
+        dest='s3_bucket',
+        type=str,
+        default='mbta-gtfs-s3',
         help='prefix to files in the mbta-gtfs-s3 bucket')
 
     parser.add_argument(
@@ -48,44 +51,42 @@ def parseArgs(args) -> BatchArgs:
         action='store_true',
         help='print out a pretty summary of the batches')
 
-    parser.add_argument(
-        '--output',
-        dest='output',
-        type=str,
-        help='filepath to dump out batches as event json list')
+    return vars(parser.parse_args(args))
 
-    parsed_args = BatchArgs(**vars(parser.parse_args(args)))
-
-    return parsed_args
-
-def file_list_from_file(input_file: str) -> Iterable[(str, int)]:
+def lambda_handler(event: dict, context) -> None:
     """
-    take a file that is the output of `aws s3 ls <dir>` and yield out filename,
-    filesize tuples.
+    AWS Lambda Python handled function as described in AWS Developer Guide:
+    https://docs.aws.amazon.com/lambda/latest/dg/python-handler.html
+    :param event: The event dict sent by Amazon API Gateway that contains all of
+            the request data.
+    :param context: The context in which the function is called.
+    :return: A response that is sent to Amazon API Gateway, to be wrapped into
+             an HTTP response. The 'statusCode' field is the HTTP status code
+             and the 'body' field is the body of the response.
+
+    expected event structure is
+    {
+        s3_prefix: str
+        s3_bucket: str
+        filesize_threshold: int
+        pretty: bool
+    }
+
+    batch files should all be of same ConfigType
     """
-    for file_info in open(input_file):
-        (date, time, size, filename) = file_info.split()
-        yield (filename, size)
+    logging.info("Processing event:\n%s" % json.dumps(event, indent=2))
+    batch_args = BatchArgs(**event)
+    logging.info(batch_args)
 
-def make_file_list(args: BatchArgs) -> Iterable[(str, int)]:
-    """
-    based on args, yield out filename, filesize tuples either from a local file
-    or from our s3 bucket.
-    """
-    if args.input_file:
-        return file_list_from_file(args.input_file)
+    file_list = file_list_from_s3(bucket_name=batch_args.s3_bucket,
+                                  file_prefix=batch_args.s3_prefix)
 
-    if args.s3_prefix:
-        return file_list_from_s3(file_prefix=args.s3_prefix)
+    batches = batch_files(file_list, batch_args.filesize_threshold)
 
-    raise Exception("shouldn't get here")
+    # TODO use boto3 to launch ingestion jobs from each batch
 
-if __name__ == '__main__':
-    args = parseArgs(sys.argv[1:])
-    file_list = make_file_list(args)
-    batches = batch_files(file_list, args.filesize_threshold)
-
-    if args.pretty:
+    # log out a summary of whats been batched.
+    if batch_args.pretty:
         total_bytes = 0
         total_files = 0
         for batch in batches:
@@ -95,9 +96,10 @@ if __name__ == '__main__':
         total_gigs = total_bytes / 1000000000
         logging.info("Batched %d gigs across %d files" % (total_gigs,
                                                           total_files))
+    else:
+        print(json.dumps([b.create_event() for b in batches], indent=2))
 
-    if args.output:
-        with open(args.output, 'w') as output_file:
-            json.dump([b.create_event() for b in batches],
-                      output_file,
-                      indent=2)
+if __name__ == '__main__':
+    event = parseArgs(sys.argv[1:])
+    lambda_handler(event, None)
+

--- a/py_gtfs_rt_ingestion/ingest.py
+++ b/py_gtfs_rt_ingestion/ingest.py
@@ -78,13 +78,14 @@ def lambda_handler(event: dict, context) -> None:
              an HTTP response. The 'statusCode' field is the HTTP status code
              and the 'body' field is the body of the response.
 
-    expected event structure is either
+    expected event structure is
     {
         files: [file_name_1, file_name_2, ...],
     }
-    S3 files will begin with 's3://'
+    where S3 files will begin with 's3://'
 
-    batch files should all be of same ConfigType
+    batch files should all be of same ConfigType as each run of this script
+    creates a single parquet file.
     """
     logging.info("Processing event:\n%s" % json.dumps(event, indent=2))
 

--- a/py_gtfs_rt_ingestion/ingest.py
+++ b/py_gtfs_rt_ingestion/ingest.py
@@ -67,35 +67,7 @@ def parseArgs(args) -> dict:
         'files': [(parsed_args.input_file)]
     }
 
-def lambda_handler(event: dict, context) -> None:
-    """
-    AWS Lambda Python handled function as described in AWS Developer Guide:
-    https://docs.aws.amazon.com/lambda/latest/dg/python-handler.html
-    :param event: The event dict sent by Amazon API Gateway that contains all of
-            the request data.
-    :param context: The context in which the function is called.
-    :return: A response that is sent to Amazon API Gateway, to be wrapped into
-             an HTTP response. The 'statusCode' field is the HTTP status code
-             and the 'body' field is the body of the response.
-
-    expected event structure is
-    {
-        files: [file_name_1, file_name_2, ...],
-    }
-    where S3 files will begin with 's3://'
-
-    batch files should all be of same ConfigType as each run of this script
-    creates a single parquet file.
-    """
-    logging.info("Processing event:\n%s" % json.dumps(event, indent=2))
-
-    # get files and function to read them based on the event. for local files,
-    # use gzip reading, for s3 files use pyarrow to read directly from s3
-    if 'files' not in event:
-        raise ArgumentException(
-            "Unable to find 'files' in event json")
-    files = event['files']
-
+def main(files: list[str]) -> None:
     config = Configuration(filename=files[0])
 
     logging.info("Creating pool with %d threads" % MULTIPROCESSING_POOL_SIZE)
@@ -125,6 +97,36 @@ def lambda_handler(event: dict, context) -> None:
         root_path=os.environ['OUTPUT_DIR'],
         partition_cols=['year','month','day','hour']
     )
+
+def lambda_handler(event: dict, context) -> None:
+    """
+    AWS Lambda Python handled function as described in AWS Developer Guide:
+    https://docs.aws.amazon.com/lambda/latest/dg/python-handler.html
+    :param event: The event dict sent by Amazon API Gateway that contains all of
+            the request data.
+    :param context: The context in which the function is called.
+    :return: A response that is sent to Amazon API Gateway, to be wrapped into
+             an HTTP response. The 'statusCode' field is the HTTP status code
+             and the 'body' field is the body of the response.
+
+    expected event structure is
+    {
+        files: [file_name_1, file_name_2, ...],
+    }
+    where S3 files will begin with 's3://'
+
+    batch files should all be of same ConfigType as each run of this script
+    creates a single parquet file.
+    """
+    logging.info("Processing event:\n%s" % json.dumps(event, indent=2))
+
+    try:
+        files = event['files']
+        main(files)
+    except Exception as e:
+        # log if something goes wrong and let lambda recatch the exception
+        logging.exception(e)
+        raise e
 
 if __name__ == '__main__':
     event = parseArgs(sys.argv[1:])

--- a/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/batcher.py
+++ b/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/batcher.py
@@ -33,7 +33,7 @@ class Batch(object):
             'files': self.filenames,
         }
 
-def batch_files(files: Iterable[(str, int)], threshold: int) -> list[Batch]:
+def batch_files(files: Iterable[(str, int)], threshold: int) -> Iterable[Batch]:
     """
     Take a bunch of files and sort them into Batches based on their config type
     (derrived from filename). Each Batch should be under a limit in total
@@ -47,7 +47,6 @@ def batch_files(files: Iterable[(str, int)], threshold: int) -> list[Batch]:
     :return: List of Batches containing all files passed in.
     """
     ongoing_batches = {t: Batch(t) for t in ConfigType}
-    complete_batches = []
 
     # iterate over file tuples, and add them to the ongoing batches. if a batch
     # is going to go past the threshold limit, move it to complete batches, and
@@ -67,7 +66,8 @@ def batch_files(files: Iterable[(str, int)], threshold: int) -> list[Batch]:
 
         if batch.total_size + int(size) > threshold:
             logging.info(batch)
-            complete_batches.append(batch)
+            yield batch
+
             ongoing_batches[config_type] = Batch(config_type)
             batch = ongoing_batches[config_type]
 
@@ -77,6 +77,4 @@ def batch_files(files: Iterable[(str, int)], threshold: int) -> list[Batch]:
     for (_, batch) in ongoing_batches.items():
         if batch.total_size > 0:
             logging.info(batch)
-            complete_batches.append(batch)
-
-    return complete_batches
+            yield batch

--- a/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/s3_utils.py
+++ b/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/s3_utils.py
@@ -3,8 +3,8 @@ import logging
 
 from collections.abc import Iterable
 
-def file_list_from_s3(bucket_name: str='mbta-gtfs-s3',
-                      file_prefix: str=None) -> Iterable[(str, int)]:
+def file_list_from_s3(bucket_name: str,
+                      file_prefix: str) -> Iterable[(str, int)]:
     """
     generate filename, filesize tuples for every file in an s3 bucket
 


### PR DESCRIPTION
Add lambda handler method to batch files script

* Have parse args generate an event dict that will be parsed to create a
  BatchArgs named tuple. All arguments will go through there, giving us
  some level of safety.
* Remove the option to read file names / sizes from a text file. That
  was useful when getting the script stood up, but no longer.
* Move pretty info printing into lambda handler method, along with
  printing out event json (which is no longer dumped to file)
* `batch_files`is a generator function now, rather than returning a
  list.
* remove default values from `file_list_from_s3` method. this method
  _should_ throw without these strings being provided.
  
* Add try / except to lambda handlers
In the lambda_handler methods of ingest and batch files scripts, wrap
the main functionality inside of a try except block and log any raised
exceptions. When exceptions are caught, log them with
`logging.exception` and re raise them so that lambda can pick them up.
This way failures will give a full trace back in the logs and lambda
will still error out.
  