### PR TITLE
Fix l1 pull query

### DIFF
--- a/performance_manager/lib/l0_rt_trip_updates.py
+++ b/performance_manager/lib/l0_rt_trip_updates.py
@@ -1,4 +1,11 @@
-from typing import Optional, Union, List, Dict, Any, Iterator, Tuple
+from typing import (
+    Optional, 
+    Union, 
+    List, 
+    Dict, 
+    Any, 
+    Iterator,
+)
 
 import pathlib
 import pandas
@@ -376,7 +383,7 @@ def merge_trip_update_events(  # pylint: disable=too-many-locals
     process_logger.log_complete()
 
 
-def process_trip_updates(db_manager: DatabaseManager) -> Tuple[int, int]:
+def process_trip_updates(db_manager: DatabaseManager) -> None:
     """
     process trip updates parquet files from metadataLog table
     """
@@ -391,9 +398,6 @@ def process_trip_updates(db_manager: DatabaseManager) -> Tuple[int, int]:
     )
 
     process_logger.add_metadata(count_of_paths=len(paths_to_load))
-
-    min_ts_processed = 10_000_000_000
-    max_ts_processed = 0
 
     for folder_data in paths_to_load:
         folder = str(pathlib.Path(folder_data["paths"][0]).parent)
@@ -420,12 +424,6 @@ def process_trip_updates(db_manager: DatabaseManager) -> Tuple[int, int]:
                 new_events = join_gtfs_static(new_events, db_manager)
 
                 new_events = hash_events(new_events)
