### PR TITLE
add batching of rt files in event loop

### DIFF
--- a/performance_manager/lib/gtfs_static_table.py
+++ b/performance_manager/lib/gtfs_static_table.py
@@ -1,5 +1,6 @@
 from typing import List, Optional
 from dataclasses import dataclass
+import pathlib
 
 import os
 import pandas
@@ -251,15 +252,15 @@ def process_static_tables(db_manager: DatabaseManager) -> None:
     process_logger.log_start()
 
     # pull list of objects that need processing from metadata table
-    paths_to_load = get_unprocessed_files("FEED_INFO", db_manager.get_session())
+    paths_to_load = get_unprocessed_files("FEED_INFO", db_manager)
     process_logger.add_metadata(filecount=len(paths_to_load))
 
-    for folder, folder_data in paths_to_load.items():
-        individual_logger = ProcessLogger("load_static_tables", folder=folder)
+    for folder_data in paths_to_load:
+        folder = str(pathlib.Path(folder_data["paths"][0]).parent)
+        individual_logger = ProcessLogger("load_static_tables", s3_path=folder)
         individual_logger.log_start()
 
         ids = folder_data["ids"]
-        folder = str(folder)
 
         static_tables = get_table_objects()
 

--- a/performance_manager/lib/rt_trip_updates.py
+++ b/performance_manager/lib/rt_trip_updates.py
@@ -1,5 +1,6 @@
 from typing import Optional, Union, List, Dict, Any, Iterator
 
+import pathlib
 import pandas
 import numpy
 
@@ -282,17 +283,18 @@ def process_trip_updates(db_manager: DatabaseManager) -> None:
 
     # pull list of objects that need processing from metadata table
     paths_to_load = get_unprocessed_files(
-        "RT_TRIP_UPDATES", db_manager.get_session()
+        "RT_TRIP_UPDATES", db_manager, file_limit=6
     )
 
     process_logger.add_metadata(paths_to_load=len(paths_to_load))
 
-    for folder_data in paths_to_load.values():
+    for folder_data in paths_to_load:
+        folder = str(pathlib.Path(folder_data["paths"][0]).parent)
         ids = folder_data["ids"]
         paths = folder_data["paths"]
 
         subprocess_logger = ProcessLogger(
-            "process_tu_dir", file_count=len(paths)
+            "process_tu_dir", file_count=len(paths), s3_path=folder
         )
         subprocess_logger.log_start()
 


### PR DESCRIPTION
this PR adds batching of gtfs-rt file processing in event loop

`get_unprocessed_files` in `lib/postgres_utils.py` has been modified to have an additional parameter `file_limit` this parameter will limit the number of grouped paths sent from the MetadataLog table in the RDS

grouped paths will be sorted from oldest to newest so files are processed as chronologically as possible

Asana Task: https://app.asana.com/0/1202841571879768/1203021761496493
