### PR TITLE
Gtfs static load

### DIFF
--- a/performance_manager/lib/__init__.py
+++ b/performance_manager/lib/__init__.py
@@ -5,14 +5,16 @@ analize the performance of the MBTA system.
 from .postgres_utils import (
     get_local_engine,
     get_experimental_engine,
-    SqlBase,
-    StaticSubHeadway,
-    VehiclePositionEvents,
+)
+
+from .postgres_schema import (
     MetadataLog,
+    SqlBase,
 )
 
 from .static_schedule import process_static_schedule
 from .rt_vehicle_positions import process_vehicle_positions
 from .rt_trip_updates import process_trip_updates
+from .gtfs_static_table import process_static_tables
 
 __version__ = "0.1.0"

--- a/performance_manager/lib/gtfs_static_table.py
+++ b/performance_manager/lib/gtfs_static_table.py
@@ -1,6 +1,7 @@
 from typing import List, Optional
 from dataclasses import dataclass
 
+import os
 import logging
 import pandas
 import numpy
@@ -179,7 +180,7 @@ def get_static_parquet_paths(table_type: str, feed_info_path: str) -> List[str]:
     """
     get static table parquet files from FEED_INFO path
     """
-    springboard_bucket = "mbta-ctd-dataplatform-dev-springboard"
+    springboard_bucket = os.environ["EXPORT_BUCKET"]
     static_prefix = feed_info_path.replace("FEED_INFO", table_type)
     static_prefix = static_prefix.replace(f"{springboard_bucket}/", "")
     return list(
@@ -276,6 +277,3 @@ def process_static_tables(sql_session: sessionmaker) -> None:
             )
             with sql_session.begin() as cursor:  # type: ignore
                 cursor.execute(update_md_log)
-
-        # delete static_tables to ensure memory freed
-        del static_tables

