### PR TITLE
match gtfs static data to event records

### DIFF
--- a/performance_manager/lib/gtfs_utils.py
+++ b/performance_manager/lib/gtfs_utils.py
@@ -10,7 +10,7 @@ def add_event_hash_column(
     expected_hash_columns: Sequence[str] = (
         "is_moving",
         "stop_sequence",
-        "stop_id",
+        "parent_station",
         "direction_id",
         "route_id",
         "start_date",

--- a/performance_manager/lib/postgres_schema.py
+++ b/performance_manager/lib/postgres_schema.py
@@ -25,6 +25,11 @@ class VehiclePositionEvents(SqlBase):  # pylint: disable=too-few-public-methods
     hash = sa.Column(
         sa.LargeBinary(16), nullable=False, index=True, unique=False
     )
+    fk_static_timestamp = sa.Column(
+        sa.Integer,
+        sa.ForeignKey("staticFeedInfo.timestamp"),
+        nullable=False,
+    )
     updated_on = sa.Column(sa.TIMESTAMP, server_default=sa.func.now())
 
 
@@ -45,6 +50,11 @@ class TripUpdateEvents(SqlBase):  # pylint: disable=too-few-public-methods
     vehicle_id = sa.Column(sa.String(60), nullable=False)
     hash = sa.Column(
         sa.LargeBinary(16), nullable=False, index=True, unique=False
+    )
+    fk_static_timestamp = sa.Column(
+        sa.Integer,
+        sa.ForeignKey("staticFeedInfo.timestamp"),
+        nullable=False,
     )
     updated_on = sa.Column(sa.TIMESTAMP, server_default=sa.func.now())
 

--- a/performance_manager/tests/july_17_filepaths.json
+++ b/performance_manager/tests/july_17_filepaths.json
@@ -270,6 +270,15 @@
         "path": "mbta-ctd-dataplatform-dev-springboard/lamp/RT_TRIP_UPDATES/year=2022/month=7/day=20/hour=9/d7794b75821241afbd116c4040334e28-0.parquet"
     },
     {
+        "path": "mbta-ctd-dataplatform-dev-springboard/lamp/FEED_INFO/timestamp=1657216900/a56ca397ee4d4da89d22d52dfbc5406c-0.parquet"
+    },
+    {
+        "path": "mbta-ctd-dataplatform-dev-springboard/lamp/FEED_INFO/timestamp=1659130909/e931dca261054e68b9259ff23da860cf-0.parquet"
+    },
+    {
+        "path": "mbta-ctd-dataplatform-dev-springboard/lamp/FEED_INFO/timestamp=1660175804/55598556e865435a8019d329c7d6f2f1-0.parquet"
+    },
+    {
         "path": "mbta-ctd-dataplatform-dev-springboard/lamp/FEED_INFO/timestamp=1661219208/6ed104fd4c724faf89ebcad5c760ab62-0.parquet"
     }
 ]


### PR DESCRIPTION
to facilitate metrics implementation, event records must be matched to gtfs static data.

this PR updates the processing of VEHICLE_POSITION and TRIP_UPDATE parquet files, to add matching of records to gtfs static schedule data.

this matching is accomplished by the addition of a column to the `eventsVehiclePositions` and `eventsTripUpdates` tables. the column is a foreign key that references a unique timestamp from the `staticFeedInfo` table.

using this foreign key, event records can be matched to their relevant gtfs static data for additional database join activity.

this PR also updates event processing by grouping event records by `parent_station` from gtfs static data, instead of `stop_id` from specific event records.

Asana Task: https://app.asana.com/0/1202939398067300/1203091943545605
