### PR TITLE
trip_id bugfix & SIGTERM graceful shutdown

### DIFF
--- a/py_gtfs_rt_ingestion/ingest.py
+++ b/py_gtfs_rt_ingestion/ingest.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+import signal
 from multiprocessing import Queue
 
 import time
@@ -13,6 +14,8 @@ from lib import (
     DEFAULT_S3_PREFIX,
     ProcessLogger,
     start_rds_writer_process,
+    handle_ecs_sigterm,
+    check_for_sigterm,
 )
 
 logging.getLogger().setLevel("INFO")
@@ -90,6 +93,7 @@ def ingest(metadata_queue: Queue) -> None:
     filepaths to the metadata table as unprocessed, and move gtfs files to the
     archive bucket (or error bucket in the event of an error)
     """
+    check_for_sigterm()
     process_logger = ProcessLogger("ingest_all")
     process_logger.log_start()
 
@@ -123,6 +127,7 @@ def main() -> None:
 
 if __name__ == "__main__":
     logging.info("Starting Ingestion Container")
+    signal.signal(signal.SIGTERM, handle_ecs_sigterm)
     load_environment()
     validate_environment()
     main()

--- a/py_gtfs_rt_ingestion/lib/__init__.py
+++ b/py_gtfs_rt_ingestion/lib/__init__.py
@@ -10,5 +10,6 @@ from .logging_utils import ProcessLogger
 from .postgres_utils import start_rds_writer_process
 from .s3_utils import file_list_from_s3, move_s3_objects, write_parquet_file
 from .utils import load_environment, group_sort_file_list, DEFAULT_S3_PREFIX
+from .ecs import check_for_sigterm, handle_ecs_sigterm
 
 __version__ = "0.1.0"

--- a/py_gtfs_rt_ingestion/lib/config_rt_bus_vehicle.py
+++ b/py_gtfs_rt_ingestion/lib/config_rt_bus_vehicle.py
@@ -21,6 +21,10 @@ class RtBusVehicleDetail(GTFSRTDetail):
                 ("feed_timestamp", pyarrow.int64()),
                 # entity
                 ("entity_id", pyarrow.string()),  # actual label: id
+                (
+                    "entity_is_deleted",
+                    pyarrow.bool_(),
+                ),  # actual label: is_deleted
                 # entity -> vehicle
                 ("block_id", pyarrow.string()),
                 ("capacity", pyarrow.int64()),
@@ -64,7 +68,10 @@ class RtBusVehicleDetail(GTFSRTDetail):
     @property
     def transformation_schema(self) -> dict:
         return {
-            "entity": (("id", "entity_id"),),
+            "entity": (
+                ("id", "entity_id"),
+                ("is_deleted", "entity_is_deleted"),
+            ),
             "entity,vehicle": (
                 ("block_id",),
                 ("capacity",),

--- a/py_gtfs_rt_ingestion/lib/config_rt_vehicle.py
+++ b/py_gtfs_rt_ingestion/lib/config_rt_vehicle.py
@@ -42,7 +42,7 @@ class RtVehicleDetail(GTFSRTDetail):
                 ("schedule_relationship", pyarrow.string()),
                 ("start_date", pyarrow.string()),
                 ("start_time", pyarrow.string()),
-                ("trip_id", pyarrow.string()),  # actual label: id
+                ("trip_id", pyarrow.string()),
                 # entity -> vehicle -> vehicle
                 ("vehicle_id", pyarrow.string()),  # actual label: id
                 ("vehicle_label", pyarrow.string()),  # actual label: label
@@ -83,7 +83,7 @@ class RtVehicleDetail(GTFSRTDetail):
                 ("schedule_relationship",),
                 ("start_date",),
                 ("start_time",),
-                ("id", "trip_id"),
+                ("trip_id",),
             ),
             "entity,vehicle,vehicle": (
                 (

--- a/py_gtfs_rt_ingestion/lib/ecs.py
+++ b/py_gtfs_rt_ingestion/lib/ecs.py
@@ -1,0 +1,22 @@
+import os
+import sys
+import logging
+
+from typing import Any
+
+
+def handle_ecs_sigterm(_: int, __: Any) -> None:
+    """
+    handler function for when ECS recieves ECS SIGTERM
+    """
+    logging.info("AWS ECS SIGTERM received")
+    os.environ["GOT_SIGTERM"] = "TRUE"
+
+
+def check_for_sigterm() -> None:
+    """
+    check if SIGTERM recived from ECS. If found, terminate process.
+    """
+    if os.environ.get("GOT_SIGTERM") is not None:
+        logging.info("SIGTERM received, terminating process...")
+        sys.exit()


### PR DESCRIPTION
This PR fixes a bug in our `ingestion` application that resulted in `trip_id` values from GTFS-RT vehicle position files not being included in parquet files. 

This PR also adds adds ECS graceful shutdown functionality to streamline CD deployments. 

Asana Task: https://app.asana.com/0/1203655790984044/1203958635792900
Asana Task: https://app.asana.com/0/1203655790984044/1203958635792903
