### PR TITLE
Filter out s3 files based on last modified date

### DIFF
--- a/py_gtfs_rt_ingestion/batch_files.py
+++ b/py_gtfs_rt_ingestion/batch_files.py
@@ -6,6 +6,7 @@ import logging
 import os
 import sys
 
+from datetime import datetime, timezone
 from typing import NamedTuple
 
 from py_gtfs_rt_ingestion import ArgumentException
@@ -95,8 +96,14 @@ def main(batch_args: BatchArgs) -> None:
     except KeyError as e:
         raise ArgumentException("Missing S3 Bucket environment variable") from e
 
+    # filter out records created since the start of the current hour.
+    now = datetime.now(tz=timezone.utc)
+    start_of_hour = now.replace(minute=0, second=0, microsecond=0)
+
     file_list = file_list_from_s3(
-        bucket_name=s3_bucket, file_prefix=batch_args.s3_prefix
+        bucket_name=s3_bucket,
+        file_prefix=batch_args.s3_prefix,
+        until=start_of_hour,
     )
 
     total_bytes = 0

--- a/py_gtfs_rt_ingestion/pyproject.toml
+++ b/py_gtfs_rt_ingestion/pyproject.toml
@@ -44,6 +44,12 @@ good-names = ["e"]
 max-line-length = 80
 min-similarity-lines = 10
 
+[tool.pytest]
+log_cli = true
+log_cli_level = "DEBUG"
+verbose = true
+
+
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/py_gtfs_rt_ingestion/tests/test_s3_utils.py
+++ b/py_gtfs_rt_ingestion/tests/test_s3_utils.py
@@ -6,6 +6,8 @@ import json
 import logging
 import os
 
+from datetime import datetime, timezone
+
 from unittest.mock import patch
 
 import boto3
@@ -32,9 +34,9 @@ def s3_stub():  # type: ignore
         stubber.assert_no_pending_responses()
 
 
-def test_file_list_s3(s3_stub):  # type: ignore
+def test_file_list_s3_empty(s3_stub):  # type: ignore
     """
-    test that list files works as expected given pre-described s3 responses
+    test that list files works as expected given empty s3 responses
     """
     # Process 'list_objects_v2' that returns no files
     page_obj_params = {
@@ -52,7 +54,11 @@ def test_file_list_s3(s3_stub):  # type: ignore
     assert len(files) == page_obj_response["KeyCount"]
     assert not files
 
-    # Process 'list_objects_v2' that returns dummy 'Contents'
+
+def test_file_list_s3_contents(s3_stub):  # type: ignore
+    """
+    Process 'list_objects_v2' that returns dummy 'Contents'
+    """
     page_obj_params = {
         "Bucket": "mbta-gtfs-s3",
         "Prefix": ANY,
@@ -64,10 +70,12 @@ def test_file_list_s3(s3_stub):  # type: ignore
             {
                 "Key": "file1",
                 "Size": 1231,
+                "LastModified": "2019-02-08 00:00:10+00:00",
             },
             {
                 "Key": "file2",
                 "Size": 43212,
+                "LastModified": "2019-02-08 00:00:10+00:00",
             },
         ],
     }
@@ -85,9 +93,11 @@ def test_file_list_s3(s3_stub):  # type: ignore
 
     assert files == should_files
 
-    # Process large page_obj_response from json file
-    # 'test_files/large_page_obj_response.json'
-    # large json file contains 1,000 Contents records.
+
+def test_file_list_s3_large(s3_stub):  # type: ignore
+    """
+    check that large responses from s3 work for file_list_from_s3 function
+    """
     large_response_file = os.path.join(
         TEST_FILE_DIR, "large_page_obj_response.json"
     )
@@ -113,6 +123,51 @@ def test_file_list_s3(s3_stub):  # type: ignore
         should_files.append((f"s3://mbta-gtfs-s3/{name}", size))
 
     assert files == should_files
+
+
+def test_file_list_s3_until(s3_stub):  # type: ignore
+    """
+    Test that time limiting works for file_list_from_s3 function
+    """
+    large_response_file = os.path.join(
+        TEST_FILE_DIR, "large_page_obj_response.json"
+    )
+    page_obj_params = {
+        "Bucket": "mbta-gtfs-s3",
+        "Prefix": ANY,
+    }
+    with open(large_response_file, "r", encoding="utf8") as file:
+        page_obj_response = json.load(file)
+
+    # update the last modified field, changing from iso time format to datetime
+    # object like expected from aws.
+    for entry in page_obj_response["Contents"]:
+        entry["LastModified"] = datetime.fromisoformat(entry["LastModified"])
+
+    s3_stub.add_response("list_objects_v2", page_obj_response, page_obj_params)
+
+    until = datetime(
+        year=2019, month=2, day=8, hour=1, minute=0, tzinfo=timezone.utc
+    )
+
+    with s3_stub:
+        files = list(file_list_from_s3("mbta-gtfs-s3", "", until))
+
+    # some of the files will be omitted because they are filterd out by date
+    assert len(files) < page_obj_response["KeyCount"]
+
+    # for the files that pass, pull the timestamps out of their filename and
+    # check that their hour is zero as all files with times after hour 0 will be
+    # filterd out.
+    for filename, _ in files:
+        # strip off all prefixes
+        filename = filename.split("/")[-1]
+
+        # iso date string is everything in filename before first _
+        date_string = filename.split("_")[0]
+
+        # convert to datetime and assert hour is 0
+        assert datetime.fromisoformat(date_string).hour == 0
 
 
 def test_move_bad_objects(s3_stub, caplog):  # type: ignore


### PR DESCRIPTION
The Batching lambda is scheduled to run at the start of every hour.
However, due to start up times, the actual run time is a few minutes
after the start of the hour. This causes most batches to have files that
were created between 3 minutes past the previous hour up until 3 minutes
past the current hour. When the parquet files are generated from these
ingested files, we partition them, leaving us with two files. One is a
large file for all data created during the previous hour while the other
is quite small, containing only data created during the first three
minutes of the current hour.

Update `file_list_from_s3` utility to filter out files modified after
passed in datetime. This feature is used in batch files dot py to
prevent the files that have been uploaded since the start of the current
hour from being batched, which should help us avoid the splits happening
on partition.

Tests were updated to catch this behavior.

pyproject dot toml was also updated to allow log statements to come
through on failure, which is useful for debugging code both in the
module and in the tests.

Asana Task: https://app.asana.com/0/1189492770004753/1202506607268445/f