### PR TITLE
add l2 headways processing

### DIFF
--- a/performance_manager/lib/__init__.py
+++ b/performance_manager/lib/__init__.py
@@ -11,5 +11,6 @@ from .postgres_utils import DatabaseManager
 from .rt_trip_updates import process_trip_updates
 from .rt_vehicle_positions import process_vehicle_positions
 from .l2_dwell_travel_times import process_dwell_travel_times
+from .l2_headways import process_headways
 
 __version__ = "0.1.0"

--- a/performance_manager/lib/gtfs_static_table.py
+++ b/performance_manager/lib/gtfs_static_table.py
@@ -232,6 +232,11 @@ def transform_data_tables(static_tables: List[StaticTableDetails]) -> None:
                     .astype("Int64")
                 )
 
+        table.data_table = table.data_table.fillna(numpy.nan).replace(
+            [numpy.nan], [None]
+        )
+        table.data_table = table.data_table.replace([""], [None])
+
 
 def insert_data_tables(
     static_tables: List[StaticTableDetails],

--- a/performance_manager/lib/l2_headways.py
+++ b/performance_manager/lib/l2_headways.py
@@ -1,0 +1,383 @@
+from typing import Optional
+import sqlalchemy as sa
+
+from .logging_utils import ProcessLogger
+from .postgres_utils import DatabaseManager
+from .postgres_schema import (
+    VehiclePositionEvents,
+    FullTripEvents,
+    TripUpdateEvents,
+    StaticStops,
+    Headways,
+    TempHeadways,
+)
+
+
+def get_min_timestamp(db_manager: DatabaseManager) -> Optional[int]:
+    """
+    find the minimum timestamp_start value for processing new headways
+    """
+    # query for trip update timestamp_start values
+    tu_timestamp_query = sa.select(
+        sa.func.min(TripUpdateEvents.timestamp_start).label("timestamp_start"),
+    ).join(
+        FullTripEvents,
+        FullTripEvents.fk_tu_stopped_event == TripUpdateEvents.pk_id,
+    )
+
+    # query for vehicle position timestamp_start values
+    vp_timestamp_query = sa.select(
+        sa.func.min(VehiclePositionEvents.timestamp_start).label(
+            "timestamp_start"
+        ),
+    ).join(
+        FullTripEvents,
+        FullTripEvents.fk_vp_stopped_event == VehiclePositionEvents.pk_id,
+    )
+
+    # get maximum updated_on timestamp from headways table
+    max_headway_update_query = sa.select(sa.func.max(Headways.updated_on))
+    # mypy error: error: "BaseCursorResult" has no attribute "fetchone"
+    max_update_dt = db_manager.execute(max_headway_update_query).fetchone()[0]  # type: ignore
+
+    # will only be None if no records exist in Headways table
+    # if records do exist, add constraing to vehicle position and trip update
+    # timestamp_start queries
+    if max_update_dt is not None:
+        tu_timestamp_query = tu_timestamp_query.where(
+            FullTripEvents.updated_on > max_update_dt
+        )
+        vp_timestamp_query = vp_timestamp_query.where(
+            FullTripEvents.updated_on > max_update_dt
+        )
+
+    # union query so all results are combined
+    min_timestamp_start_cte = tu_timestamp_query.union(vp_timestamp_query).cte(
+        name="min_timestamp"
+    )
+
+    # get minimum timestamp_start value for records needing to be added to
+    # headways table
+    min_timestamp_start_query = sa.select(
+        sa.func.min(min_timestamp_start_cte.c.timestamp_start)
+    )
+
+    # this will return a valid timestamp_start integer or None, if no records
+    # need to be added to headways table
+    # mypy error: error: "BaseCursorResult" has no attribute "fetchone"
+    min_timestamp_start = db_manager.execute(min_timestamp_start_query).fetchone()[0]  # type: ignore
+
+    # pull overlapping timestamp start values going back 6 Hours
+    # this effecitvely sets a maxium headway value of 6 hours
+    # it is assumed that headways over 6 hours are not really headways and do not
+    # need to be recorded
+    if isinstance(min_timestamp_start, int):
+        min_timestamp_start -= 60 * 60 * 6
+
+    # return None or int value
+    return min_timestamp_start
+
+
+def load_temp_headways(db_manager: DatabaseManager) -> int:
+    """
+    perform update on headways table
+
+    """
+    process_logger = ProcessLogger("l2_load_temp_headways")
+    process_logger.log_start()
+
+    # get minimum timestamp_start value for records that need to be processed
+    # for headways table
+    # will return None if no headways need to be processed
+    min_timestamp_start = get_min_timestamp(db_manager)
+    if min_timestamp_start is None:
+        process_logger.add_metadata(temp_rows_inserted=0)
+        process_logger.log_complete()
+        return 0
+
+    # headways will be aggregated by the following fields:
+    # - direction_id
+    # - route_id
+    # - start_date
+    # - parent_station
+    #
+    # query for stop event records from vehcile positions that require headways
+    # processing
+    vp_query = (
+        sa.select(
+            FullTripEvents.fk_vp_stopped_event.label("fk_vp_stopped_event"),
+            sa.literal(None).label("fk_tu_stopped_event"),
+            FullTripEvents.hash,
+            VehiclePositionEvents.direction_id,
+            VehiclePositionEvents.route_id,
+            VehiclePositionEvents.start_date,
+            VehiclePositionEvents.vehicle_id,
+            sa.case(
+                (
+                    StaticStops.parent_station.isnot(None),
+                    StaticStops.parent_station,
+                ),
+                else_=VehiclePositionEvents.stop_id,
+            ).label("parent_station"),
+            VehiclePositionEvents.timestamp_start,
+        )
+        .join(
+            VehiclePositionEvents,
+            FullTripEvents.fk_vp_stopped_event == VehiclePositionEvents.pk_id,
+        )
+        .join(
+            StaticStops,
+            sa.and_(
+                VehiclePositionEvents.fk_static_timestamp
+                == StaticStops.timestamp,
+                VehiclePositionEvents.stop_id == StaticStops.stop_id,
+            ),
+            isouter=True,
+        )
+        .where(
+            sa.and_(
+                FullTripEvents.fk_vp_stopped_event.isnot(None),
+                VehiclePositionEvents.timestamp_start > min_timestamp_start,
+            )
+        )
+    )
+
+    # query for stop event records from trip updates that require headways
+    # processing
+    tu_query = (
+        sa.select(
+            sa.literal(None).label("fk_vp_stopped_event"),
+            FullTripEvents.fk_tu_stopped_event.label("fk_tu_stopped_event"),
+            FullTripEvents.hash,
+            TripUpdateEvents.direction_id,
+            TripUpdateEvents.route_id,
+            TripUpdateEvents.start_date,
+            TripUpdateEvents.vehicle_id,
+            sa.case(
+                (
+                    StaticStops.parent_station.isnot(None),
+                    StaticStops.parent_station,
+                ),
+                else_=TripUpdateEvents.stop_id,
+            ).label("parent_station"),
+            TripUpdateEvents.timestamp_start,
+        )
+        .join(
+            TripUpdateEvents,
+            FullTripEvents.fk_tu_stopped_event == TripUpdateEvents.pk_id,
+        )
+        .join(
+            StaticStops,
+            sa.and_(
+                TripUpdateEvents.fk_static_timestamp == StaticStops.timestamp,
+                TripUpdateEvents.stop_id == StaticStops.stop_id,
+            ),
+            isouter=True,
+        )
+        .where(
+            sa.and_(
+                FullTripEvents.fk_tu_stopped_event.isnot(None),
+                FullTripEvents.fk_vp_stopped_event.is_(None),
+                TripUpdateEvents.timestamp_start > min_timestamp_start,
+            )
+        )
+    )
+
+    # merge stop event results from vehcile positions and trip updates into
+    # one query all records should be unique
+    stop_events_cte = vp_query.union_all(tu_query).cte(name="all_stop_events")
+
+    # this subquery performs lag operation on vehicle_id and timestamp_start
+    # fields, these lag operations create the fields of prev_vehicle_id and
+    # prev_timestamp_start for every record
+    # (except first record of partition groups)
+    filter_query = sa.select(
+        stop_events_cte.c.fk_vp_stopped_event,
+        stop_events_cte.c.fk_tu_stopped_event,
+        stop_events_cte.c.hash,
+        stop_events_cte.c.direction_id,
+        stop_events_cte.c.route_id,
+        stop_events_cte.c.start_date,
+        stop_events_cte.c.parent_station,
+        stop_events_cte.c.vehicle_id,
+        sa.func.lag(stop_events_cte.c.vehicle_id)
+        .over(
+            order_by=stop_events_cte.c.timestamp_start,
+            partition_by=(
+                stop_events_cte.c.direction_id,
+                stop_events_cte.c.route_id,
+                stop_events_cte.c.start_date,
+                stop_events_cte.c.parent_station,
+            ),
+        )
+        .label("prev_vehicle_id"),
+        stop_events_cte.c.timestamp_start,
+        sa.func.lag(stop_events_cte.c.timestamp_start)
+        .over(
+            order_by=stop_events_cte.c.timestamp_start,
+            partition_by=(
+                stop_events_cte.c.direction_id,
+                stop_events_cte.c.route_id,
+                stop_events_cte.c.start_date,
+                stop_events_cte.c.parent_station,
+            ),
+        )
+        .label("prev_timestamp_start"),
+    ).subquery(name="filter_query")
+
+    # this subquery is responsible for filtering duplicative stop events
+    # it will filter out records where the same vehicle is recorded at the same
+    # partition group within 3 minutes
+    # (likely impossible but requires verification)
+    headways_lag_query = (
+        sa.select(
+            filter_query.c.fk_vp_stopped_event,
+            filter_query.c.fk_tu_stopped_event,
+            filter_query.c.hash,
+            filter_query.c.timestamp_start,
+            sa.func.lag(filter_query.c.timestamp_start)
+            .over(
+                order_by=filter_query.c.timestamp_start,
+                partition_by=(
+                    filter_query.c.direction_id,
+                    filter_query.c.route_id,
+                    filter_query.c.start_date,
+                    filter_query.c.parent_station,
+                ),
+            )
+            .label("prev_timestamp_start"),
+        )
+        .where(
+            sa.or_(
+                filter_query.c.vehicle_id != filter_query.c.prev_vehicle_id,
+                filter_query.c.timestamp_start
+                - filter_query.c.prev_timestamp_start
+                > 180,
+            )
+        )
+        .subquery(name="headways_lag")
+    )
+
+    # final select statement to be used for insertion of records into temporary
+    # headways table
+    headways_final_query = sa.select(
+        headways_lag_query.c.fk_vp_stopped_event,
+        headways_lag_query.c.fk_tu_stopped_event,
+        headways_lag_query.c.hash.label("fk_trip_event_hash"),
+        (
+            headways_lag_query.c.timestamp_start
+            - headways_lag_query.c.prev_timestamp_start
+        ).label("headway_seconds"),
+    )
+
+    insert_cols = [
+        "fk_vp_stopped_event",
+        "fk_tu_stopped_event",
+        "fk_trip_event_hash",
+        "headway_seconds",
+    ]
+
+    insert_query = (
+        TempHeadways.metadata.tables[TempHeadways.__tablename__]
+        .insert()
+        .from_select(
+            insert_cols,
+            headways_final_query,
+        )
+    )
+
+    db_manager.truncate_table(TempHeadways)
+    result = db_manager.execute(insert_query)
+
+    process_logger.add_metadata(temp_rows_inserted=result.rowcount)
+    process_logger.log_complete()
+
+    return result.rowcount
+
+
+def update_headways_from_temp(db_manager: DatabaseManager) -> None:
+    """
+    update headways tables with UPDATE from SELECT of TempHeadways table
+    """
+    process_logger = ProcessLogger("l2_headways_update")
+    process_logger.log_start()
+    update_query = (
+        Headways.metadata.tables[Headways.__tablename__]
+        .update()
+        .values(
+            fk_trip_event_hash=TempHeadways.fk_trip_event_hash,
+            fk_tu_stopped_event=TempHeadways.fk_tu_stopped_event,
+            fk_vp_stopped_event=TempHeadways.fk_vp_stopped_event,
+            headway_seconds=TempHeadways.headway_seconds,
+        )
+        .where(Headways.fk_trip_event_hash == TempHeadways.fk_trip_event_hash)
+    )
+
+    result = db_manager.execute(update_query)
+
+    process_logger.add_metadata(rows_updated=result.rowcount)
+    process_logger.log_complete()
+
+
+def insert_new_headways(db_manager: DatabaseManager) -> None:
+    """
+    insert new headways into Headways table with INSERT from SELECT of
+    TempHeadways table
+    """
+    insert_cols = [
+        "fk_vp_stopped_event",
+        "fk_tu_stopped_event",
+        "fk_trip_event_hash",
+        "headway_seconds",
+    ]
+
+    process_logger = ProcessLogger("l2_headways_insert")
+    process_logger.log_start()
+    insert_query = (
+        Headways.metadata.tables[Headways.__tablename__]
+        .insert()
+        .from_select(
+            insert_cols,
+            sa.select(
+                TempHeadways.fk_vp_stopped_event,
+                TempHeadways.fk_tu_stopped_event,
+                TempHeadways.fk_trip_event_hash,
+                TempHeadways.headway_seconds,
+            )
+            .join(
+                Headways,
+                Headways.fk_trip_event_hash == TempHeadways.fk_trip_event_hash,
+                isouter=True,
+            )
+            .where((Headways.fk_trip_event_hash.is_(None))),
+        )
+    )
+    result = db_manager.execute(insert_query)
+
+    process_logger.add_metadata(rows_inserted=result.rowcount)
+    process_logger.log_complete()
+
+
+def process_headways(db_manager: DatabaseManager) -> None:
+    """
+    process new events from L1 FullTripEvents table and insert into
+    Headways table
+
+    """
+    process_logger = ProcessLogger("process_l2_headways")
+    process_logger.log_start()
+    try:
+        temp_table_rows = load_temp_headways(db_manager)
+
+        # gate to check for no records needing update / insert
+        if temp_table_rows == 0:
+            process_logger.log_complete()
+            return
+
+        update_headways_from_temp(db_manager)
+        insert_new_headways(db_manager)
+
+        process_logger.log_complete()
+
+    except Exception as exception:
+        process_logger.log_failure(exception)

--- a/performance_manager/lib/postgres_schema.py
+++ b/performance_manager/lib/postgres_schema.py
@@ -108,13 +108,13 @@ class StaticRoutes(SqlBase):  # pylint: disable=too-few-public-methods
     pk_id = sa.Column(sa.Integer, primary_key=True)
     route_id = sa.Column(sa.String(60), nullable=False)
     agency_id = sa.Column(sa.SmallInteger, nullable=False)
-    route_short_name = sa.Column(sa.String(60), nullable=False)
-    route_long_name = sa.Column(sa.String(150), nullable=False)
-    route_desc = sa.Column(sa.String(40), nullable=False)
+    route_short_name = sa.Column(sa.String(60), nullable=True)
+    route_long_name = sa.Column(sa.String(150), nullable=True)
+    route_desc = sa.Column(sa.String(40), nullable=True)
     route_type = sa.Column(sa.SmallInteger, nullable=False)
     route_sort_order = sa.Column(sa.Integer, nullable=False)
     route_fare_class = sa.Column(sa.String(30), nullable=False)
-    line_id = sa.Column(sa.String(30), nullable=False)
+    line_id = sa.Column(sa.String(30), nullable=True)
     timestamp = sa.Column(sa.Integer, nullable=False)
 
 
@@ -126,10 +126,10 @@ class StaticStops(SqlBase):  # pylint: disable=too-few-public-methods
     pk_id = sa.Column(sa.Integer, primary_key=True)
     stop_id = sa.Column(sa.String(128), nullable=False)
     stop_name = sa.Column(sa.String(128), nullable=False)
-    stop_desc = sa.Column(sa.String(256), nullable=False)
-    platform_code = sa.Column(sa.String(10), nullable=False)
-    platform_name = sa.Column(sa.String(60), nullable=False)
-    parent_station = sa.Column(sa.String(30), nullable=False)
+    stop_desc = sa.Column(sa.String(256), nullable=True)
+    platform_code = sa.Column(sa.String(10), nullable=True)
+    platform_name = sa.Column(sa.String(60), nullable=True)
+    parent_station = sa.Column(sa.String(30), nullable=True)
     timestamp = sa.Column(sa.Integer, nullable=False)
 
 
@@ -140,8 +140,8 @@ class StaticStopTimes(SqlBase):  # pylint: disable=too-few-public-methods
 
     pk_id = sa.Column(sa.Integer, primary_key=True)
     trip_id = sa.Column(sa.String(128), nullable=False)
-    arrival_time = sa.Column(sa.Integer, nullable=True)
-    departure_time = sa.Column(sa.Integer, nullable=True)
+    arrival_time = sa.Column(sa.Integer, nullable=False)
+    departure_time = sa.Column(sa.Integer, nullable=False)
     stop_id = sa.Column(sa.String(30), nullable=False)
     stop_sequence = sa.Column(sa.SmallInteger, nullable=False)
     timestamp = sa.Column(sa.Integer, nullable=False)
@@ -251,3 +251,55 @@ class DwellTimes(SqlBase):  # pylint: disable=too-few-public-methods
         nullable=False,
     )
     created_on = sa.Column(sa.TIMESTAMP, server_default=sa.func.now())
