### PR TITLE
Rate Limit Ingestion Application 

### DIFF
--- a/performance_manager/lib/l2_dwell_travel_times.py
+++ b/performance_manager/lib/l2_dwell_travel_times.py
@@ -16,7 +16,7 @@ def dwell_times(db_manager: DatabaseManager) -> None:
 
     executed as delete and insert
     """
-    process_logger = ProcessLogger("update_l2_dwell_times")
+    process_logger = ProcessLogger("l2_load_table", table_type="dwell_times")
     process_logger.log_start()
 
     # base select for insert of records dwell times
@@ -62,14 +62,14 @@ def dwell_times(db_manager: DatabaseManager) -> None:
         .execution_options(synchronize_session="fetch")
     )
     delete_result = db_manager.execute(delete_query)
-    process_logger.add_metadata(rows_updated=delete_result.rowcount)
+    process_logger.add_metadata(total_updated=delete_result.rowcount)
 
     # insert new dwell time records
     insert_query = DwellTimes.__table__.insert().from_select(
         ["fk_dwell_time_id", "dwell_time_seconds"], insert_select
     )
     insert_result = db_manager.execute(insert_query)
-    process_logger.add_metadata(rows_inserted=insert_result.rowcount)
+    process_logger.add_metadata(total_inserted=insert_result.rowcount)
 
     process_logger.log_complete()
 
@@ -80,7 +80,7 @@ def travel_times(db_manager: DatabaseManager) -> None:
 
     executed as delete and insert
     """
-    process_logger = ProcessLogger("update_l2_travel_times")
+    process_logger = ProcessLogger("l2_load_table", table_type="travel_times")
     process_logger.log_start()
 
     # base select for insert of records travel times
@@ -126,14 +126,14 @@ def travel_times(db_manager: DatabaseManager) -> None:
         .execution_options(synchronize_session="fetch")
     )
     delete_result = db_manager.execute(delete_query)
-    process_logger.add_metadata(rows_updated=delete_result.rowcount)
+    process_logger.add_metadata(total_updated=delete_result.rowcount)
 
     # insert new travel time records
     insert_query = TravelTimes.__table__.insert().from_select(
         ["fk_travel_time_id", "travel_time_seconds"], insert_select
     )
     insert_result = db_manager.execute(insert_query)
-    process_logger.add_metadata(rows_inserted=insert_result.rowcount)
+    process_logger.add_metadata(total_inserted=insert_result.rowcount)
 
     process_logger.log_complete()
 
@@ -154,7 +154,7 @@ def process_dwell_travel_times(db_manager: DatabaseManager) -> None:
     records requiring updating are first deleted and then all new/updated
     records are inserted
     """
-    process_logger = ProcessLogger("process_l2_dwell_and_travel")
+    process_logger = ProcessLogger("l2_load_tables")
     process_logger.log_start()
     try:
 

--- a/performance_manager/lib/l2_headways.py
+++ b/performance_manager/lib/l2_headways.py
@@ -292,7 +292,7 @@ def load_temp_headways(db_manager: DatabaseManager) -> bool:
     db_manager.truncate_table(TempHeadways)
     result = db_manager.execute(insert_query)
 
-    process_logger.add_metadata(temp_rows_inserted=result.rowcount)
+    process_logger.add_metadata(temp_table_record_count=result.rowcount)
     process_logger.log_complete()
 
     if result.rowcount > 0:
@@ -305,7 +305,7 @@ def update_headways_from_temp(db_manager: DatabaseManager) -> None:
     """
     update headways tables with UPDATE from SELECT of TempHeadways table
     """
-    process_logger = ProcessLogger("l2_headways_update")
+    process_logger = ProcessLogger("l2_load_table", table_type="headways")
     process_logger.log_start()
     update_query = (
         Headways.metadata.tables[Headways.__tablename__]
@@ -321,7 +321,7 @@ def update_headways_from_temp(db_manager: DatabaseManager) -> None:
 
     result = db_manager.execute(update_query)
 
-    process_logger.add_metadata(rows_updated=result.rowcount)
+    process_logger.add_metadata(total_updated=result.rowcount)
     process_logger.log_complete()
 
 
@@ -337,7 +337,7 @@ def insert_new_headways(db_manager: DatabaseManager) -> None:
         "headway_seconds",
     ]
 
-    process_logger = ProcessLogger("l2_headways_insert")
+    process_logger = ProcessLogger("l2_load_table", table_type="headways")
     process_logger.log_start()
     insert_query = (
         Headways.metadata.tables[Headways.__tablename__]
@@ -360,7 +360,7 @@ def insert_new_headways(db_manager: DatabaseManager) -> None:
     )
     result = db_manager.execute(insert_query)
 
-    process_logger.add_metadata(rows_inserted=result.rowcount)
+    process_logger.add_metadata(total_inserted=result.rowcount)
     process_logger.log_complete()
 
 

--- a/py_gtfs_rt_ingestion/lib/s3_utils.py
+++ b/py_gtfs_rt_ingestion/lib/s3_utils.py
@@ -38,7 +38,9 @@ def get_zip_buffer(filename: str) -> Tuple[IO[bytes], int]:
     )
 
 
-def file_list_from_s3(bucket_name: str, file_prefix: str) -> List[str]:
+def file_list_from_s3(
+    bucket_name: str, file_prefix: str, max_list_size: int = 250_000
+) -> List[str]:
     """
     generate filename, filesize tuples for every file in an s3 bucket
 
@@ -63,6 +65,9 @@ def file_list_from_s3(bucket_name: str, file_prefix: str) -> List[str]:
                 continue
             for obj in page["Contents"]:
                 filepaths.append(os.path.join("s3://", bucket_name, obj["Key"]))
+
+            if len(filepaths) > max_list_size:
+                break
 
         process_logger.add_metadata(list_size=len(filepaths))
         process_logger.log_complete()


### PR DESCRIPTION
Changes in this PR:
1. Rate limit ingest application.
  - Rate limit is achieved by limiting the number of files pulled from `file_list_from_s3` by default this values is set at 250,000. We see at maximum ~6,000 files per hour for gtfs-rt processing. The gtfs-rt `convert` function has also been limited to produce a maximum of 10 tables per event loop. 10 * 6,000 = 60,000 which is significantly less than the 250,000 files we're pulling from s3.
2. Unlimited retry attempts on `insert_metadata`.
  - `insert_metadata` can not and should not fail to insert records. Any failure can be attributed to RDS connection issues which should be able to resolved while insert attempts are made.
3. Minor logging changes to `performance_manager`

Asana Task: https://app.asana.com/0/1203185253920158/1203399959411145
