### PR TITLE
Fix signal+multiprocessing bug

### DIFF
--- a/py_gtfs_rt_ingestion/ingest.py
+++ b/py_gtfs_rt_ingestion/ingest.py
@@ -110,12 +110,12 @@ def main() -> None:
     """every second run jobs that are currently pending"""
     # start rds writer process
     # this will create only one rds engine while app is running
-    metadata_queue, _rds_process = start_rds_writer_process()
+    metadata_queue, rds_process = start_rds_writer_process()
 
     schedule.every(5).minutes.do(ingest, metadata_queue=metadata_queue)
 
     while True:
-        check_for_sigterm(metadata_queue)
+        check_for_sigterm(metadata_queue, rds_process)
         schedule.run_pending()
         time.sleep(1)
 

--- a/py_gtfs_rt_ingestion/ingest.py
+++ b/py_gtfs_rt_ingestion/ingest.py
@@ -93,7 +93,6 @@ def ingest(metadata_queue: Queue) -> None:
     filepaths to the metadata table as unprocessed, and move gtfs files to the
     archive bucket (or error bucket in the event of an error)
     """
-    check_for_sigterm()
     process_logger = ProcessLogger("ingest_all")
     process_logger.log_start()
 
@@ -116,6 +115,7 @@ def main() -> None:
     schedule.every(5).minutes.do(ingest, metadata_queue=metadata_queue)
 
     while True:
+        check_for_sigterm(metadata_queue)
         schedule.run_pending()
         time.sleep(1)
 

--- a/py_gtfs_rt_ingestion/lib/ecs.py
+++ b/py_gtfs_rt_ingestion/lib/ecs.py
@@ -1,7 +1,9 @@
 import os
 import sys
+import time
 import logging
 
+from multiprocessing import Queue
 from typing import Any
 
 
@@ -13,10 +15,12 @@ def handle_ecs_sigterm(_: int, __: Any) -> None:
     os.environ["GOT_SIGTERM"] = "TRUE"
 
 
-def check_for_sigterm() -> None:
+def check_for_sigterm(metadata_queue: Queue) -> None:
     """
     check if SIGTERM recived from ECS. If found, terminate process.
     """
     if os.environ.get("GOT_SIGTERM") is not None:
         logging.info("SIGTERM received, terminating process...")
+        metadata_queue.put(None)
+        time.sleep(5)
         sys.exit()

--- a/py_gtfs_rt_ingestion/lib/ecs.py
+++ b/py_gtfs_rt_ingestion/lib/ecs.py
@@ -1,9 +1,8 @@
 import os
 import sys
-import time
 import logging
 
-from multiprocessing import Queue
+from multiprocessing import Queue, Process
 from typing import Any
 
 
@@ -15,12 +14,13 @@ def handle_ecs_sigterm(_: int, __: Any) -> None:
     os.environ["GOT_SIGTERM"] = "TRUE"
 
 
-def check_for_sigterm(metadata_queue: Queue) -> None:
+def check_for_sigterm(metadata_queue: Queue, rds_process: Process) -> None:
     """
     check if SIGTERM recived from ECS. If found, terminate process.
     """
     if os.environ.get("GOT_SIGTERM") is not None:
         logging.info("SIGTERM received, terminating process...")
+        # send signal to stop rds writer process and wait for exit
         metadata_queue.put(None)
-        time.sleep(5)
+        rds_process.join()
         sys.exit()

--- a/py_gtfs_rt_ingestion/lib/ingest.py
+++ b/py_gtfs_rt_ingestion/lib/ingest.py
@@ -81,7 +81,12 @@ def ingest_files(files: List[str], metadata_queue: Queue) -> None:
     converters[ConfigType.ERROR].add_files(error_files)
 
     # The remaining converters can be run in parallel
+    #
+    # the use of signal.signal, multiprocessing.Manager and multiprocessing.Pool.map, in combination,
+    # causes inadvertant SIGTERM signals to be sent by application and main event loop to be blocked
+    #
+    # launching converter processes with map_async avoids throwing of SIGTERM signals and blocking
     with Pool(processes=len(converters)) as pool:
-        _ = pool.map_async(run_converter, converters.values())
+        pool.map_async(run_converter, converters.values())
         pool.close()
         pool.join()

--- a/py_gtfs_rt_ingestion/lib/ingest.py
+++ b/py_gtfs_rt_ingestion/lib/ingest.py
@@ -82,4 +82,6 @@ def ingest_files(files: List[str], metadata_queue: Queue) -> None:
 
     # The remaining converters can be run in parallel
     with Pool(processes=len(converters)) as pool:
-        pool.map(run_converter, converters.values())
+        _ = pool.map_async(run_converter, converters.values())
+        pool.close()
+        pool.join()


### PR DESCRIPTION
Our use of the following functions, in combination, causes `SIGTERM` signals to be thrown and blocking of main event loop.

- signal.signal
- multiprocessing.Pool.map
- multiprocessing.Manager

Launching all `Converter` processes with `multiprocessing.Pool.map_async` resolves the issue of throwing `SIGTERM` signals and blocking the main event loop. 

Also added additional steps to `check_for_sigterm` function to shutdown rds_writer_process when `SIGTERM` signal is received from AWS. 

Asana Task: https://app.asana.com/0/1203655790984049/1204005780226888