### PR TITLE
FIX: Use different URI in Deploy Workflows

### DIFF
--- a/.github/workflows/ingestion-deploy-dev.yaml
+++ b/.github/workflows/ingestion-deploy-dev.yaml
@@ -17,8 +17,9 @@ jobs:
       environment: dev
       dockerfile-path: ./py_gtfs_rt_ingestion/
       cluster: lamp
+      docker-additional-tags: lamp_ingestion
     secrets:
       aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
       aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      docker-repo: ${{ secrets.DOCKER_REPO }}
+      docker-repo: ${{ secrets.INGESTION_DOCKER_URI }}
       slack-webhook: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/performance-manager-deploy-dev.yaml
+++ b/.github/workflows/performance-manager-deploy-dev.yaml
@@ -17,8 +17,9 @@ jobs:
       environment: dev
       dockerfile-path: ./performance_manager/
       cluster: lamp
+      docker-additional-tags: lamp_performance_manager
     secrets:
       aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
       aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      docker-repo: ${{ secrets.DOCKER_REPO }}
+      docker-repo: ${{ secrets.PERFORMANCE_MANAGER_DOCKER_URI }}
       slack-webhook: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
We were using the same URI to deploy to both the Performance Manager and Ingestion containers. When we would merge a PR that touched both projects, it would deploy two docker images to the same repo with the same tag, overwriting one of them. When the next step in the deploy process would go to the repo to pick up the image with the tag, it ended up deploying the same image to both containers, resulting in either two Ingestions running or two Performance managers running.

To fix this, I've added two secrets to the github repo to replace the DOCKER_REPO secret; one for ingestion and one for performance manager. In the github workflows, we now use those docker repo secrets. Additionally, I've added more tags that should appear alongside the git hash to describe the images, making it easier to identify what the images are and when they are from.

Asana Task: https://app.asana.com/0/1202848167169706/1203403213474705/f
