### PR TITLE
check for timestamp columns

### DIFF
--- a/performance_manager/lib/l0_rt_vehicle_positions.py
+++ b/performance_manager/lib/l0_rt_vehicle_positions.py
@@ -243,6 +243,10 @@ def transform_vp_timestamps(
             ("vehicle_timestamp", True): "vp_move_timestamp",
         }
     )
+    # verify timestamp columns were created
+    for column in ("vp_stop_timestamp","vp_move_timestamp"):
+        if column not in vp_timestamps.columns:
+            vp_timestamps[column] = None
 
     # we no longer need is moving or vehicle timestamp as those are all
     # stored in the vp_timestamps dataframe. drop duplicated trip stop hash

--- a/performance_manager/lib/l0_rt_vehicle_positions.py
+++ b/performance_manager/lib/l0_rt_vehicle_positions.py
@@ -244,7 +244,7 @@ def transform_vp_timestamps(
         }
     )
     # verify timestamp columns were created
-    for column in ("vp_stop_timestamp","vp_move_timestamp"):
+    for column in ("vp_stop_timestamp", "vp_move_timestamp"):
         if column not in vp_timestamps.columns:
             vp_timestamps[column] = None
 


### PR DESCRIPTION
hotfix for RT_Vehicle_Positions failure.

verifies that `vp_move_timestamp` and `vp_stop_timsetamp` were both created from pivot table