-                min_ts_processed = min(
-                    min_ts_processed, int(new_events["timestamp_start"].min())
-                )
-                max_ts_processed = max(
-                    max_ts_processed, int(new_events["timestamp_start"].max())
-                )
 
                 merge_trip_update_events(
                     new_events=new_events,
@@ -453,9 +451,4 @@ def process_trip_updates(db_manager: DatabaseManager) -> Tuple[int, int]:
             subprocess_logger.log_failure(exception)
         # pylint: enable=duplicate-code
 
-    process_logger.add_metadata(
-        min_ts_processed=min_ts_processed, max_ts_processed=max_ts_processed
-    )
     process_logger.log_complete()
-
-    return (min_ts_processed, max_ts_processed)

--- a/performance_manager/lib/l0_rt_trip_updates.py
+++ b/performance_manager/lib/l0_rt_trip_updates.py
@@ -1,9 +1,9 @@
 from typing import (
-    Optional, 
-    Union, 
-    List, 
-    Dict, 
-    Any, 
+    Optional,
+    Union,
+    List,
+    Dict,
+    Any,
     Iterator,
 )
 

--- a/performance_manager/lib/l0_rt_vehicle_positions.py
+++ b/performance_manager/lib/l0_rt_vehicle_positions.py
@@ -1,4 +1,4 @@
-from typing import List, Union, Tuple
+from typing import List, Union
 
 import pathlib
 import numpy
@@ -363,7 +363,7 @@ def merge_vehicle_position_events(
     process_logger.log_complete()
 
 
-def process_vehicle_positions(db_manager: DatabaseManager) -> Tuple[int, int]:
+def process_vehicle_positions(db_manager: DatabaseManager) -> None:
     """
     process a bunch of vehicle position files
     create events for them
@@ -379,9 +379,6 @@ def process_vehicle_positions(db_manager: DatabaseManager) -> Tuple[int, int]:
         "RT_VEHICLE_POSITIONS", db_manager, file_limit=6
     )
     process_logger.add_metadata(count_of_paths=len(paths_to_load))
-
-    min_ts_processed = 10_000_000_000
-    max_ts_processed = 0
 
     for folder_data in paths_to_load:
         folder = str(pathlib.Path(folder_data["paths"][0]).parent)
@@ -409,12 +406,6 @@ def process_vehicle_positions(db_manager: DatabaseManager) -> Tuple[int, int]:
 
             new_events = transform_vp_timestamps(new_events)
             sizes["merge_events_count"] = new_events.shape[0]
-            min_ts_processed = min(
-                min_ts_processed, int(new_events["timestamp_start"].min())
-            )
-            max_ts_processed = max(
-                max_ts_processed, int(new_events["timestamp_end"].max())
-            )
 
             subprocess_logger.add_metadata(**sizes)
 
@@ -441,5 +432,3 @@ def process_vehicle_positions(db_manager: DatabaseManager) -> Tuple[int, int]:
             subprocess_logger.log_failure(exception)
 
     process_logger.log_complete()
-
-    return (min_ts_processed, max_ts_processed)

--- a/performance_manager/lib/l1_full_trip_events.py
+++ b/performance_manager/lib/l1_full_trip_events.py
@@ -55,10 +55,6 @@ def pull_and_transform(
 
     dupe_hash_cte = (
         sa.select(VehiclePositionEvents.hash)
-        .where(
-            (VehiclePositionEvents.timestamp_start > min_ts_process)
-            & (VehiclePositionEvents.timestamp_end < max_ts_process)
-        )
         .group_by(VehiclePositionEvents.hash)
         .having(sa.func.count() > 1)
     ).cte("dupe_hash")
@@ -101,8 +97,6 @@ def pull_and_transform(
         )
         .where(
             (VehiclePositionEvents.is_moving == sa.true())
-            & (VehiclePositionEvents.timestamp_start > min_ts_process)
-            & (VehiclePositionEvents.timestamp_end < max_ts_process)
             & (VehiclePositionEvents.stop_sequence.isnot(None))
             & (VehiclePositionEvents.stop_id.isnot(None))
             & (VehiclePositionEvents.direction_id.isnot(None))
@@ -154,8 +148,6 @@ def pull_and_transform(
         )
         .where(
             (VehiclePositionEvents.is_moving == sa.false())
-            & (VehiclePositionEvents.timestamp_start > min_ts_process)
-            & (VehiclePositionEvents.timestamp_end < max_ts_process)
             & (VehiclePositionEvents.stop_sequence.isnot(None))
             & (VehiclePositionEvents.stop_id.isnot(None))
             & (VehiclePositionEvents.direction_id.isnot(None))
@@ -201,8 +193,6 @@ def pull_and_transform(
         )
         .where(
             (TripUpdateEvents.stop_sequence.isnot(None))
-            & (TripUpdateEvents.timestamp_start > min_ts_process)
-            & (TripUpdateEvents.timestamp_start < max_ts_process)
             & (TripUpdateEvents.stop_id.isnot(None))
             & (TripUpdateEvents.direction_id.isnot(None))
             & (TripUpdateEvents.route_id.isnot(None))

--- a/performance_manager/startup.py
+++ b/performance_manager/startup.py
@@ -138,21 +138,11 @@ def main(args: argparse.Namespace) -> None:
 
         try:
             process_static_tables(db_manager)
-
-            min_ts_processed, max_ts_processed = process_vehicle_positions(
-                db_manager
-            )
-            min_ts, max_ts = process_trip_updates(db_manager)
-
-            min_ts_processed = min(min_ts_processed, min_ts)
-            max_ts_processed = max(max_ts_processed, max_ts)
-
-            if max_ts_processed > 0:
-                process_full_trip_events(
-                    db_manager, min_ts_processed, max_ts_processed
-                )
-                process_dwell_travel_times(db_manager)
-                process_headways(db_manager)
+            process_vehicle_positions(db_manager)
+            process_trip_updates(db_manager)
+            process_full_trip_events(db_manager)
+            process_dwell_travel_times(db_manager)
+            process_headways(db_manager)
 
             process_logger.log_complete()
         except Exception as exception:


### PR DESCRIPTION
This PR is meant to improve the performance of `pull_and_transform` for Level 1 `FullTripEvents` loading. 

For each event loop, this implementation limits records pulled from Level 0 tables to having an `updated_on` timestamp greater than the `max(updated_on)` timestamp from the Level 1 `FullTripEvents` table. 

Previously, full primary key comparisons were done between the Level 0 and Level 1 tables to determine which records required loading into the Level 1 table. 

Updates and Inserts are still completed via `hash` comparisons between the `FullTripEvents` and temporary `loadFullTripEvents` tables. 

Asana Task: https://app.asana.com/0/1203185331040541/1203480946583916