### PR TITLE
Update URI handling to get ready for dev deploy

### DIFF
--- a/py_gtfs_rt_ingestion/batch_files.py
+++ b/py_gtfs_rt_ingestion/batch_files.py
@@ -8,6 +8,7 @@ import sys
 from collections.abc import Iterable
 from typing import NamedTuple
 
+from py_gtfs_rt_ingestion import DEFAULT_S3_PREFIX
 from py_gtfs_rt_ingestion import batch_files
 from py_gtfs_rt_ingestion import file_list_from_s3
 
@@ -17,9 +18,9 @@ logging.basicConfig(level=logging.INFO)
 DESCRIPTION = "Generate batches of json files that should be processed"
 
 class BatchArgs(NamedTuple):
-    s3_prefix: str
     s3_bucket: str
     filesize_threshold: int
+    s3_prefix: str = DEFAULT_S3_PREFIX
     print_events: bool = False
     dry_run: bool = False
 
@@ -29,7 +30,7 @@ def parseArgs(args) -> dict:
         '--s3-prefix',
         dest='s3_prefix',
         type=str,
-        default='',
+        default=DEFAULT_S3_PREFIX,
         help='prefix to files in the mbta-gtfs-s3 bucket')
 
     parser.add_argument(

--- a/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/__init__.py
+++ b/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/__init__.py
@@ -1,9 +1,10 @@
 __version__ = '0.1.0'
 
+DEFAULT_S3_PREFIX = "lamp"
 from .batcher import batch_files
 from .config_base import ConfigType
 from .configuration import Configuration
 from .convert import gz_to_pyarrow
 from .error import ArgumentException
 from .s3_utils import file_list_from_s3
-from .s3_utils import move_3s_objects
+from .s3_utils import move_s3_objects

--- a/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/batcher.py
+++ b/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/batcher.py
@@ -18,7 +18,6 @@ class Batch(object):
         self.config_type = config_type
         self.filenames = []
         self.total_size = 0
-        self.bucket = 'mbta-gtfs-s3'
 
     def __str__(self) -> None:
         return "Batch of %d bytes in %d %s files" % (self.total_size,
@@ -26,7 +25,7 @@ class Batch(object):
                                                      self.config_type)
 
     def add_file(self, filename: str, filesize: int) -> None:
-        self.filenames.append(os.path.join('s3://',self.bucket,filename))
+        self.filenames.append(filename)
         self.total_size += filesize
 
     def trigger_lambda(self) -> None:

--- a/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/convert.py
+++ b/py_gtfs_rt_ingestion/py_gtfs_rt_ingestion/convert.py
@@ -15,7 +15,7 @@ def gz_to_pyarrow(filename: str, config: Configuration):
     """
     logging.info("Converting %s to Parquet Table" % filename)
     try:
-        if str(filename).startswith('s3://'):
+        if filename.startswith('s3://'):
             active_fs = fs.S3FileSystem()
             file_to_load = str(filename).replace('s3://','')
         else:

--- a/py_gtfs_rt_ingestion/pyproject.toml
+++ b/py_gtfs_rt_ingestion/pyproject.toml
@@ -8,9 +8,9 @@ authors = ["MBTA CTD <developer@mbta.com>",
 [tool.poetry.dependencies]
 python = "^3.9"
 pyarrow = "^8.0.0"
-boto3 = "^1.23.3"
 
 [tool.poetry.dev-dependencies]
+boto3 = "^1.23.3"
 pytest = "^5.2"
 pandas = "^1.4.2"
 pytest-cov = "^3.0.0"

--- a/py_gtfs_rt_ingestion/tests/test_ingest.py
+++ b/py_gtfs_rt_ingestion/tests/test_ingest.py
@@ -6,12 +6,24 @@ def test_argparse():
     """
     Test that the custom argparse is working as expected
     """
-    dummy_file_path = 'my/fake/path'
-    dummy_output_dir = 'my/fake/output_dir/'
+    filepath = 'my/fake/path.json.gz'
 
-    dummy_arguments = ['--input', dummy_file_path,
-                       '--output', dummy_output_dir]
-    event = parseArgs(dummy_arguments)
+    export_bucket = 'fake_dataplatform_springboard'
+    error_bucket = 'fake_dataplatform_error'
+    archive_bucket = 'fake_dataplatform_archive'
 
-    assert os.environ['OUTPUT_DIR'] == dummy_output_dir
-    assert event['files'][0] == dummy_file_path
+    arguments = ['--input', filepath,
+                 '--export', export_bucket,
+                 '--archive', archive_bucket,
+                 '--error', error_bucket]
+
+    event = parseArgs(arguments)
+
+    # check that argparse assigns env vars correctly
+    assert os.environ['EXPORT_BUCKET'] == export_bucket
+    assert os.environ['ARCHIVE_BUCKET'] == archive_bucket
+    assert os.environ['ERROR_BUCKET'] == error_bucket
+
+    # check that argparse creates the correct event
+    assert len(event['files']) == 1
+    assert event['files'][0] == filepath

--- a/py_gtfs_rt_ingestion/tests/test_s3_utils.py
+++ b/py_gtfs_rt_ingestion/tests/test_s3_utils.py
@@ -9,7 +9,7 @@ from botocore.stub import ANY
 from unittest.mock import patch
 
 from py_gtfs_rt_ingestion.s3_utils import file_list_from_s3
-from py_gtfs_rt_ingestion.s3_utils import move_3s_objects
+from py_gtfs_rt_ingestion.s3_utils import move_s3_objects
 
 TEST_FILE_DIR = os.path.join(os.path.dirname(__file__), "test_files")
 
@@ -62,7 +62,8 @@ def test_file_list_s3(s3_stub):
         files = [file for file in file_list_from_s3('mbta-gtfs-s3','')]
 
     assert len(files) == page_obj_response['KeyCount']
-    assert files == [(d['Key'], d['Size']) for d in page_obj_response['Contents']]
+    assert files == [("s3://mbta-gtfs-s3/%s" % d['Key'], d['Size'])
+                     for d in page_obj_response['Contents']]
 
     # Process large page_obj_response from json file 'test_files/large_page_obj_response.json'
     # large json file contains 1,000 Contents records.
@@ -78,7 +79,8 @@ def test_file_list_s3(s3_stub):
         files = [file for file in file_list_from_s3('mbta-gtfs-s3','')]
 
     assert len(files) == page_obj_response['KeyCount']
-    assert files == [(d['Key'], d['Size']) for d in page_obj_response['Contents']]
+    assert files == [("s3://mbta-gtfs-s3/%s" % d['Key'], d['Size'])
+                     for d in page_obj_response['Contents']]
 
 def test_move_bad_objects(s3_stub, caplog):
     bad_file_list = [
@@ -87,11 +89,12 @@ def test_move_bad_objects(s3_stub, caplog):
     ]
     src_bucket = 'bad_src_bucket'
     dest_bucket = 'bad_dest_bucket'
-    
+
     caplog.set_level(logging.WARNING)
     with s3_stub:
-        move_3s_objects(bad_file_list, src_bucket, dest_bucket)
-    assert f"{src_bucket} bucket not found in bad_file1 path" in caplog.text
-    assert f"{src_bucket} bucket not found in bad_file2 path" in caplog.text
+        move_s3_objects(bad_file_list, dest_bucket)
+
+    for bad_file in bad_file_list:
+        assert "Unable to move %s to %s" % (bad_file, dest_bucket) in caplog.text
 
 


### PR DESCRIPTION
* Use pyarrow s3 filesystem to move things about
* `file_list_from_s3` yields (URI, filesize) tuples instead of
  (filename, filesize)
* Batch class no longer contains a bucket name since always using URIs
* `write_to_dataset` has filesystem argument set to s3
* updates to tests to get this all working properly.
* add default s3_prefix set to "lamp" for initial testing to library.
  its used by both the ingest and batch scripts and paired with our env
  variables.  there is probably a better way to set this up, but it
  should be fine for now.