--- a/performance_manager/lib/gtfs_static_table.py
+++ b/performance_manager/lib/gtfs_static_table.py
@@ -1,0 +1,317 @@
+from typing import List, Optional
+
+import logging
+import pandas
+import numpy
+
+import sqlalchemy as sa
+from sqlalchemy.orm import sessionmaker
+
+from .s3_utils import read_parquet, file_list_from_s3
+from .postgres_utils import MetadataLog, get_unprocessed_files
+from .postgres_schema import (
+    StaticFeedInfo,
+    StaticTrips,
+    StaticRoutes,
+    StaticStops,
+    StaticStopTimes,
+    StaticCalendar,
+)
+from .gtfs_utils import start_time_to_seconds
+
+
+def get_static_parquet_paths(table_type: str, feed_info_path: str) -> List[str]:
+    """
+    get static table parquet files from FEED_INFO path
+    """
+    springboard_bucket = "mbta-ctd-dataplatform-dev-springboard"
+    static_prefix = feed_info_path.replace("FEED_INFO", table_type)
+    static_prefix = static_prefix.replace(f"{springboard_bucket}/", "")
+    return list(
+        uri for uri in file_list_from_s3(springboard_bucket, static_prefix)
+    )
+
+
+# pylint: disable=too-many-arguments
+def get_and_insert_static_tables(
+    table_name: str,
+    feed_info_path: str,
+    session: sa.orm.session.sessionmaker,
+    insert_table: str,
+    columns_to_pull: List[str],
+    int64_cols: Optional[List[str]] = None,
+    bool_cols: Optional[List[str]] = None,
+    time_to_seconds_cols: Optional[List[str]] = None,
+) -> None:
+    """
+    common static table processing and insert logic
+    """
+    paths_to_load = get_static_parquet_paths(table_name, feed_info_path)
+
+    data_table = read_parquet(paths_to_load, columns=columns_to_pull)
+
+    assert data_table.shape[0] > 0
+
+    data_table = data_table.drop_duplicates()
+
+    if int64_cols is not None:
+        for col in int64_cols:
+            data_table[col] = pandas.to_numeric(data_table[col]).astype("Int64")
+
+    if bool_cols is not None:
+        for col in bool_cols:
+            data_table[col] = numpy.where(
+                data_table[col] == 1, True, False
+            ).astype(numpy.bool8)
+
+    if time_to_seconds_cols is not None:
+        for col in time_to_seconds_cols:
+            data_table[col] = (
+                data_table[col].apply(start_time_to_seconds).astype("Int64")
+            )
+
+    with session.begin() as cursor:  # type: ignore
+        cursor.execute(
+            sa.insert(insert_table), data_table.to_dict(orient="records")
+        )
+
+
+# pylint: enable=too-many-arguments
+
+
+def process_feed_info(
+    feed_info_path: str, session: sa.orm.session.sessionmaker
+) -> None:
+    """
+    load feed_info table
+    """
+    table_name = "FEED_INFO"
+    insert_table = StaticFeedInfo.__table__
+    columns_to_pull = [
+        "feed_start_date",
+        "feed_end_date",
+        "feed_version",
+        "timestamp",
+    ]
+    int64_cols = [
+        "feed_start_date",
+        "feed_end_date",
+        "timestamp",
+    ]
+    get_and_insert_static_tables(
+        table_name,
+        feed_info_path,
+        session,
+        insert_table,
+        columns_to_pull=columns_to_pull,
+        int64_cols=int64_cols,
+    )
+
+
+def process_trips(
+    feed_info_path: str, session: sa.orm.session.sessionmaker
+) -> None:
+    """
+    load trips table
+    """
+    table_name = "TRIPS"
+    insert_table = StaticTrips.__table__
+    columns_to_pull = [
+        "route_id",
+        "service_id",
+        "trip_id",
+        "direction_id",
+        "timestamp",
+    ]
+    int64_cols = [
+        "timestamp",
+    ]
+    bool_cols = ["direction_id"]
+    get_and_insert_static_tables(
+        table_name,
+        feed_info_path,
+        session,
+        insert_table,
+        columns_to_pull=columns_to_pull,
+        int64_cols=int64_cols,
+        bool_cols=bool_cols,
+    )
+
+
+def process_routes(
+    feed_info_path: str, session: sa.orm.session.sessionmaker
+) -> None:
+    """
+    load routes table
+    """
+    table_name = "ROUTES"
+    insert_table = StaticRoutes.__table__
+    columns_to_pull = [
+        "route_id",
+        "agency_id",
+        "route_short_name",
+        "route_long_name",
+        "route_desc",
+        "route_type",
+        "route_sort_order",
+        "route_fare_class",
+        "line_id",
+        "timestamp",
+    ]
+    int64_cols = [
+        "agency_id",
+        "route_type",
+        "route_sort_order",
+        "timestamp",
+    ]
+    get_and_insert_static_tables(
+        table_name,
+        feed_info_path,
+        session,
+        insert_table,
+        columns_to_pull=columns_to_pull,
+        int64_cols=int64_cols,
+    )
+
+
+def process_stops(
+    feed_info_path: str, session: sa.orm.session.sessionmaker
+) -> None:
+    """
+    load stops table
+    """
+    table_name = "STOPS"
+    insert_table = StaticStops.__table__
+    columns_to_pull = [
+        "stop_id",
+        "stop_name",
+        "stop_desc",
+        "platform_code",
+        "platform_name",
+        "parent_station",
+        "timestamp",
+    ]
+    int64_cols = [
+        "timestamp",
+    ]
+    get_and_insert_static_tables(
+        table_name,
+        feed_info_path,
+        session,
+        insert_table,
+        columns_to_pull=columns_to_pull,
+        int64_cols=int64_cols,
+    )
+
+
+def process_stop_times(
+    feed_info_path: str, session: sa.orm.session.sessionmaker
+) -> None:
+    """
+    load stop_times table
+    """
+    table_name = "STOP_TIMES"
+    insert_table = StaticStopTimes.__table__
+    columns_to_pull = [
+        "trip_id",
+        "arrival_time",
+        "departure_time",
+        "stop_id",
+        "stop_sequence",
+        "timestamp",
+    ]
+    int64_cols = [
+        "stop_sequence",
+        "timestamp",
+    ]
+    time_to_seconds_cols = [
+        "arrival_time",
+        "departure_time",
+    ]
+    get_and_insert_static_tables(
+        table_name,
+        feed_info_path,
+        session,
+        insert_table,
+        columns_to_pull=columns_to_pull,
+        int64_cols=int64_cols,
+        time_to_seconds_cols=time_to_seconds_cols,
+    )
+
+
+def process_calendar(
+    feed_info_path: str, session: sa.orm.session.sessionmaker
+) -> None:
+    """
+    load calendar table
+    """
+    table_name = "CALENDAR"
+    insert_table = StaticCalendar.__table__
+    columns_to_pull = [
+        "service_id",
+        "monday",
+        "tuesday",
+        "wednesday",
+        "thursday",
+        "friday",
+        "saturday",
+        "sunday",
+        "start_date",
+        "end_date",
+        "timestamp",
+    ]
+    int64_cols = [
+        "start_date",
+        "end_date",
+        "timestamp",
+    ]
+    bool_cols = [
+        "monday",
+        "tuesday",
+        "wednesday",
+        "thursday",
+        "friday",
+        "saturday",
+        "sunday",
+    ]
+    get_and_insert_static_tables(
+        table_name,
+        feed_info_path,
+        session,
+        insert_table,
+        columns_to_pull=columns_to_pull,
+        int64_cols=int64_cols,
+        bool_cols=bool_cols,
+    )
+
+
+def process_static_tables(sql_session: sessionmaker) -> None:
+    """
+    process gtfs static table files from metadataLog table
+    """
+
+    # pull list of objects that need processing from metadata table
+    paths_to_load = get_unprocessed_files("FEED_INFO", sql_session)
+
+    for folder, folder_data in paths_to_load.items():
+        ids = folder_data["ids"]
+        folder = str(folder)
+
+        try:
+            process_feed_info(folder, sql_session)
+            process_trips(folder, sql_session)
+            process_routes(folder, sql_session)
+            process_stops(folder, sql_session)
+            process_stop_times(folder, sql_session)
+            process_calendar(folder, sql_session)
+        except Exception as e:
+            logging.info("Error Processing Trip Updates")
+            logging.exception(e)
+        else:
+            update_md_log = (
+                sa.update(MetadataLog.__table__)
+                .where(MetadataLog.pk_id.in_(ids))
+                .values(processed=1)
+            )
+            with sql_session.begin() as cursor:  # type: ignore
+                cursor.execute(update_md_log)

--- a/performance_manager/lib/gtfs_static_table.py
+++ b/performance_manager/lib/gtfs_static_table.py
@@ -1,4 +1,5 @@
 from typing import List, Optional
+from dataclasses import dataclass
 
 import logging
 import pandas
