### PR TITLE
Standardize Bucket Names and Validate Env Vars

### DIFF
--- a/.env
+++ b/.env
@@ -9,7 +9,7 @@ DB_USER=postgres
 DB_PASSWORD=postgres
 
 # s3 locations
-EXPORT_BUCKET=mbta-ctd-dataplatform-dev-springboard
+SPRINGBOARD_BUCKET=mbta-ctd-dataplatform-dev-springboard
 ARCHIVE_BUCKET=mbta-ctd-dataplatform-dev-archive
 ERROR_BUCKET=mbta-ctd-dataplatform-dev-error
-INGEST_BUCKET=mbta-ctd-dataplatform-dev-incoming
+INCOMING_BUCKET=mbta-ctd-dataplatform-dev-incoming

--- a/performance_manager/lib/gtfs_static_table.py
+++ b/performance_manager/lib/gtfs_static_table.py
@@ -179,7 +179,7 @@ def get_static_parquet_paths(table_type: str, feed_info_path: str) -> List[str]:
     """
     get static table parquet files from FEED_INFO path
     """
-    springboard_bucket = os.environ["EXPORT_BUCKET"]
+    springboard_bucket = os.environ["SPRINGBOARD_BUCKET"]
     static_prefix = feed_info_path.replace("FEED_INFO", table_type)
     static_prefix = static_prefix.replace(f"{springboard_bucket}/", "")
     return list(

--- a/performance_manager/startup.py
+++ b/performance_manager/startup.py
@@ -52,6 +52,36 @@ def load_environment() -> None:
         raise exception
 
 
+def validate_environment() -> None:
+    """
+    ensure that the environment has all the variables its required to have
+    before starting triggering main, making certain errors easier to debug.
+    """
+    # these variables required for normal opperation, ensure they are present
+    required_variables = [
+        "SPRINGBOARD_BUCKET",
+        "DB_HOST",
+        "DB_NAME",
+        "DB_PORT",
+        "DB_USER",
+    ]
+
+    missing_required = [
+        key for key in required_variables if os.environ.get(key, None) is None
+    ]
+
+    # if db password is missing, db region is required to generate a token to
+    # use as the password to the cloud database
+    if os.environ.get("DB_PASSWORD", None) is None:
+        if os.environ.get("DB_REGION", None) is None:
+            missing_required.append("DB_REGION")
+
+    if missing_required:
+        raise Exception(
+            f"Missing required environment variables {missing_required}"
+        )
+
+
 def parse_args(args: List[str]) -> argparse.Namespace:
     """parse args for running this entrypoint script"""
     parser = argparse.ArgumentParser(description=DESCRIPTION)
@@ -125,6 +155,7 @@ def main(args: argparse.Namespace) -> None:
 
 if __name__ == "__main__":
     load_environment()
+    validate_environment()
     parsed_args = parse_args(sys.argv[1:])
 
     main(parsed_args)

--- a/performance_manager/tests/demo_events.json
+++ b/performance_manager/tests/demo_events.json
@@ -1,0 +1,29 @@
+[
+    {
+        "path": "mbta-ctd-dataplatform-dev-springboard/lamp/RT_VEHICLE_POSITIONS/year=2022/month=7/day=20/hour=0/ade29e12f6144ebdaa27c86083a358b3-0.parquet"
+    },
+    {
+        "path": "mbta-ctd-dataplatform-dev-springboard/lamp/RT_VEHICLE_POSITIONS/year=2022/month=7/day=20/hour=0/eecaaf159f804e9686f4d16f816a708f-0.parquet"
+    },
+    {
+        "path": "mbta-ctd-dataplatform-dev-springboard/lamp/RT_VEHICLE_POSITIONS/year=2022/month=7/day=20/hour=1/2e14b3724450454d8bd2578e63995dae-0.parquet"
+    },
+    {
+        "path": "mbta-ctd-dataplatform-dev-springboard/lamp/RT_VEHICLE_POSITIONS/year=2022/month=7/day=20/hour=1/3338ab3b2f9b4026881f98c902f38fa9-0.parquet"
+    },
+    {
+        "path": "mbta-ctd-dataplatform-dev-springboard/lamp/RT_TRIP_UPDATES/year=2022/month=7/day=20/hour=0/1733d119787145b587c5c9f4af43a02d-0.parquet"
+    },
+    {
+        "path": "mbta-ctd-dataplatform-dev-springboard/lamp/RT_TRIP_UPDATES/year=2022/month=7/day=20/hour=0/fce9108288f04479aff70c081e3acf30-0.parquet"
+    },
+    {
+        "path": "mbta-ctd-dataplatform-dev-springboard/lamp/RT_TRIP_UPDATES/year=2022/month=7/day=20/hour=1/14e07765d4ff4a33b400953ca2da2c4d-0.parquet"
+    },
+    {
+        "path": "mbta-ctd-dataplatform-dev-springboard/lamp/RT_TRIP_UPDATES/year=2022/month=7/day=20/hour=1/d3d6db70652743159d5d24b5051d757a-0.parquet"
+    },
+    {
+        "path": "mbta-ctd-dataplatform-dev-springboard/lamp/FEED_INFO/timestamp=1661219208/6ed104fd4c724faf89ebcad5c760ab62-0.parquet"
+    }
+]

--- a/py_gtfs_rt_ingestion/dev_test_setup.py
+++ b/py_gtfs_rt_ingestion/dev_test_setup.py
@@ -15,8 +15,8 @@ import boto3
 from py_gtfs_rt_ingestion import file_list_from_s3
 
 GTFS_BUCKET = "mbta-gtfs-s3"
-DEV_INGEST_BUCKET = "mbta-ctd-dataplatform-dev-incoming"
-DEV_EXPORT_BUCKET = "mbta-ctd-dataplatform-dev-springboard"
+DEV_INCOMING_BUCKET = "mbta-ctd-dataplatform-dev-incoming"
+DEV_SPRINGBOARD_BUCKET = "mbta-ctd-dataplatform-dev-springboard"
 DEV_ARCHIVE_BUCKET = "mbta-ctd-dataplatform-dev-archive"
 DEV_ERROR_BUCKET = "mbta-ctd-dataplatform-dev-error"
 LAMP_PREFIX = "lamp/"
@@ -129,8 +129,8 @@ def clear_dev_buckets(args: SetupArgs) -> None:
     Clear all development buckets of objects
     """
     bucket_list = (
-        DEV_INGEST_BUCKET,
-        DEV_EXPORT_BUCKET,
+        DEV_INCOMING_BUCKET,
+        DEV_SPRINGBOARD_BUCKET,
         DEV_ARCHIVE_BUCKET,
         DEV_ERROR_BUCKET,
     )
@@ -213,7 +213,7 @@ def copy_obj(prefix: str, num_to_copy: int) -> int:
         try:
             s3_client.copy(
                 copy_source,
-                DEV_INGEST_BUCKET,
+                DEV_INCOMING_BUCKET,
                 os.path.join(LAMP_PREFIX, key),
             )
         except Exception as e:
@@ -251,7 +251,7 @@ def copy_gfts_to_ingest(args: SetupArgs) -> None:
     objects to development Ingest bucket
     """
     src_uri_root = f"s3://{os.path.join(GTFS_BUCKET, args.src_prefix)}"
-    dest_urc_root = f"s3://{os.path.join(DEV_INGEST_BUCKET, LAMP_PREFIX)}"
+    dest_urc_root = f"s3://{os.path.join(DEV_INCOMING_BUCKET, LAMP_PREFIX)}"
 
     logging.info("Enumerating folders in (%s)...", src_uri_root)
     s3_client = boto3.client("s3")


### PR DESCRIPTION
We had two bucket names that were non standard before we realized there were standards. Now `ingest_bucket` has been renamed `incoming_bucket` and `export_bucket` has been renamed `springboard_bucket`.

Additionally, the entry point scripts `startup.py`, `batch_files.py` and `ingest.py` all have environment variable validation functions then ensure that all required environment variables have been set before executing.

Asana Task: https://app.asana.com/0/1189492770004753/1202862782004919/f
