### PR TITLE
Add pool_pre_ping to SQLAlchemy Engine

### DIFF
--- a/performance_manager/lib/postgres_utils.py
+++ b/performance_manager/lib/postgres_utils.py
@@ -149,7 +149,9 @@ def get_local_engine(
             f"{db_ssl_options}"
         )
 
-        engine = sa.create_engine(database_url, echo=echo, future=True)
+        engine = sa.create_engine(
+            database_url, echo=echo, future=True, pool_pre_ping=True
+        )
 
         process_logger.log_complete()
         return engine

--- a/py_gtfs_rt_ingestion/lib/postgres_utils.py
+++ b/py_gtfs_rt_ingestion/lib/postgres_utils.py
@@ -77,7 +77,9 @@ def get_local_engine(echo: bool = False) -> sa.engine.Engine:
             f"{db_ssl_options}"
         )
 
-        engine = sa.create_engine(database_url, echo=echo, future=True)
+        engine = sa.create_engine(
+            database_url, echo=echo, future=True, pool_pre_ping=True
+        )
 
         process_logger.log_complete()
         return engine


### PR DESCRIPTION
The pool pre ping will try to ping the db before any other interactions, and reconnect if there is a problem, hopefully avoiding some connection errors from stale connections.
