### PR TITLE
Add Batch.trigger_lambda functionality

### DIFF
--- a/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/error.py
+++ b/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/error.py
@@ -21,3 +21,9 @@ class NoImplException(GTFSIngestException):
     General Error for things we haven't done yet.
     """
     pass
+
+class AWSException(GTFSIngestException):
+    """
+    Error to throw when something goes wrong interacting with s3 or lambda
+    """
+    pass

--- a/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/s3_utils.py
+++ b/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/s3_utils.py
@@ -29,3 +29,10 @@ def file_list_from_s3(bucket_name: str,
             continue
         for obj in page['Contents']:
             yield (obj['Key'], obj['Size'])
+
+def invoke_async_lambda(function_arn: str, event: dict) -> None:
+    lambda_client = boto3.client('lambda')
+    logging.info("Invoking Lambda: %s" % function_arn)
+    lambda_client.invoke(FunctionName=function_arn,
+                         InvocationType='Event',
+                         Payload=json.dumps(event))

--- a/py_gtfs_rt_ingestion/tests/test_batcher.py
+++ b/py_gtfs_rt_ingestion/tests/test_batcher.py
@@ -7,7 +7,7 @@ from botocore.stub import ANY
 from py_gtfs_rt_ingestion import ConfigType
 from py_gtfs_rt_ingestion.batcher import Batch
 from py_gtfs_rt_ingestion.batcher import batch_files
-from py_gtfs_rt_ingestion.error import NoImplException
+from py_gtfs_rt_ingestion.error import ArgumentException
 from py_gtfs_rt_ingestion.s3_utils import file_list_from_s3
 
 from .test_s3_utils import s3_stub
@@ -39,7 +39,7 @@ def test_batch_class(capfd):
     assert out == f"Batch of {sum(files.values())} bytes in {len(files)} {config_type} files\n" 
 
     # Calling `trigger_lambda` method raises exception
-    with pytest.raises(NoImplException):
+    with pytest.raises(ArgumentException):
         Batch(ConfigType.RT_VEHICLE_POSITIONS).trigger_lambda()
 
 def test_bad_file_names():


### PR DESCRIPTION
The batch lambda function needs to be able to trigger the ingest lambda
for each batch that it creates. The method usesboto3, and an environment
variable that contains the ingest lambdas ARN. The actual call itself is
async and run inside of the s3_utils library. There are a handful of
logging statements and exceptions to make clear whats going on / wrong.

The batch lambda script has new flags that can be used to do a dry run
(not triggering the lambda) and printing out events as json formatted
strings.