@@ -20,6 +21,160 @@ from .postgres_schema import (
 from .gtfs_utils import start_time_to_seconds
 
 
+@dataclass
+class StaticTableDetails:
+    """
+    Container class for loading static gtfs schedule tables
+    """
+
+    table_name: str
+    insert_table: str
+    columns_to_pull: List[str]
+    int64_cols: Optional[List[str]] = None
+    bool_cols: Optional[List[str]] = None
+    time_to_seconds_cols: Optional[List[str]] = None
+    data_table: pandas.DataFrame = pandas.DataFrame()
+
+
+def get_table_objects() -> List[StaticTableDetails]:
+    """
+    getter function for clean list of gtfs static table details objects
+    """
+    feed_info = StaticTableDetails(
+        table_name="FEED_INFO",
+        insert_table=StaticFeedInfo.__table__,
+        columns_to_pull=[
+            "feed_start_date",
+            "feed_end_date",
+            "feed_version",
+            "timestamp",
+        ],
+        int64_cols=[
+            "feed_start_date",
+            "feed_end_date",
+            "timestamp",
+        ],
+    )
+
+    trips = StaticTableDetails(
+        table_name="TRIPS",
+        insert_table=StaticTrips.__table__,
+        columns_to_pull=[
+            "route_id",
+            "service_id",
+            "trip_id",
+            "direction_id",
+            "timestamp",
+        ],
+        int64_cols=[
+            "timestamp",
+        ],
+        bool_cols=["direction_id"],
+    )
+
+    routes = StaticTableDetails(
+        table_name="ROUTES",
+        insert_table=StaticRoutes.__table__,
+        columns_to_pull=[
+            "route_id",
+            "agency_id",
+            "route_short_name",
+            "route_long_name",
+            "route_desc",
+            "route_type",
+            "route_sort_order",
+            "route_fare_class",
+            "line_id",
+            "timestamp",
+        ],
+        int64_cols=[
+            "agency_id",
+            "route_type",
+            "route_sort_order",
+            "timestamp",
+        ],
+    )
+
+    stops = StaticTableDetails(
+        table_name="STOPS",
+        insert_table=StaticStops.__table__,
+        columns_to_pull=[
+            "stop_id",
+            "stop_name",
+            "stop_desc",
+            "platform_code",
+            "platform_name",
+            "parent_station",
+            "timestamp",
+        ],
+        int64_cols=[
+            "timestamp",
+        ],
+    )
+
+    stop_times = StaticTableDetails(
+        table_name="STOP_TIMES",
+        insert_table=StaticStopTimes.__table__,
+        columns_to_pull=[
+            "trip_id",
+            "arrival_time",
+            "departure_time",
+            "stop_id",
+            "stop_sequence",
+            "timestamp",
+        ],
+        int64_cols=[
+            "stop_sequence",
+            "timestamp",
+        ],
+        time_to_seconds_cols=[
+            "arrival_time",
+            "departure_time",
+        ],
+    )
+
+    calendar = StaticTableDetails(
+        table_name="CALENDAR",
+        insert_table=StaticCalendar.__table__,
+        columns_to_pull=[
+            "service_id",
+            "monday",
+            "tuesday",
+            "wednesday",
+            "thursday",
+            "friday",
+            "saturday",
+            "sunday",
+            "start_date",
+            "end_date",
+            "timestamp",
+        ],
+        int64_cols=[
+            "start_date",
+            "end_date",
+            "timestamp",
+        ],
+        bool_cols=[
+            "monday",
+            "tuesday",
+            "wednesday",
+            "thursday",
+            "friday",
+            "saturday",
+            "sunday",
+        ],
+    )
+
+    return [
+        feed_info,
+        trips,
+        routes,
+        stops,
+        stop_times,
+        calendar,
+    ]
+
+
 def get_static_parquet_paths(table_type: str, feed_info_path: str) -> List[str]:
     """
     get static table parquet files from FEED_INFO path
@@ -32,257 +187,64 @@ def get_static_parquet_paths(table_type: str, feed_info_path: str) -> List[str]:
     )
 
 
-# pylint: disable=too-many-arguments
-def get_and_insert_static_tables(
-    table_name: str,
-    feed_info_path: str,
-    session: sa.orm.session.sessionmaker,
-    insert_table: str,
-    columns_to_pull: List[str],
-    int64_cols: Optional[List[str]] = None,
-    bool_cols: Optional[List[str]] = None,
-    time_to_seconds_cols: Optional[List[str]] = None,
+def load_parquet_files(
+    static_tables: List[StaticTableDetails], feed_info_path: str
 ) -> None:
     """
-    common static table processing and insert logic
+    get parquet paths to load from feed_info_path and load parquet files as
+    dataframe into StaticTableDetails objects
     """
-    paths_to_load = get_static_parquet_paths(table_name, feed_info_path)
-
-    data_table = read_parquet(paths_to_load, columns=columns_to_pull)
-
-    assert data_table.shape[0] > 0
-
-    data_table = data_table.drop_duplicates()
-
-    if int64_cols is not None:
-        for col in int64_cols:
-            data_table[col] = pandas.to_numeric(data_table[col]).astype("Int64")
-
-    if bool_cols is not None:
-        for col in bool_cols:
-            data_table[col] = numpy.where(
-                data_table[col] == 1, True, False
-            ).astype(numpy.bool8)
-
-    if time_to_seconds_cols is not None:
-        for col in time_to_seconds_cols:
-            data_table[col] = (
-                data_table[col].apply(start_time_to_seconds).astype("Int64")
-            )
-
-    with session.begin() as cursor:  # type: ignore
-        cursor.execute(
-            sa.insert(insert_table), data_table.to_dict(orient="records")
+    for table in static_tables:
+        paths_to_load = get_static_parquet_paths(
+            table.table_name, feed_info_path
         )
+        table.data_table = read_parquet(
+            paths_to_load, columns=table.columns_to_pull
+        )
+        assert table.data_table.shape[0] > 0
 
 
-# pylint: enable=too-many-arguments
+def transform_data_tables(static_tables: List[StaticTableDetails]) -> None:
+    """
+    transform static gtfs schedule dataframe objects as required
+    """
+    for table in static_tables:
+        table.data_table = table.data_table.drop_duplicates()
+
+        if table.int64_cols is not None:
+            for col in table.int64_cols:
+                table.data_table[col] = pandas.to_numeric(
+                    table.data_table[col]
+                ).astype("Int64")
+
+        if table.bool_cols is not None:
+            for col in table.bool_cols:
+                table.data_table[col] = numpy.where(
+                    table.data_table[col] == 1, True, False
+                ).astype(numpy.bool8)
+
+        if table.time_to_seconds_cols is not None:
+            for col in table.time_to_seconds_cols:
+                table.data_table[col] = (
+                    table.data_table[col]
+                    .apply(start_time_to_seconds)
+                    .astype("Int64")
+                )
 
 
-def process_feed_info(
-    feed_info_path: str, session: sa.orm.session.sessionmaker
+def insert_data_tables(
+    static_tables: List[StaticTableDetails],
+    session: sa.orm.session.sessionmaker,
 ) -> None:
     """
-    load feed_info table
+    insert static gtfs data tables into rds tables
     """
-    table_name = "FEED_INFO"
-    insert_table = StaticFeedInfo.__table__
-    columns_to_pull = [
-        "feed_start_date",
-        "feed_end_date",
-        "feed_version",
-        "timestamp",
-    ]
-    int64_cols = [
-        "feed_start_date",
-        "feed_end_date",
-        "timestamp",
-    ]
-    get_and_insert_static_tables(
-        table_name,
-        feed_info_path,
-        session,
-        insert_table,
-        columns_to_pull=columns_to_pull,
-        int64_cols=int64_cols,
-    )
-
-
-def process_trips(
-    feed_info_path: str, session: sa.orm.session.sessionmaker
-) -> None:
-    """
-    load trips table
-    """
-    table_name = "TRIPS"
-    insert_table = StaticTrips.__table__
-    columns_to_pull = [
-        "route_id",
-        "service_id",
-        "trip_id",
-        "direction_id",
-        "timestamp",
-    ]
-    int64_cols = [
-        "timestamp",
-    ]
-    bool_cols = ["direction_id"]
-    get_and_insert_static_tables(
-        table_name,
-        feed_info_path,
-        session,
-        insert_table,
-        columns_to_pull=columns_to_pull,
-        int64_cols=int64_cols,
-        bool_cols=bool_cols,
-    )
-
-
-def process_routes(
-    feed_info_path: str, session: sa.orm.session.sessionmaker
-) -> None:
-    """
-    load routes table
-    """
-    table_name = "ROUTES"
-    insert_table = StaticRoutes.__table__
-    columns_to_pull = [
-        "route_id",
-        "agency_id",
-        "route_short_name",
-        "route_long_name",
-        "route_desc",
-        "route_type",
-        "route_sort_order",
-        "route_fare_class",
-        "line_id",
-        "timestamp",
-    ]
-    int64_cols = [
-        "agency_id",
-        "route_type",
-        "route_sort_order",
-        "timestamp",
-    ]
-    get_and_insert_static_tables(
-        table_name,
-        feed_info_path,
-        session,
-        insert_table,
-        columns_to_pull=columns_to_pull,
-        int64_cols=int64_cols,
-    )
-
-
-def process_stops(
-    feed_info_path: str, session: sa.orm.session.sessionmaker
-) -> None:
-    """
-    load stops table
-    """
-    table_name = "STOPS"
-    insert_table = StaticStops.__table__
-    columns_to_pull = [
-        "stop_id",
-        "stop_name",
-        "stop_desc",
-        "platform_code",
-        "platform_name",
-        "parent_station",
-        "timestamp",
-    ]
-    int64_cols = [
-        "timestamp",
-    ]
-    get_and_insert_static_tables(
-        table_name,
-        feed_info_path,
-        session,
-        insert_table,
-        columns_to_pull=columns_to_pull,
-        int64_cols=int64_cols,
-    )
-
-
-def process_stop_times(
-    feed_info_path: str, session: sa.orm.session.sessionmaker
-) -> None:
-    """
-    load stop_times table
-    """
-    table_name = "STOP_TIMES"
-    insert_table = StaticStopTimes.__table__
-    columns_to_pull = [
-        "trip_id",
-        "arrival_time",
-        "departure_time",
-        "stop_id",
-        "stop_sequence",
-        "timestamp",
-    ]
-    int64_cols = [
-        "stop_sequence",
-        "timestamp",
-    ]
-    time_to_seconds_cols = [
-        "arrival_time",
-        "departure_time",
-    ]
-    get_and_insert_static_tables(
-        table_name,
-        feed_info_path,
-        session,
-        insert_table,
-        columns_to_pull=columns_to_pull,
-        int64_cols=int64_cols,
-        time_to_seconds_cols=time_to_seconds_cols,
-    )
-
-
-def process_calendar(
-    feed_info_path: str, session: sa.orm.session.sessionmaker
-) -> None:
-    """
-    load calendar table
-    """
-    table_name = "CALENDAR"
-    insert_table = StaticCalendar.__table__
-    columns_to_pull = [
-        "service_id",
-        "monday",
-        "tuesday",
-        "wednesday",
-        "thursday",
-        "friday",
-        "saturday",
-        "sunday",
-        "start_date",
-        "end_date",
-        "timestamp",
-    ]
-    int64_cols = [
-        "start_date",
-        "end_date",
-        "timestamp",
-    ]
-    bool_cols = [
-        "monday",
-        "tuesday",
-        "wednesday",
-        "thursday",
-        "friday",
-        "saturday",
-        "sunday",
-    ]
-    get_and_insert_static_tables(
-        table_name,
-        feed_info_path,
-        session,
-        insert_table,
-        columns_to_pull=columns_to_pull,
-        int64_cols=int64_cols,
-        bool_cols=bool_cols,
-    )
+    for table in static_tables:
+        with session.begin() as cursor:  # type: ignore
+            cursor.execute(
+                sa.insert(table.insert_table),
+                table.data_table.to_dict(orient="records"),
+            )
 
 
 def process_static_tables(sql_session: sessionmaker) -> None:
@@ -297,15 +259,14 @@ def process_static_tables(sql_session: sessionmaker) -> None:
         ids = folder_data["ids"]
         folder = str(folder)
 
+        static_tables = get_table_objects()
+
         try:
-            process_feed_info(folder, sql_session)
-            process_trips(folder, sql_session)
-            process_routes(folder, sql_session)
-            process_stops(folder, sql_session)
-            process_stop_times(folder, sql_session)
-            process_calendar(folder, sql_session)
+            load_parquet_files(static_tables, folder)
+            transform_data_tables(static_tables)
+            insert_data_tables(static_tables, sql_session)
         except Exception as e:
-            logging.info("Error Processing Trip Updates")
+            logging.info("Error Processing Static GTFS Schedules")
             logging.exception(e)
         else:
             update_md_log = (
@@ -315,3 +276,6 @@ def process_static_tables(sql_session: sessionmaker) -> None:
             )
             with sql_session.begin() as cursor:  # type: ignore
                 cursor.execute(update_md_log)
+
+        # delete static_tables to ensure memory freed
+        del static_tables

--- a/performance_manager/lib/postgres_schema.py
+++ b/performance_manager/lib/postgres_schema.py
@@ -44,7 +44,7 @@ class VehiclePositionEvents(SqlBase):  # pylint: disable=too-few-public-methods
 
     pk_id = sa.Column(sa.Integer, primary_key=True)
     is_moving = sa.Column(sa.Boolean)
-    current_stop_sequence = sa.Column(sa.SmallInteger, nullable=True)
+    stop_sequence = sa.Column(sa.SmallInteger, nullable=True)
     stop_id = sa.Column(sa.String(60), nullable=True)
     timestamp_start = sa.Column(sa.Integer, nullable=False)
     timestamp_end = sa.Column(sa.Integer, nullable=False)
@@ -53,7 +53,7 @@ class VehiclePositionEvents(SqlBase):  # pylint: disable=too-few-public-methods
     start_date = sa.Column(sa.Integer, nullable=True)
     start_time = sa.Column(sa.Integer, nullable=True)
     vehicle_id = sa.Column(sa.String(60), nullable=False)
-    hash = sa.Column(sa.BigInteger, nullable=False)
+    hash = sa.Column(sa.BigInteger, nullable=False, index=True, unique=False)
     updated_on = sa.Column(
         sa.DateTime, server_default=sa.func.now(), server_onupdate=sa.func.now()
     )
@@ -74,7 +74,7 @@ class TripUpdateEvents(SqlBase):  # pylint: disable=too-few-public-methods
     start_date = sa.Column(sa.Integer, nullable=True)
     start_time = sa.Column(sa.Integer, nullable=True)
     vehicle_id = sa.Column(sa.String(60), nullable=False)
-    hash = sa.Column(sa.BigInteger, nullable=False)
+    hash = sa.Column(sa.BigInteger, nullable=False, index=True, unique=False)
     updated_on = sa.Column(
         sa.DateTime, server_default=sa.func.now(), server_onupdate=sa.func.now()
     )

--- a/performance_manager/lib/postgres_schema.py
+++ b/performance_manager/lib/postgres_schema.py
@@ -1,0 +1,193 @@
+from typing import Any
+
+import sqlalchemy as sa
+from sqlalchemy.ext.declarative import declarative_base
+
+SqlBase: Any = declarative_base()
+
+
+class StaticSubHeadway(SqlBase):  # pylint: disable=too-few-public-methods
+    """Table for Static Subway Headway information"""
+
+    __tablename__ = "staticSubwayHeadways"
+
+    id = sa.Column(sa.Integer, primary_key=True)
+    trip_id = sa.Column(sa.String(100))
+    arrival_time = sa.Column(sa.String(10))
+    departure_time = sa.Column(sa.String(10))
+    stop_id = sa.Column(sa.Integer)
+    stop_sequence = sa.Column(sa.Integer)
+    pickup_type = sa.Column(sa.Integer)
+    drop_off_type = sa.Column(sa.Integer)
+    # TODO(zap) this should be an optional int, but it currently throws an
+    # error if its a pandas.nan
+    timepoint = sa.Column(sa.String)
+    checkpoint_id = sa.Column(sa.String)
+    route_type = sa.Column(sa.Integer)
+    route_id = sa.Column(sa.String(60))
+    service_id = sa.Column(sa.String(60))
+    direction_id = sa.Column(sa.Integer)
+    parent_station = sa.Column(sa.String(60))
+    departure_time_sec = sa.Column(sa.Float)
+    prev_departure_time_sec = sa.Column(sa.Float)
+    head_way = sa.Column(sa.Integer)
+
+    def __repr__(self) -> str:
+        """this is just a helper string for debugging."""
+        return f"( id='{self.id}', trip_id='{self.trip_id}', arrival_time='{self.arrival_time}', departure_time='{self.departure_time}', stop_id='{self.stop_id}', stop_sequence='{self.stop_sequence}', pickup_type='{self.pickup_type}', drop_off_type='{self.drop_off_type}', timepoint='{self.timepoint}', checkpoint_id='{self.checkpoint_id}', route_type='{self.route_type}', route_id='{self.route_id}', service_id='{self.service_id}', direction_id='{self.direction_id}', parent_station='{self.parent_station}', departure_time_sec='{self.departure_time_sec}', prev_departure_time_sec='{self.prev_departure_time_sec}', head_way='{self.head_way}')"
+
+
+class VehiclePositionEvents(SqlBase):  # pylint: disable=too-few-public-methods
+    """Table for GTFS-RT Vehicle Position Events"""
+
+    __tablename__ = "eventsVehiclePositions"
+
+    pk_id = sa.Column(sa.Integer, primary_key=True)
+    is_moving = sa.Column(sa.Boolean)
+    current_stop_sequence = sa.Column(sa.SmallInteger, nullable=True)
+    stop_id = sa.Column(sa.String(60), nullable=True)
+    timestamp_start = sa.Column(sa.Integer, nullable=False)
+    timestamp_end = sa.Column(sa.Integer, nullable=False)
+    direction_id = sa.Column(sa.SmallInteger, nullable=True)
+    route_id = sa.Column(sa.String(60), nullable=True)
+    start_date = sa.Column(sa.Integer, nullable=True)
+    start_time = sa.Column(sa.Integer, nullable=True)
+    vehicle_id = sa.Column(sa.String(60), nullable=False)
+    hash = sa.Column(sa.BigInteger, nullable=False)
+    updated_on = sa.Column(
+        sa.DateTime, server_default=sa.func.now(), server_onupdate=sa.func.now()
+    )
+
+
+class TripUpdateEvents(SqlBase):  # pylint: disable=too-few-public-methods
+    """Table for GTFS-RT Trip Update Predicted Stop Events"""
+
+    __tablename__ = "eventsTripUpdates"
+
+    pk_id = sa.Column(sa.Integer, primary_key=True)
+    is_moving = sa.Column(sa.Boolean)
+    stop_sequence = sa.Column(sa.SmallInteger, nullable=True)
+    stop_id = sa.Column(sa.String(60), nullable=True)
+    timestamp_start = sa.Column(sa.Integer, nullable=False)
+    direction_id = sa.Column(sa.SmallInteger, nullable=True)
+    route_id = sa.Column(sa.String(60), nullable=True)
+    start_date = sa.Column(sa.Integer, nullable=True)
+    start_time = sa.Column(sa.Integer, nullable=True)
+    vehicle_id = sa.Column(sa.String(60), nullable=False)
+    hash = sa.Column(sa.BigInteger, nullable=False)
+    updated_on = sa.Column(
+        sa.DateTime, server_default=sa.func.now(), server_onupdate=sa.func.now()
+    )
+
+
+class MetadataLog(SqlBase):  # pylint: disable=too-few-public-methods
+    """Table for keeping track of parquet files in S3"""
+
+    __tablename__ = "metadataLog"
+
+    pk_id = sa.Column(sa.Integer, primary_key=True)
+    processed = sa.Column(sa.Boolean, default=sa.false())
+    path = sa.Column(sa.String(256), nullable=False, unique=True)
+    updated_on = sa.Column(
+        sa.TIMESTAMP,
+        server_default=sa.func.now(),
+        server_onupdate=sa.func.now(),
+    )
+    created_on = sa.Column(sa.TIMESTAMP, server_default=sa.func.now())
+
+
+class StaticFeedInfo(SqlBase):  # pylint: disable=too-few-public-methods
+    """Table for GTFS feed info"""
+
+    __tablename__ = "staticFeedInfo"
+
+    pk_id = sa.Column(sa.Integer, primary_key=True)
+    feed_start_date = sa.Column(sa.Integer, nullable=False)
+    feed_end_date = sa.Column(sa.Integer, nullable=False)
+    feed_version = sa.Column(sa.String(75), nullable=False, unique=True)
+    timestamp = sa.Column(sa.Integer, nullable=False, unique=True)
+    updated_on = sa.Column(
+        sa.TIMESTAMP,
+        server_default=sa.func.now(),
+        server_onupdate=sa.func.now(),
+    )
+    created_on = sa.Column(sa.TIMESTAMP, server_default=sa.func.now())
+
+
+class StaticTrips(SqlBase):  # pylint: disable=too-few-public-methods
+    """Table for GTFS trips"""
+
+    __tablename__ = "staticTrips"
+
+    pk_id = sa.Column(sa.Integer, primary_key=True)
+    route_id = sa.Column(sa.String(60), nullable=False)
+    service_id = sa.Column(sa.String(60), nullable=False)
+    trip_id = sa.Column(sa.String(128), nullable=False)
+    direction_id = sa.Column(sa.Boolean)
+    timestamp = sa.Column(sa.Integer, nullable=False)
+
+
+class StaticRoutes(SqlBase):  # pylint: disable=too-few-public-methods
+    """Table for GTFS routes"""
+
+    __tablename__ = "staticRoutes"
+
+    pk_id = sa.Column(sa.Integer, primary_key=True)
+    route_id = sa.Column(sa.String(60), nullable=False)
+    agency_id = sa.Column(sa.SmallInteger, nullable=False)
+    route_short_name = sa.Column(sa.String(60), nullable=False)
+    route_long_name = sa.Column(sa.String(150), nullable=False)
+    route_desc = sa.Column(sa.String(40), nullable=False)
+    route_type = sa.Column(sa.SmallInteger, nullable=False)
+    route_sort_order = sa.Column(sa.Integer, nullable=False)
+    route_fare_class = sa.Column(sa.String(30), nullable=False)
+    line_id = sa.Column(sa.String(30), nullable=False)
+    timestamp = sa.Column(sa.Integer, nullable=False)
+
+
+class StaticStops(SqlBase):  # pylint: disable=too-few-public-methods
+    """Table for GTFS stops"""
+
+    __tablename__ = "staticStops"
+
+    pk_id = sa.Column(sa.Integer, primary_key=True)
+    stop_id = sa.Column(sa.String(128), nullable=False)
+    stop_name = sa.Column(sa.String(128), nullable=False)
+    stop_desc = sa.Column(sa.String(256), nullable=False)
+    platform_code = sa.Column(sa.String(10), nullable=False)
+    platform_name = sa.Column(sa.String(60), nullable=False)
+    parent_station = sa.Column(sa.String(30), nullable=False)
+    timestamp = sa.Column(sa.Integer, nullable=False)
+
+
+class StaticStopTimes(SqlBase):  # pylint: disable=too-few-public-methods
+    """Table for GTFS stop times"""
+
+    __tablename__ = "staticStopTimes"
+
+    pk_id = sa.Column(sa.Integer, primary_key=True)
+    trip_id = sa.Column(sa.String(128), nullable=False)
+    arrival_time = sa.Column(sa.Integer, nullable=True)
+    departure_time = sa.Column(sa.Integer, nullable=True)
+    stop_id = sa.Column(sa.String(30), nullable=False)
+    stop_sequence = sa.Column(sa.SmallInteger, nullable=False)
+    timestamp = sa.Column(sa.Integer, nullable=False)
+
+
+class StaticCalendar(SqlBase):  # pylint: disable=too-few-public-methods
+    """Table for GTFS calendar"""
+
+    __tablename__ = "staticCalendar"
+
+    pk_id = sa.Column(sa.Integer, primary_key=True)
+    service_id = sa.Column(sa.String(128), nullable=False)
+    monday = sa.Column(sa.Boolean)
+    tuesday = sa.Column(sa.Boolean)
+    wednesday = sa.Column(sa.Boolean)
+    thursday = sa.Column(sa.Boolean)
+    friday = sa.Column(sa.Boolean)
+    saturday = sa.Column(sa.Boolean)
+    sunday = sa.Column(sa.Boolean)
+    start_date = sa.Column(sa.Integer, nullable=False)
+    end_date = sa.Column(sa.Integer, nullable=False)
+    timestamp = sa.Column(sa.Integer, nullable=False)

--- a/performance_manager/lib/postgres_utils.py
+++ b/performance_manager/lib/postgres_utils.py
@@ -3,12 +3,13 @@ import os
 import pathlib
 import urllib.parse
 
-from typing import Any, Dict, List
+from typing import Dict, List
 
 import sqlalchemy as sa
 from sqlalchemy.engine import URL as DbUrl  # type: ignore
-from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
+
+from .postgres_schema import MetadataLog
 
 
 def get_local_engine(
@@ -73,7 +74,6 @@ def get_aws_engine() -> sa.future.engine.Engine:  # type: ignore
 # For more context:
 # https://docs.sqlalchemy.org/en/14/orm/extensions/mypy.html
 # https://github.com/python/mypy/issues/2477
-SqlBase: Any = declarative_base()
 
 
 def write_from_dict(
@@ -92,96 +92,6 @@ def write_from_dict(
     except Exception as e:
         logging.error("Error Writing Dataframe to Database")
         logging.exception(e)
-
-
-class StaticSubHeadway(SqlBase):  # pylint: disable=too-few-public-methods
-    """Table for Static Subway Headway information"""
-
-    __tablename__ = "staticSubwayHeadways"
-
-    id = sa.Column(sa.Integer, primary_key=True)
-    trip_id = sa.Column(sa.String(100))
-    arrival_time = sa.Column(sa.String(10))
-    departure_time = sa.Column(sa.String(10))
-    stop_id = sa.Column(sa.Integer)
-    stop_sequence = sa.Column(sa.Integer)
-    pickup_type = sa.Column(sa.Integer)
-    drop_off_type = sa.Column(sa.Integer)
-    # TODO(zap) this should be an optional int, but it currently throws an
-    # error if its a pandas.nan
-    timepoint = sa.Column(sa.String)
-    checkpoint_id = sa.Column(sa.String)
-    route_type = sa.Column(sa.Integer)
-    route_id = sa.Column(sa.String(60))
-    service_id = sa.Column(sa.String(60))
-    direction_id = sa.Column(sa.Integer)
-    parent_station = sa.Column(sa.String(60))
-    departure_time_sec = sa.Column(sa.Float)
-    prev_departure_time_sec = sa.Column(sa.Float)
-    head_way = sa.Column(sa.Integer)
-
-    def __repr__(self) -> str:
-        """this is just a helper string for debugging."""
-        return f"( id='{self.id}', trip_id='{self.trip_id}', arrival_time='{self.arrival_time}', departure_time='{self.departure_time}', stop_id='{self.stop_id}', stop_sequence='{self.stop_sequence}', pickup_type='{self.pickup_type}', drop_off_type='{self.drop_off_type}', timepoint='{self.timepoint}', checkpoint_id='{self.checkpoint_id}', route_type='{self.route_type}', route_id='{self.route_id}', service_id='{self.service_id}', direction_id='{self.direction_id}', parent_station='{self.parent_station}', departure_time_sec='{self.departure_time_sec}', prev_departure_time_sec='{self.prev_departure_time_sec}', head_way='{self.head_way}')"
-
-
-class VehiclePositionEvents(SqlBase):  # pylint: disable=too-few-public-methods
-    """Table for GTFS-RT Vehicle Position Events"""
-
-    __tablename__ = "eventsVehiclePositions"
-
-    pk_id = sa.Column(sa.Integer, primary_key=True)
-    is_moving = sa.Column(sa.Boolean)
-    current_stop_sequence = sa.Column(sa.SmallInteger, nullable=True)
-    stop_id = sa.Column(sa.String(60), nullable=True)
-    timestamp_start = sa.Column(sa.Integer, nullable=False)
-    timestamp_end = sa.Column(sa.Integer, nullable=False)
-    direction_id = sa.Column(sa.SmallInteger, nullable=True)
-    route_id = sa.Column(sa.String(60), nullable=True)
-    start_date = sa.Column(sa.Integer, nullable=True)
-    start_time = sa.Column(sa.Integer, nullable=True)
-    vehicle_id = sa.Column(sa.String(60), nullable=False)
-    hash = sa.Column(sa.BigInteger, nullable=False)
-    updated_on = sa.Column(
-        sa.DateTime, server_default=sa.func.now(), server_onupdate=sa.func.now()
-    )
-
-
-class TripUpdateEvents(SqlBase):  # pylint: disable=too-few-public-methods
-    """Table for GTFS-RT Trip Update Predicted Stop Events"""
-
-    __tablename__ = "eventsTripUpdates"
-
-    pk_id = sa.Column(sa.Integer, primary_key=True)
-    is_moving = sa.Column(sa.Boolean)
-    stop_sequence = sa.Column(sa.SmallInteger, nullable=True)
-    stop_id = sa.Column(sa.String(60), nullable=True)
-    timestamp_start = sa.Column(sa.Integer, nullable=False)
-    direction_id = sa.Column(sa.SmallInteger, nullable=True)
-    route_id = sa.Column(sa.String(60), nullable=True)
-    start_date = sa.Column(sa.Integer, nullable=True)
-    start_time = sa.Column(sa.Integer, nullable=True)
-    vehicle_id = sa.Column(sa.String(60), nullable=False)
-    hash = sa.Column(sa.BigInteger, nullable=False)
-    updated_on = sa.Column(
-        sa.DateTime, server_default=sa.func.now(), server_onupdate=sa.func.now()
-    )
-
-
-class MetadataLog(SqlBase):  # pylint: disable=too-few-public-methods
-    """Table for keeping track of parquet files in S3"""
-
-    __tablename__ = "metadataLog"
-
-    pk_id = sa.Column(sa.Integer, primary_key=True)
-    processed = sa.Column(sa.Boolean, default=False)
-    path = sa.Column(sa.String(256), nullable=False, unique=True)
-    updated_on = sa.Column(
-        sa.TIMESTAMP,
-        server_default=sa.func.now(),
-        server_onupdate=sa.func.now(),
-    )
-    created_on = sa.Column(sa.TIMESTAMP, server_default=sa.func.now())
 
 
 def get_unprocessed_files(

--- a/performance_manager/lib/rt_trip_updates.py
+++ b/performance_manager/lib/rt_trip_updates.py
@@ -12,7 +12,8 @@ from sqlalchemy.orm import sessionmaker
 
 from .s3_utils import read_parquet
 from .gtfs_utils import start_time_to_seconds, add_event_hash_column
-from .postgres_utils import TripUpdateEvents, MetadataLog, get_unprocessed_files
+from .postgres_utils import get_unprocessed_files
+from .postgres_schema import TripUpdateEvents, MetadataLog
 
 
 def get_tu_dataframe(to_load: Union[str, List[str]]) -> pandas.DataFrame:

--- a/performance_manager/lib/rt_vehicle_positions.py
+++ b/performance_manager/lib/rt_vehicle_positions.py
@@ -11,10 +11,9 @@ from sqlalchemy.orm import sessionmaker
 
 from .s3_utils import read_parquet
 from .postgres_utils import (
-    VehiclePositionEvents,
-    MetadataLog,
     get_unprocessed_files,
 )
+from .postgres_schema import VehiclePositionEvents, MetadataLog
 from .gtfs_utils import start_time_to_seconds, add_event_hash_column
 
 

--- a/performance_manager/lib/rt_vehicle_positions.py
+++ b/performance_manager/lib/rt_vehicle_positions.py
@@ -174,8 +174,8 @@ def get_event_overlap(
             VehiclePositionEvents.vehicle_id,
         )
     ).where(
-        (VehiclePositionEvents.timestamp_start > timestamp_to_pull_min)
-        & (VehiclePositionEvents.timestamp_end < timestamp_to_pull_max)
+        (VehiclePositionEvents.timestamp_end > timestamp_to_pull_min)
+        & (VehiclePositionEvents.timestamp_start < timestamp_to_pull_max)
     )
 
     with sql_session.begin() as session:  # type: ignore

--- a/performance_manager/lib/s3_utils.py
+++ b/performance_manager/lib/s3_utils.py
@@ -1,7 +1,6 @@
 import logging
 import os
-from collections.abc import Iterable
-from typing import Optional, List, Tuple, Union, Sequence
+from typing import Optional, List, Tuple, Union, Sequence, Iterator
 
 import boto3
 import pandas
@@ -31,7 +30,7 @@ def read_parquet(
     )
 
 
-def file_list_from_s3(bucket_name: str, file_prefix: str) -> Iterable[str]:
+def file_list_from_s3(bucket_name: str, file_prefix: str) -> Iterator[str]:
     """
     generate filename, filesize tuples for every file in an s3 bucket
 

--- a/performance_manager/startup.py
+++ b/performance_manager/startup.py
@@ -20,6 +20,7 @@ from lib import (
     get_local_engine,
     process_vehicle_positions,
     process_trip_updates,
+    process_static_tables,
 )
 
 logging.getLogger().setLevel("INFO")
@@ -125,6 +126,7 @@ def main(args: argparse.Namespace) -> None:
         """function to invoke on a scheduled routine"""
         logging.info("Entering Iteration")
 
+        process_static_tables(sql_session)
         process_vehicle_positions(sql_session)
         process_trip_updates(sql_session)
 

--- a/performance_manager/tests/july_17_filepaths.json
+++ b/performance_manager/tests/july_17_filepaths.json
@@ -268,5 +268,8 @@
     },
     {
         "path": "mbta-ctd-dataplatform-dev-springboard/lamp/RT_TRIP_UPDATES/year=2022/month=7/day=20/hour=9/d7794b75821241afbd116c4040334e28-0.parquet"
+    },
+    {
+        "path": "mbta-ctd-dataplatform-dev-springboard/lamp/FEED_INFO/timestamp=1661219208/6ed104fd4c724faf89ebcad5c760ab62-0.parquet"
     }
 ]


### PR DESCRIPTION
Add capability to process static GTFS schedule tables needed to generate performance metrics.

Tables Loaded:
- FEED_INFO
- STOPS
- ROUTES
- STOP_TIMES
- TRIPS
- CALENDAR

Moved postgres table schema definitions into `performance_manager/lib/postgres_schema.py`

Asana Task: https://app.asana.com/0/1202784843755682/1202841571879783
