### PR TITLE
Bug Fix: Trip Update Loading (explode_stop_time_update)

### DIFF
--- a/.github/workflows/ingestion-ci.yaml
+++ b/.github/workflows/ingestion-ci.yaml
@@ -18,7 +18,7 @@ defaults:
 jobs:
   setup:
     name: Setup
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/poetry_deps
@@ -27,7 +27,7 @@ jobs:
 
   format:
     name: Format
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: setup
     steps:
       - uses: actions/checkout@v2
@@ -38,7 +38,7 @@ jobs:
 
   typing:
     name: Type Check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: setup
     steps:
       - uses: actions/checkout@v2
@@ -49,7 +49,7 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: setup
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/performance-manager-ci.yaml
+++ b/.github/workflows/performance-manager-ci.yaml
@@ -18,7 +18,7 @@ defaults:
 jobs:
   setup:
     name: Setup
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/poetry_deps
@@ -27,7 +27,7 @@ jobs:
 
   format:
     name: Format
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: setup
     steps:
       - uses: actions/checkout@v2
@@ -35,12 +35,11 @@ jobs:
         with:
           poetry-dir: performance_manager
       - run: |
-          source $ASDF_DIR/asdf.sh
           poetry run black . --check
 
   typing:
     name: Type Check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: setup
     steps:
       - uses: actions/checkout@v2
@@ -48,12 +47,11 @@ jobs:
         with:
           poetry-dir: performance_manager
       - run: |
-          source $ASDF_DIR/asdf.sh
           poetry run mypy .
 
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: setup
     steps:
       - uses: actions/checkout@v2
@@ -61,12 +59,11 @@ jobs:
         with:
           poetry-dir: performance_manager
       - run: |
-          source $ASDF_DIR/asdf.sh
           poetry run pylint *.py lib/ tests/
 
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: setup
     env:
       BOOTSTRAPPED: 1
@@ -91,5 +88,4 @@ jobs:
         with:
           poetry-dir: performance_manager
       - run: |
-          source $ASDF_DIR/asdf.sh
           poetry run pytest

--- a/.github/workflows/performance-manager-ci.yaml
+++ b/.github/workflows/performance-manager-ci.yaml
@@ -34,7 +34,7 @@ jobs:
       - uses: ./.github/actions/poetry_deps
         with:
           poetry-dir: performance_manager
-      - run: poetry run black . --check
+      - run: . $HOME/.asdf/asdf.sh && poetry run black . --check
 
   typing:
     name: Type Check
@@ -45,7 +45,7 @@ jobs:
       - uses: ./.github/actions/poetry_deps
         with:
           poetry-dir: performance_manager
-      - run: poetry run mypy .
+      - run: . $HOME/.asdf/asdf.sh && poetry run mypy .
 
   lint:
     name: Lint
@@ -56,7 +56,7 @@ jobs:
       - uses: ./.github/actions/poetry_deps
         with:
           poetry-dir: performance_manager
-      - run: poetry run pylint *.py lib/ tests/
+      - run: . $HOME/.asdf/asdf.sh && poetry run pylint *.py lib/ tests/
 
   test:
     name: Test
@@ -84,4 +84,4 @@ jobs:
       - uses: ./.github/actions/poetry_deps
         with:
           poetry-dir: performance_manager
-      - run: poetry run pytest
+      - run: . $HOME/.asdf/asdf.sh && poetry run pytest

--- a/.github/workflows/performance-manager-ci.yaml
+++ b/.github/workflows/performance-manager-ci.yaml
@@ -35,7 +35,7 @@ jobs:
         with:
           poetry-dir: performance_manager
       - run: |
-          . /home/runner/.asdf/asdf.sh
+          source $ASDF_DIR/asdf.sh
           poetry run black . --check
 
   typing:
@@ -48,7 +48,7 @@ jobs:
         with:
           poetry-dir: performance_manager
       - run: |
-          . /home/runner/.asdf/asdf.sh 
+          source $ASDF_DIR/asdf.sh
           poetry run mypy .
 
   lint:
@@ -61,7 +61,7 @@ jobs:
         with:
           poetry-dir: performance_manager
       - run: |
-          . /home/runner/.asdf/asdf.sh
+          source $ASDF_DIR/asdf.sh
           poetry run pylint *.py lib/ tests/
 
   test:
@@ -91,5 +91,5 @@ jobs:
         with:
           poetry-dir: performance_manager
       - run: |
-          . /home/runner/.asdf/asdf.sh
+          source $ASDF_DIR/asdf.sh
           poetry run pytest

--- a/.github/workflows/performance-manager-ci.yaml
+++ b/.github/workflows/performance-manager-ci.yaml
@@ -34,7 +34,9 @@ jobs:
       - uses: ./.github/actions/poetry_deps
         with:
           poetry-dir: performance_manager
-      - run: . $HOME/.asdf/asdf.sh && poetry run black . --check
+      - run: |
+          . /home/runner/.asdf/asdf.sh
+          poetry run black . --check
 
   typing:
     name: Type Check
@@ -45,7 +47,9 @@ jobs:
       - uses: ./.github/actions/poetry_deps
         with:
           poetry-dir: performance_manager
-      - run: . $HOME/.asdf/asdf.sh && poetry run mypy .
+      - run: |
+          . /home/runner/.asdf/asdf.sh 
+          poetry run mypy .
 
   lint:
     name: Lint
@@ -56,7 +60,9 @@ jobs:
       - uses: ./.github/actions/poetry_deps
         with:
           poetry-dir: performance_manager
