### PR TITLE
Add function to move s3 objects between buckets

### DIFF
--- a/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/__init__.py
+++ b/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/__init__.py
@@ -6,3 +6,4 @@ from .configuration import Configuration
 from .convert import gz_to_pyarrow
 from .error import ArgumentException
 from .s3_utils import file_list_from_s3
+from .s3_utils import move_3s_objects

--- a/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/convert.py
+++ b/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/convert.py
@@ -17,11 +17,12 @@ def gz_to_pyarrow(filename: str, config: Configuration):
     try:
         if str(filename).startswith('s3://'):
             active_fs = fs.S3FileSystem()
-            filename = str(filename).replace('s3://','')
+            file_to_load = str(filename).replace('s3://','')
         else:
             active_fs = fs.LocalFileSystem()
+            file_to_load = filename
 
-        with active_fs.open_input_stream(filename) as f:
+        with active_fs.open_input_stream(file_to_load) as f:
             json_data = json.load(f)
 
         pa_table = _json_to_pyarrow(json_data=json_data, config=config)

--- a/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/s3_utils.py
+++ b/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/s3_utils.py
@@ -55,7 +55,8 @@ def move_3s_objects(obj_list: list[str],
     for obj in obj_list:
         # Check if source bucket is in obj path, should skip local files???
         if src_bucket not in obj:
-            logging.warn(f"{src_bucket} bucket not found in {obj} path")
+            logging.warning("%s bucket not found in %s path" % (src_bucket, 
+                                                             obj))
             continue
         # strip 's3://' and bucket name from obj path
         copy_key = re.sub(rf"({src_bucket}/|s3://)","",obj)
@@ -69,4 +70,6 @@ def move_3s_objects(obj_list: list[str],
         except Exception as e:
             logging.exception(e)
         else:
-            logging.info(f"Moved {obj} from {src_bucket} to {dest_bucket}")
+            logging.info("Moved %s from %s to %s" % (obj,
+                                                     src_bucket,
+                                                     dest_bucket))

--- a/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/s3_utils.py
+++ b/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/s3_utils.py
@@ -1,5 +1,7 @@
 import boto3
+import json
 import logging
+import re
 
 from collections.abc import Iterable
 
@@ -36,3 +38,35 @@ def invoke_async_lambda(function_arn: str, event: dict) -> None:
     lambda_client.invoke(FunctionName=function_arn,
                          InvocationType='Event',
                          Payload=json.dumps(event))
+
+def move_3s_objects(obj_list: list[str], 
+                    src_bucket: str,
+                    dest_bucket: str) -> None:
+    """
+    move list of S3 objects for src_bucket to dest_bucket
+
+    :param obj_list: list of S3 object paths
+    :param src_bucket: S3 bucket to move from
+    :param dest_bucket: S3 bucket to move to
+
+    No return value.
+    """
+    s3_client = get_s3_client()
+    for obj in obj_list:
+        # Check if source bucket is in obj path, should skip local files???
+        if src_bucket not in obj:
+            logging.warn(f"{src_bucket} bucket not found in {obj} path")
+            continue
+        # strip 's3://' and bucket name from obj path
+        copy_key = re.sub(rf"({src_bucket}/|s3://)","",obj)
+        copy_source = {
+                'Bucket': src_bucket,
+                'Key': copy_key,
+            }
+        try:
+            s3_client.copy(copy_source, dest_bucket, copy_key)
+            s3_client.delete(copy_source)
+        except Exception as e:
+            logging.exception(e)
+        else:
+            logging.info(f"Moved {obj} from {src_bucket} to {dest_bucket}")

--- a/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/s3_utils.py
+++ b/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/s3_utils.py
@@ -43,9 +43,9 @@ def move_3s_objects(obj_list: list[str],
                     src_bucket: str,
                     dest_bucket: str) -> None:
     """
-    move list of S3 objects for src_bucket to dest_bucket
+    Move list of S3 objects from src_bucket to dest_bucket.
 
-    :param obj_list: list of S3 object paths
+    :param obj_list: list of S3 object paths (paths must start with src_bucket)
     :param src_bucket: S3 bucket to move from
     :param dest_bucket: S3 bucket to move to
 

--- a/py_gtfs_rt_ingestion/tests/test_convert.py
+++ b/py_gtfs_rt_ingestion/tests/test_convert.py
@@ -12,12 +12,10 @@ TEST_FILE_DIR = os.path.join(os.path.dirname(__file__), "test_files")
 def test_bad_conversion():
     bad_return = gz_to_pyarrow(filename='badfile',config=None)
     assert bad_return == 'badfile'
-    assert not isinstance(bad_return, pyarrow.Table)
 
     with patch('pyarrow.fs.S3FileSystem', return_value=fs.LocalFileSystem):
         bad_return = gz_to_pyarrow(filename='s3://badfile',config=None)
-    assert  bad_return == 'badfile'
-    assert not isinstance(bad_return, pyarrow.Table)
+    assert  bad_return == 's3://badfile'
 
 def test_empty_files(tmpdir):
     configs_to_test = (


### PR DESCRIPTION
Add s3 object moving to `s3_utils.py`
    
boto3 doesn't have direct 'move' method, so 'move' action consists of 'copy' and 'delete' calls.

Probably some more work to do here with handling of bucket names and environmental variables.