+
+
+class Headways(SqlBase):  # pylint: disable=too-few-public-methods
+    """Level 2 Table for Headways"""
+
+    __tablename__ = "headways"
+
+    # foreign key pointing to primary key in fullTripEvents
+    # for stopped events
+    fk_trip_event_hash = sa.Column(
+        sa.LargeBinary(16),
+        sa.ForeignKey("fullTripEvents.hash", ondelete="CASCADE"),
+        nullable=False,
+        primary_key=True,
+    )
+    fk_vp_stopped_event = sa.Column(
+        sa.Integer,
+        nullable=True,
+    )
+    fk_tu_stopped_event = sa.Column(
+        sa.Integer,
+        nullable=True,
+    )
+    headway_seconds = sa.Column(
+        sa.Integer,
+        nullable=True,
+    )
+    updated_on = sa.Column(sa.TIMESTAMP, server_default=sa.func.now())
+
+
+class TempHeadways(SqlBase):  # pylint: disable=too-few-public-methods
+    """Table for loading new Level-2 headways"""
+
+    __tablename__ = "loadHeadways"
+
+    fk_trip_event_hash = sa.Column(
+        sa.LargeBinary(16),
+        nullable=False,
+        primary_key=True,
+    )
+    fk_vp_stopped_event = sa.Column(
+        sa.Integer,
+        nullable=True,
+    )
+    fk_tu_stopped_event = sa.Column(
+        sa.Integer,
+        nullable=True,
+    )
+    headway_seconds = sa.Column(
+        sa.Integer,
+        nullable=True,
+    )

--- a/performance_manager/startup.py
+++ b/performance_manager/startup.py
@@ -17,6 +17,7 @@ from lib import (
     process_static_tables,
     process_full_trip_events,
     process_dwell_travel_times,
+    process_headways,
 )
 
 logging.getLogger().setLevel("INFO")
@@ -143,6 +144,7 @@ def main(args: argparse.Namespace) -> None:
             process_trip_updates(db_manager)
             process_full_trip_events(db_manager)
             process_dwell_travel_times(db_manager)
+            process_headways(db_manager)
 
             process_logger.log_complete()
         except Exception as exception:


### PR DESCRIPTION
this PR adds processing of l2 headways table to performance manager

insert and update logic is accomplished through all SQL calls

steps involved:
1. pull minimum timestamp_start value for records needing headways processing
2. load headways values (with 6 hours of overlapping records) into temporary headways table
3. update existing headways from temporary table
4. insert new headwasy from temporary table

Asana Task: https://app.asana.com/0/1202939398067300/1203123341195650