-      - run: . $HOME/.asdf/asdf.sh && poetry run pylint *.py lib/ tests/
+      - run: |
+          . /home/runner/.asdf/asdf.sh
+          poetry run pylint *.py lib/ tests/
 
   test:
     name: Test
@@ -84,4 +90,6 @@ jobs:
       - uses: ./.github/actions/poetry_deps
         with:
           poetry-dir: performance_manager
-      - run: . $HOME/.asdf/asdf.sh && poetry run pytest
+      - run: |
+          . /home/runner/.asdf/asdf.sh
+          poetry run pytest

--- a/.github/workflows/performance-manager-ci.yaml
+++ b/.github/workflows/performance-manager-ci.yaml
@@ -18,7 +18,7 @@ defaults:
 jobs:
   setup:
     name: Setup
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/poetry_deps
@@ -27,43 +27,40 @@ jobs:
 
   format:
     name: Format
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: setup
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/poetry_deps
         with:
           poetry-dir: performance_manager
-      - run: |
-          poetry run black . --check
+      - run: poetry run black . --check
 
   typing:
     name: Type Check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: setup
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/poetry_deps
         with:
           poetry-dir: performance_manager
-      - run: |
-          poetry run mypy .
+      - run: poetry run mypy .
 
   lint:
     name: Lint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: setup
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/poetry_deps
         with:
           poetry-dir: performance_manager
-      - run: |
-          poetry run pylint *.py lib/ tests/
+      - run: poetry run pylint *.py lib/ tests/
 
   test:
     name: Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: setup
     env:
       BOOTSTRAPPED: 1
@@ -87,5 +84,4 @@ jobs:
       - uses: ./.github/actions/poetry_deps
         with:
           poetry-dir: performance_manager
-      - run: |
-          poetry run pytest
+      - run: poetry run pytest

--- a/.github/workflows/performance-manager-ci.yaml
+++ b/.github/workflows/performance-manager-ci.yaml
@@ -18,7 +18,7 @@ defaults:
 jobs:
   setup:
     name: Setup
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/poetry_deps
@@ -27,7 +27,7 @@ jobs:
 
   format:
     name: Format
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: setup
     steps:
       - uses: actions/checkout@v2
@@ -38,7 +38,7 @@ jobs:
 
   typing:
     name: Type Check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: setup
     steps:
       - uses: actions/checkout@v2
@@ -49,7 +49,7 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: setup
     steps:
       - uses: actions/checkout@v2
@@ -60,7 +60,7 @@ jobs:
 
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: setup
     env:
       BOOTSTRAPPED: 1

--- a/performance_manager/lib/l0_rt_trip_updates.py
+++ b/performance_manager/lib/l0_rt_trip_updates.py
@@ -54,7 +54,7 @@ def get_tu_dataframe_chunks(
 
 # pylint: disable=too-many-arguments
 def explode_stop_time_update(
-    stop_time_update: List[Dict[str, Any]],
+    stop_time_update: Optional[List[Dict[str, Any]]],
     timestamp: int,
     direction_id: int,
     route_id: Any,
@@ -75,13 +75,20 @@ def explode_stop_time_update(
         "vehicle_id": vehicle_id,
     }
     return_list: List[Dict[str, Any]] = []
+
+    # fix: https://app.asana.com/0/1203185331040541/1203495730837934
+    # it appears that numpy.vectorize batches function inputs which can
+    # result in None being passed in for stop_time_update
+    if stop_time_update is None:
+        return None
+
     for record in stop_time_update:
         try:
             arrival_time = int(record["arrival"]["time"])
         except (TypeError, KeyError):
             continue
         # filter out stop event predictions that are too far into the future
-        # and are unlikel to be used as a final stop event prediction
+        # and are unlikely to be used as a final stop event prediction
         # (2 minutes) or predictions that go into the past (negative values)
         if arrival_time - timestamp < 0 or arrival_time - timestamp > 120:
             continue

--- a/performance_manager/pyproject.toml
+++ b/performance_manager/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["MBTA CTD <developer@mbta.com>",
            "Mike Zappitello <mzappitello@mbta.com>"]
 
 [tool.poetry.dependencies]
-python = "^3.9"
+python = "3.9.12"
 pyarrow = "^8.0.0"
 boto3 = "^1.23.3"
 pandas = "^1.4.3"

--- a/performance_manager/pyproject.toml
+++ b/performance_manager/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["MBTA CTD <developer@mbta.com>",
            "Mike Zappitello <mzappitello@mbta.com>"]
 
 [tool.poetry.dependencies]
-python = "3.9.12"
+python = "~3.9"
 pyarrow = "^8.0.0"
 boto3 = "^1.23.3"
 pandas = "^1.4.3"

--- a/performance_manager/pyproject.toml
+++ b/performance_manager/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["MBTA CTD <developer@mbta.com>",
            "Mike Zappitello <mzappitello@mbta.com>"]
 
 [tool.poetry.dependencies]
-python = "~3.9"
+python = "^3.9"
 pyarrow = "^8.0.0"
 boto3 = "^1.23.3"
 pandas = "^1.4.3"


### PR DESCRIPTION
This fixes a  bug caused by the apparent batching of the `numpy.vectorize` function. 

Very infrequently a `None` type would be passed into `explode_stop_time_update` as the `stop_time_update` parameter. 

Asana Task: https://app.asana.com/0/1203185331040541/1203495730837934
