### PR TITLE
don't use timestamp

### DIFF
--- a/performance_manager/lib/l0_rt_trip_updates.py
+++ b/performance_manager/lib/l0_rt_trip_updates.py
@@ -195,7 +195,7 @@ def join_gtfs_static(
             .where(
                 (StaticFeedInfo.feed_start_date <= date)
                 & (StaticFeedInfo.feed_end_date >= date)
-                & (StaticFeedInfo.timestamp < min_timestamp)
+                # & (StaticFeedInfo.timestamp < min_timestamp)
             )
             .order_by(StaticFeedInfo.timestamp.desc())
             .limit(1)

--- a/performance_manager/lib/l0_rt_vehicle_positions.py
+++ b/performance_manager/lib/l0_rt_vehicle_positions.py
@@ -109,7 +109,7 @@ def join_gtfs_static(
             .where(
                 (StaticFeedInfo.feed_start_date <= date)
                 & (StaticFeedInfo.feed_end_date >= date)
-                & (StaticFeedInfo.timestamp < min_timestamp)
+                # & (StaticFeedInfo.timestamp < min_timestamp)
             )
             .order_by(StaticFeedInfo.timestamp.desc())
             .limit(1)


### PR DESCRIPTION
The place we get `timestamp` from is fake for all of our seed data. So can't be trusted on table load business logic. 
