### PR TITLE
Business Logic for Trips and Metrics table loading

### DIFF
--- a/performance_manager/lib/__init__.py
+++ b/performance_manager/lib/__init__.py
@@ -9,5 +9,6 @@ from .logging_utils import ProcessLogger
 from .postgres_schema import MetadataLog, SqlBase
 from .postgres_utils import DatabaseManager
 from .ecs import handle_ecs_sigterm, check_for_sigterm
+from .l1_rt_metrics import process_trips_and_metrics
 
 __version__ = "0.1.0"

--- a/performance_manager/lib/l1_cte_statements.py
+++ b/performance_manager/lib/l1_cte_statements.py
@@ -1,21 +1,22 @@
 import datetime
 import calendar
 
+from typing import List
 import sqlalchemy as sa
-from typing import Dict, List
 
 from .postgres_schema import (
     VehicleEvents,
     VehicleTrips,
-    VehicleEventMetrics,
     StaticCalendar,
     StaticStopTimes,
     StaticStops,
-    StaticRoutes,
-    StaticTrips
+    StaticTrips,
 )
 
-def get_static_trips_cte(timestamps: List[int], start_date: int) -> sa.sql.Selectable:
+
+def get_static_trips_cte(
+    timestamps: List[int], start_date: int
+) -> sa.sql.selectable.CTE:
     """
     return CTE named "static_trip_cte" for all static trips on given date
     """
@@ -31,50 +32,73 @@ def get_static_trips_cte(timestamps: List[int], start_date: int) -> sa.sql.Selec
                 StaticStops.parent_station,
                 StaticStops.stop_id,
             ).label("parent_station"),
-            (sa.func.lag(StaticStopTimes.departure_time).over(
-                partition_by=(StaticStopTimes.timestamp,StaticStopTimes.trip_id),
+            (
+                sa.func.lag(StaticStopTimes.departure_time)
+                .over(
+                    partition_by=(
+                        StaticStopTimes.timestamp,
+                        StaticStopTimes.trip_id,
+                    ),
+                    order_by=StaticStopTimes.stop_sequence,
+                )
+                .is_(None)
+            ).label("static_trip_first_stop"),
+            (
+                sa.func.lead(StaticStopTimes.departure_time)
+                .over(
+                    partition_by=(
+                        StaticStopTimes.timestamp,
+                        StaticStopTimes.trip_id,
+                    ),
+                    order_by=StaticStopTimes.stop_sequence,
+                )
+                .is_(None)
+            ).label("static_trip_last_stop"),
+            sa.func.rank()
+            .over(
+                partition_by=(
+                    StaticStopTimes.timestamp,
+                    StaticStopTimes.trip_id,
+                ),
                 order_by=StaticStopTimes.stop_sequence,
-            ) == None).label("static_trip_first_stop"),
-            (sa.func.lead(StaticStopTimes.departure_time).over(
-                partition_by=(StaticStopTimes.timestamp,StaticStopTimes.trip_id),
-                order_by=StaticStopTimes.stop_sequence,
-            ) == None).label("static_trip_last_stop"),
-            sa.func.rank().over(
-                partition_by=(StaticStopTimes.timestamp,StaticStopTimes.trip_id),
-                order_by=StaticStopTimes.stop_sequence,
-            ).label("static_trip_stop_rank"),
+            )
+            .label("static_trip_stop_rank"),
             StaticTrips.route_id,
             StaticTrips.direction_id,
-        ).select_from(
-            StaticStopTimes
-        ).join(
+        )
+        .select_from(StaticStopTimes)
+        .join(
             StaticTrips,
             sa.and_(
                 StaticStopTimes.timestamp == StaticTrips.timestamp,
                 StaticStopTimes.trip_id == StaticTrips.trip_id,
             ),
-        ).join(
+        )
+        .join(
             StaticStops,
             sa.and_(
                 StaticStopTimes.timestamp == StaticStops.timestamp,
                 StaticStopTimes.stop_id == StaticStops.stop_id,
             ),
-        ).join(
+        )
+        .join(
             StaticCalendar,
             sa.and_(
                 StaticStopTimes.timestamp == StaticCalendar.timestamp,
                 StaticTrips.service_id == StaticCalendar.service_id,
             ),
-        ).where(
+        )
+        .where(
             (StaticStopTimes.timestamp.in_(timestamps))
             & (getattr(StaticCalendar, day_of_week) == sa.true())
             & (StaticCalendar.start_date <= int(start_date))
             & (StaticCalendar.end_date >= int(start_date))
-        ).cte(name="static_trips_cte")
+        )
+        .cte(name="static_trips_cte")
     )
 
 
-def get_rt_trips_cte(start_date: int) -> sa.sql.Selectable:
+def get_rt_trips_cte(start_date: int) -> sa.sql.selectable.CTE:
     """
     return CTE named "rt_trips_cte" for all RT trips on a given date
     """
@@ -90,29 +114,125 @@ def get_rt_trips_cte(start_date: int) -> sa.sql.Selectable:
             VehicleEvents.trip_hash,
             VehicleEvents.stop_sequence,
             VehicleEvents.parent_station,
+            VehicleEvents.trip_stop_hash,
             VehicleEvents.vp_move_timestamp,
             VehicleEvents.vp_stop_timestamp,
             VehicleEvents.tu_stop_timestamp,
-            (sa.func.lag(VehicleEvents.trip_hash).over(
+            (
+                sa.func.lag(VehicleEvents.trip_hash)
+                .over(
+                    partition_by=(VehicleEvents.trip_hash),
+                    order_by=VehicleEvents.stop_sequence,
+                )
+                .is_(None)
+            ).label("rt_trip_first_stop_flag"),
+            (
+                sa.func.lead(VehicleEvents.trip_hash)
+                .over(
+                    partition_by=(VehicleEvents.trip_hash),
+                    order_by=VehicleEvents.stop_sequence,
+                )
+                .is_(None)
+            ).label("rt_trip_last_stop_flag"),
+            sa.func.rank()
+            .over(
                 partition_by=(VehicleEvents.trip_hash),
                 order_by=VehicleEvents.stop_sequence,
-            ) == None).label("rt_trip_first_stop_flag"),
-            (sa.func.lead(VehicleEvents.trip_hash).over(
-                partition_by=(VehicleEvents.trip_hash),
-                order_by=VehicleEvents.stop_sequence,
-            ) == None).label("rt_trip_last_stop_flag"),
-            sa.func.rank().over(
-                partition_by=(VehicleEvents.trip_hash),
-                order_by=VehicleEvents.stop_sequence,
-            ).label("rt_trip_stop_rank"),
-        ).select_from(
-            VehicleEvents
-        ).where(
+            )
+            .label("rt_trip_stop_rank"),
+        )
+        .select_from(VehicleEvents)
+        .where(
             VehicleEvents.start_date == start_date,
             sa.or_(
-                VehicleEvents.vp_move_timestamp != None,
-                VehicleEvents.vp_stop_timestamp != None,
-            )
+                VehicleEvents.vp_move_timestamp.is_not(None),
+                VehicleEvents.vp_stop_timestamp.is_not(None),
+            ),
         )
     ).cte(name="rt_trips_cte")
 
+
+def get_trips_for_metrics(
+    timestamps: List[int], start_date: int
+) -> sa.sql.selectable.CTE:
+    """
+    return CTE named "trips_for_metrics" to develop metrics tables
+
+    """
+
+    static_trips_cte = get_static_trips_cte(timestamps, start_date)
+    rt_trips_cte = get_rt_trips_cte(start_date)
+
+    return (
+        sa.select(
+            rt_trips_cte.c.trip_stop_hash,
+            rt_trips_cte.c.fk_static_timestamp,
+            rt_trips_cte.c.trip_hash,
+            rt_trips_cte.c.direction_id,
+            rt_trips_cte.c.route_id,
+            rt_trips_cte.c.start_time,
+            rt_trips_cte.c.vehicle_id,
+            rt_trips_cte.c.parent_station,
+            rt_trips_cte.c.vp_move_timestamp.label("move_timestamp"),
+            sa.func.coalesce(
+                rt_trips_cte.c.vp_stop_timestamp,
+                rt_trips_cte.c.tu_stop_timestamp,
+            ).label("stop_timestamp"),
+            sa.func.coalesce(
+                rt_trips_cte.c.vp_move_timestamp,
+                rt_trips_cte.c.vp_stop_timestamp,
+                rt_trips_cte.c.tu_stop_timestamp,
+            ).label("sort_timestamp"),
+            sa.func.coalesce(
+                static_trips_cte.c.static_trip_first_stop,
+                rt_trips_cte.c.rt_trip_first_stop_flag,
+            ).label("first_stop_flag"),
+            sa.func.coalesce(
+                static_trips_cte.c.static_trip_last_stop,
+                rt_trips_cte.c.rt_trip_last_stop_flag,
+            ).label("last_stop_flag"),
+            sa.func.coalesce(
+                static_trips_cte.c.static_trip_stop_rank,
+                rt_trips_cte.c.rt_trip_stop_rank,
+            ).label("stop_rank"),
+            sa.func.lead(rt_trips_cte.c.vp_move_timestamp)
+            .over(
+                partition_by=rt_trips_cte.c.vehicle_id,
+                order_by=sa.func.coalesce(
+                    rt_trips_cte.c.vp_move_timestamp,
+                    rt_trips_cte.c.vp_stop_timestamp,
+                    rt_trips_cte.c.tu_stop_timestamp,
+                ),
+            )
+            .label("next_station_move"),
+            VehicleTrips.stop_count,
+            VehicleTrips.trunk_route_id,
+        )
+        .distinct(
+            rt_trips_cte.c.trip_stop_hash,
+        )
+        .select_from(rt_trips_cte)
+        .join(
+            VehicleTrips,
+            rt_trips_cte.c.trip_hash == VehicleTrips.trip_hash,
+            isouter=True,
+        )
+        .join(
+            static_trips_cte,
+            sa.and_(
+                VehicleTrips.static_trip_id_guess
+                == static_trips_cte.c.static_trip_id,
+                rt_trips_cte.c.fk_static_timestamp
+                == static_trips_cte.c.timestamp,
+                rt_trips_cte.c.parent_station
+                == static_trips_cte.c.parent_station,
+                rt_trips_cte.c.rt_trip_stop_rank
+                >= static_trips_cte.c.static_trip_stop_rank,
+            ),
+            isouter=True,
+        )
+        .order_by(
+            rt_trips_cte.c.trip_stop_hash,
+            static_trips_cte.c.static_trip_stop_rank,
+        )
+    ).cte(name="trip_for_metrics")

--- a/performance_manager/lib/l1_cte_statements.py
+++ b/performance_manager/lib/l1_cte_statements.py
@@ -1,0 +1,118 @@
+import datetime
+import calendar
+
+import sqlalchemy as sa
+from typing import Dict, List
+
+from .postgres_schema import (
+    VehicleEvents,
+    VehicleTrips,
+    VehicleEventMetrics,
+    StaticCalendar,
+    StaticStopTimes,
+    StaticStops,
+    StaticRoutes,
+    StaticTrips
+)
+
+def get_static_trips_cte(timestamps: List[int], start_date: int) -> sa.sql.Selectable:
+    """
+    return CTE named "static_trip_cte" for all static trips on given date
+    """
+    start_date_dt = datetime.datetime.strptime(str(start_date), "%Y%m%d")
+    day_of_week = calendar.day_name[start_date_dt.weekday()].lower()
+
+    return (
+        sa.select(
+            StaticStopTimes.timestamp,
+            StaticStopTimes.trip_id.label("static_trip_id"),
+            StaticStopTimes.arrival_time.label("static_stop_timestamp"),
+            sa.func.coalesce(
+                StaticStops.parent_station,
+                StaticStops.stop_id,
+            ).label("parent_station"),
+            (sa.func.lag(StaticStopTimes.departure_time).over(
+                partition_by=(StaticStopTimes.timestamp,StaticStopTimes.trip_id),
+                order_by=StaticStopTimes.stop_sequence,
+            ) == None).label("static_trip_first_stop"),
+            (sa.func.lead(StaticStopTimes.departure_time).over(
+                partition_by=(StaticStopTimes.timestamp,StaticStopTimes.trip_id),
+                order_by=StaticStopTimes.stop_sequence,
+            ) == None).label("static_trip_last_stop"),
+            sa.func.rank().over(
+                partition_by=(StaticStopTimes.timestamp,StaticStopTimes.trip_id),
+                order_by=StaticStopTimes.stop_sequence,
+            ).label("static_trip_stop_rank"),
+            StaticTrips.route_id,
+            StaticTrips.direction_id,
+        ).select_from(
+            StaticStopTimes
+        ).join(
+            StaticTrips,
+            sa.and_(
+                StaticStopTimes.timestamp == StaticTrips.timestamp,
+                StaticStopTimes.trip_id == StaticTrips.trip_id,
+            ),
+        ).join(
+            StaticStops,
+            sa.and_(
+                StaticStopTimes.timestamp == StaticStops.timestamp,
+                StaticStopTimes.stop_id == StaticStops.stop_id,
+            ),
+        ).join(
+            StaticCalendar,
+            sa.and_(
+                StaticStopTimes.timestamp == StaticCalendar.timestamp,
+                StaticTrips.service_id == StaticCalendar.service_id,
+            ),
+        ).where(
+            (StaticStopTimes.timestamp.in_(timestamps))
+            & (getattr(StaticCalendar, day_of_week) == sa.true())
+            & (StaticCalendar.start_date <= int(start_date))
+            & (StaticCalendar.end_date >= int(start_date))
+        ).cte(name="static_trips_cte")
+    )
+
+
+def get_rt_trips_cte(start_date: int) -> sa.sql.Selectable:
+    """
+    return CTE named "rt_trips_cte" for all RT trips on a given date
+    """
+
+    return (
+        sa.select(
+            VehicleEvents.fk_static_timestamp,
+            VehicleEvents.direction_id,
+            VehicleEvents.route_id,
+            VehicleEvents.start_date,
+            VehicleEvents.start_time,
+            VehicleEvents.vehicle_id,
+            VehicleEvents.trip_hash,
+            VehicleEvents.stop_sequence,
+            VehicleEvents.parent_station,
+            VehicleEvents.vp_move_timestamp,
+            VehicleEvents.vp_stop_timestamp,
+            VehicleEvents.tu_stop_timestamp,
+            (sa.func.lag(VehicleEvents.trip_hash).over(
+                partition_by=(VehicleEvents.trip_hash),
+                order_by=VehicleEvents.stop_sequence,
+            ) == None).label("rt_trip_first_stop_flag"),
+            (sa.func.lead(VehicleEvents.trip_hash).over(
+                partition_by=(VehicleEvents.trip_hash),
+                order_by=VehicleEvents.stop_sequence,
+            ) == None).label("rt_trip_last_stop_flag"),
+            sa.func.rank().over(
+                partition_by=(VehicleEvents.trip_hash),
+                order_by=VehicleEvents.stop_sequence,
+            ).label("rt_trip_stop_rank"),
+        ).select_from(
+            VehicleEvents
+        ).where(
+            VehicleEvents.start_date == start_date,
+            sa.or_(
+                VehicleEvents.vp_move_timestamp != None,
+                VehicleEvents.vp_stop_timestamp != None,
+            )
+        )
+    ).cte(name="rt_trips_cte")
+

--- a/performance_manager/lib/l1_rt_metrics.py
+++ b/performance_manager/lib/l1_rt_metrics.py
@@ -1,0 +1,348 @@
+
+import sqlalchemy as sa
+from typing import Dict, List
+import logging
+
+from .logging_utils import ProcessLogger
+from .postgres_utils import DatabaseManager
+from .postgres_schema import (
+    VehicleEvents,
+    VehicleTrips,
+    VehicleEventMetrics,
+)
+from .l1_cte_statements import (
+    get_rt_trips_cte,
+    get_static_trips_cte,
+)
+
+def get_seed_data(db_manager: DatabaseManager) -> Dict[int, List[int]]:
+    """
+    get seed data for populating trip and metrics tables
+
+    return: Dict[start_date:int : List[fk_static_timestamps]]
+    """
+    last_metric_update = (
+        sa.select(
+            sa.func.coalesce(
+                    sa.func.max(VehicleTrips.updated_on),
+                    sa.func.to_timestamp(0),
+            )
+        ).scalar_subquery()
+    )
+
+    seed_query = (
+        sa.select(
+            VehicleEvents.start_date,
+            VehicleEvents.fk_static_timestamp,
+        ).distinct(
+            VehicleEvents.start_date,
+            VehicleEvents.fk_static_timestamp,
+        ).where(
+            VehicleEvents.updated_on > last_metric_update
+        ).order_by(
+            VehicleEvents.start_date
+        ).limit(100)
+    )
+
+    # returns empty list if no records to process
+    seed_data = db_manager.select_as_list(seed_query)
+
+    seed_data_return: Dict[int, List[int]] = {}
+    for record in seed_data:
+        start_date = record.get("start_date")
+        timestamp = record.get("fk_static_timestamp")
+
+        if start_date not in seed_data_return:
+            seed_data_return[start_date] = []
+        seed_data_return[start_date].append(timestamp)
+
+    return seed_data_return
+
+def process_trips_tables(db_manager: DatabaseManager, seed_data: Dict[int, List[int]]) -> None:
+    """
+    process updates to multiple trips tables
+    """
+
+    MAX_TABLES_TO_PROCESS = 3
+
+    process_logger = ProcessLogger("l1_rt_trips_tables_loader", seed_data_size=len(seed_data))
+    process_logger.log_start()
+
+    tables_processed=0
+    for seed_start_date in sorted(seed_data.keys())[:MAX_TABLES_TO_PROCESS]:
+        seed_timestamps = seed_data[seed_start_date]
+        process_trips_table(db_manager, seed_start_date, seed_timestamps)
+        tables_processed += 1
+
+    process_logger.add_metadata(tables_processed=tables_processed)
+    process_logger.log_complete()
+
+
+def process_trips_table(db_manager: DatabaseManager, seed_start_date: int, seed_timestamps: List[int]) -> None:
+    """
+    processs updates to trips table
+
+    will only process one days worth of trips data per run, but can be modfied
+    to process additional says provided in seed_data
+    """
+    process_logger = ProcessLogger("l1_rt_trips_table_loader")
+    process_logger.log_start()
+
+    static_trips_cte = get_static_trips_cte(seed_timestamps, seed_start_date)
+
+    first_stop_static_cte = (
+        sa.select(
+            static_trips_cte.c.timestamp,
+            static_trips_cte.c.static_trip_id,
+            static_trips_cte.c.static_stop_timestamp.label("static_start_time"),
+            static_trips_cte.c.parent_station.label("static_trip_first_stop"),
+        ).select_from(
+            static_trips_cte
+        ).where(
+            static_trips_cte.c.static_trip_first_stop == sa.true()
+        ).cte(name="first_stop_static_cte")
+    )
+
+    static_trips_summary_cte = (
+        sa.select(
+            static_trips_cte.c.timestamp,
+            static_trips_cte.c.static_trip_id,
+            static_trips_cte.c.route_id,
+            static_trips_cte.c.direction_id,
+            first_stop_static_cte.c.static_start_time,
+            first_stop_static_cte.c.static_trip_first_stop,
+            static_trips_cte.c.parent_station.label("static_trip_last_stop"),
+            static_trips_cte.c.static_trip_stop_rank.label("static_stop_count"),
+        ).select_from(
+            static_trips_cte
+        ).join(
+            first_stop_static_cte,
+            sa.and_(
+                static_trips_cte.c.timestamp == first_stop_static_cte.c.timestamp,
+                static_trips_cte.c.static_trip_id == first_stop_static_cte.c.static_trip_id,
+            )
+        ).where(
+            static_trips_cte.c.static_trip_last_stop == sa.true()
+        ).cte(name="static_trips_summary_cte")
+    )
+
+    rt_trips_cte = get_rt_trips_cte(seed_start_date)
+
+    first_stop_rt_cte = (
+        sa.select(
+            rt_trips_cte.c.trip_hash,
+            rt_trips_cte.c.parent_station.label("rt_trip_first_stop"),
+        ).select_from(
+            rt_trips_cte
+        ).where(
+            rt_trips_cte.c.rt_trip_first_stop_flag == sa.true()
+        )
+    ).cte(name="first_stop_rt_cte")
+
+    rt_trips_summary_cte = (
+        sa.select(
+            rt_trips_cte.c.fk_static_timestamp.label("timestamp"),
+            rt_trips_cte.c.trip_hash,
+            rt_trips_cte.c.direction_id,
+            rt_trips_cte.c.route_id,
+            rt_trips_cte.c.start_date,
+            rt_trips_cte.c.start_time,
+            rt_trips_cte.c.vehicle_id,
+            first_stop_rt_cte.c.rt_trip_first_stop,
+            rt_trips_cte.c.parent_station.label("rt_trip_last_stop"),
+            rt_trips_cte.c.rt_trip_stop_rank.label("rt_stop_count")
+        ).select_from(
+            rt_trips_cte
+        ).join(
+            first_stop_rt_cte,
+            rt_trips_cte.c.trip_hash == first_stop_rt_cte.c.trip_hash
+        ).where(
+            rt_trips_cte.c.rt_trip_last_stop_flag == sa.true()
+        )
+    ).cte(name="rt_trips_summary_cte")
+
+    exact_trips_match = (
+        sa.select(
+            rt_trips_summary_cte.c.timestamp,
+            rt_trips_summary_cte.c.trip_hash,
+            rt_trips_summary_cte.c.direction_id,
+            rt_trips_summary_cte.c.route_id,
+            rt_trips_summary_cte.c.start_date,
+            rt_trips_summary_cte.c.start_time,
+            rt_trips_summary_cte.c.vehicle_id,
+            rt_trips_summary_cte.c.rt_stop_count,
+            static_trips_summary_cte.c.static_trip_id,
+            static_trips_summary_cte.c.static_start_time,
+            static_trips_summary_cte.c.static_stop_count,
+            sa.literal(True).label("first_last_station_match"),
+        ).distinct(
+            rt_trips_summary_cte.c.trip_hash,
+        ).select_from(
+            rt_trips_summary_cte
+        ).join(
+            static_trips_summary_cte,
+            sa.and_(
+                rt_trips_summary_cte.c.timestamp == static_trips_summary_cte.c.timestamp,
+                rt_trips_summary_cte.c.direction_id == static_trips_summary_cte.c.direction_id,
+                rt_trips_summary_cte.c.route_id == static_trips_summary_cte.c.route_id,
+                rt_trips_summary_cte.c.rt_trip_first_stop == static_trips_summary_cte.c.static_trip_first_stop,
+                rt_trips_summary_cte.c.rt_trip_last_stop == static_trips_summary_cte.c.static_trip_last_stop,
+                sa.func.abs(rt_trips_summary_cte.c.start_time - static_trips_summary_cte.c.static_start_time) < 3600,
+            ),
+            isouter=True
+        ).order_by(
+            rt_trips_summary_cte.c.trip_hash,
+            sa.func.abs(rt_trips_summary_cte.c.start_time - static_trips_summary_cte.c.static_start_time),
+        )
+    ).cte(name="exact_trips_match")
+
+    backup_trips_match = (
+        sa.select(
+            exact_trips_match.c.timestamp,
+            exact_trips_match.c.trip_hash,
+            exact_trips_match.c.direction_id,
+            exact_trips_match.c.route_id,
+            exact_trips_match.c.start_date,
+            exact_trips_match.c.start_time,
+            exact_trips_match.c.vehicle_id,
+            exact_trips_match.c.rt_stop_count,
+            static_trips_summary_cte.c.static_trip_id,
+            static_trips_summary_cte.c.static_start_time,
+            static_trips_summary_cte.c.static_stop_count,
+            sa.literal(False).label("first_last_station_match"),
+        ).distinct(
+            exact_trips_match.c.trip_hash,
+        ).select_from(
+            exact_trips_match
+        ).join(
+            static_trips_summary_cte,
+            sa.and_(
+                exact_trips_match.c.timestamp == static_trips_summary_cte.c.timestamp,
+                exact_trips_match.c.direction_id == static_trips_summary_cte.c.direction_id,
+                exact_trips_match.c.route_id == static_trips_summary_cte.c.route_id,
+            ),
+        ).where(
+            exact_trips_match.c.static_trip_id == None
+        ).order_by(
+            exact_trips_match.c.trip_hash,
+            sa.func.abs(exact_trips_match.c.start_time - static_trips_summary_cte.c.static_start_time),
+        )
+    ).cte(name="backup_trips_match")
+
+    all_new_trips = (
+        sa.union(
+            sa.select(exact_trips_match).where(exact_trips_match.c.static_trip_id != None),
+            sa.select(backup_trips_match),
+        )
+    ).cte(name="all_new_trips")
+
+    update_insert_query = (
+        sa.select(
+            all_new_trips.c.trip_hash,
+            VehicleTrips.trip_hash.label("existing_trip_hash"),
+            all_new_trips.c.direction_id,
+            all_new_trips.c.route_id,
+            all_new_trips.c.start_date,
+            all_new_trips.c.start_time,
+            all_new_trips.c.vehicle_id,
+            all_new_trips.c.rt_stop_count.label("stop_count"),
+            all_new_trips.c.static_trip_id.label("static_trip_id_guess"),
+            all_new_trips.c.static_start_time,
+            all_new_trips.c.static_stop_count,
+            all_new_trips.c.first_last_station_match,
+            sa.case(
+                [
+                    (
+                        sa.or_(
+                            all_new_trips.c.rt_stop_count != VehicleTrips.stop_count,
+                            all_new_trips.c.static_trip_id != VehicleTrips.static_trip_id_guess,
+                            all_new_trips.c.static_start_time != VehicleTrips.static_start_time,
+                            all_new_trips.c.static_stop_count != VehicleTrips.static_stop_count,
+                            all_new_trips.c.first_last_station_match != VehicleTrips.first_last_station_match,
+                        ),
+                        sa.literal(True)
+                    )
+                ],
+                else_=sa.literal(False),
+            ).label("to_update")
+        ).select_from(
+            all_new_trips
+        ).join(
+            VehicleTrips,
+            sa.and_(
+                all_new_trips.c.trip_hash == VehicleTrips.trip_hash,
+                VehicleTrips.start_date == seed_start_date,
+            ),
+            isouter=True,
+        )
+    )
+
+    update_insert_trips = db_manager.select_as_dataframe(update_insert_query)
+
+    if update_insert_trips.shape[0] == 0:
+        process_logger.add_metadata(
+            trip_insert_count=0,
+            trip_update_count=0,
+        )
+        process_logger.log_complete()
+        return
+
+
+    update_mask = (
+        (update_insert_trips["existing_trip_hash"].notna())
+        & (update_insert_trips["to_update"] == True)
+    )
+    insert_mask = update_insert_trips["existing_trip_hash"].isna()
+
+    process_logger.add_metadata(
+        trip_insert_count=insert_mask.sum(),
+        trip_update_count=update_mask.sum(),
+    )
+
+    if update_mask.sum() > 0:
+        update_cols = [
+            "trip_hash",
+            "stop_count",
+            "static_trip_id_guess",
+            "static_start_time",
+            "static_stop_count",
+            "first_last_station_match"
+        ]
+        db_manager.execute_with_data(
+            sa.update(VehicleTrips.__table__).where(
+                VehicleTrips.trip_hash == sa.bindparam("b_trip_hash"),
+            ),
+            update_insert_trips.loc[update_mask, update_cols].rename(
+                columns={"trip_hash":"b_trip_hash"}
+            )
+        )
+    
+    if insert_mask.sum() > 0:
+        insert_cols = [
+            "trip_hash",
+            "direction_id",
+            "route_id",
+            "start_date",
+            "start_time",
+            "vehicle_id",
+            "stop_count",
+            "static_trip_id_guess",
+            "static_start_time",
+            "static_stop_count",
+            "first_last_station_match"
+        ]
+        db_manager.execute_with_data(
+            sa.insert(VehicleTrips.__table__),
+            update_insert_trips.loc[insert_mask, insert_cols]
+        )
+
+    process_logger.log_complete()
+
+
+def process_trips_and_metrics(db_manager: DatabaseManager) -> None:
+    try:
+        seed_data = get_seed_data(db_manager)
+        process_trips_tables(db_manager, seed_data)
+
+    except Exception as e:
+        logging.exception(e)

--- a/performance_manager/lib/l1_rt_metrics.py
+++ b/performance_manager/lib/l1_rt_metrics.py
@@ -1,7 +1,8 @@
-
-import sqlalchemy as sa
-from typing import Dict, List
+from typing import Dict, List, Any
 import logging
+
+import numpy
+import sqlalchemy as sa
 
 from .logging_utils import ProcessLogger
 from .postgres_utils import DatabaseManager
@@ -13,7 +14,9 @@ from .postgres_schema import (
 from .l1_cte_statements import (
     get_rt_trips_cte,
     get_static_trips_cte,
+    get_trips_for_metrics,
 )
+
 
 def get_seed_data(db_manager: DatabaseManager) -> Dict[int, List[int]]:
     """
@@ -21,33 +24,31 @@ def get_seed_data(db_manager: DatabaseManager) -> Dict[int, List[int]]:
 
     return: Dict[start_date:int : List[fk_static_timestamps]]
     """
-    last_metric_update = (
-        sa.select(
-            sa.func.coalesce(
-                    sa.func.max(VehicleTrips.updated_on),
-                    sa.func.to_timestamp(0),
-            )
-        ).scalar_subquery()
-    )
+    last_metric_update = sa.select(
+        sa.func.coalesce(
+            sa.func.max(VehicleTrips.updated_on),
+            sa.func.to_timestamp(0),
+        )
+    ).scalar_subquery()
 
     seed_query = (
         sa.select(
             VehicleEvents.start_date,
             VehicleEvents.fk_static_timestamp,
-        ).distinct(
+        )
+        .distinct(
             VehicleEvents.start_date,
             VehicleEvents.fk_static_timestamp,
-        ).where(
-            VehicleEvents.updated_on > last_metric_update
-        ).order_by(
-            VehicleEvents.start_date
-        ).limit(100)
+        )
+        .where(VehicleEvents.updated_on > last_metric_update)
+        .order_by(VehicleEvents.start_date)
+        .limit(100)
     )
 
     # returns empty list if no records to process
     seed_data = db_manager.select_as_list(seed_query)
 
-    seed_data_return: Dict[int, List[int]] = {}
+    seed_data_return: Dict[Any, List[Any]] = {}
     for record in seed_data:
         start_date = record.get("start_date")
         timestamp = record.get("fk_static_timestamp")
@@ -58,32 +59,42 @@ def get_seed_data(db_manager: DatabaseManager) -> Dict[int, List[int]]:
 
     return seed_data_return
 
-def process_trips_tables(db_manager: DatabaseManager, seed_data: Dict[int, List[int]]) -> None:
+
+def process_tables(
+    db_manager: DatabaseManager, seed_data: Dict[int, List[int]]
+) -> None:
     """
-    process updates to multiple trips tables
+    process updates to multiple days of trips
     """
 
-    MAX_TABLES_TO_PROCESS = 3
+    max_days_to_process = 3
 
-    process_logger = ProcessLogger("l1_rt_trips_tables_loader", seed_data_size=len(seed_data))
+    process_logger = ProcessLogger(
+        "l1_tables_loader", seed_data_size=len(seed_data)
+    )
     process_logger.log_start()
 
-    tables_processed=0
-    for seed_start_date in sorted(seed_data.keys())[:MAX_TABLES_TO_PROCESS]:
+    days_processed = 0
+    for seed_start_date in sorted(seed_data.keys())[:max_days_to_process]:
         seed_timestamps = seed_data[seed_start_date]
         process_trips_table(db_manager, seed_start_date, seed_timestamps)
-        tables_processed += 1
+        process_metrics_table(db_manager, seed_start_date, seed_timestamps)
+        days_processed += 1
 
-    process_logger.add_metadata(tables_processed=tables_processed)
+    process_logger.add_metadata(days_processed=days_processed)
     process_logger.log_complete()
 
 
-def process_trips_table(db_manager: DatabaseManager, seed_start_date: int, seed_timestamps: List[int]) -> None:
+# pylint: disable=R0914
+# pylint too many local variables (more than 15)
+def process_trips_table(
+    db_manager: DatabaseManager,
+    seed_start_date: int,
+    seed_timestamps: List[int],
+) -> None:
     """
     processs updates to trips table
 
-    will only process one days worth of trips data per run, but can be modfied
-    to process additional says provided in seed_data
     """
     process_logger = ProcessLogger("l1_rt_trips_table_loader")
     process_logger.log_start()
@@ -96,11 +107,10 @@ def process_trips_table(db_manager: DatabaseManager, seed_start_date: int, seed_
             static_trips_cte.c.static_trip_id,
             static_trips_cte.c.static_stop_timestamp.label("static_start_time"),
             static_trips_cte.c.parent_station.label("static_trip_first_stop"),
-        ).select_from(
-            static_trips_cte
-        ).where(
-            static_trips_cte.c.static_trip_first_stop == sa.true()
-        ).cte(name="first_stop_static_cte")
+        )
+        .select_from(static_trips_cte)
+        .where(static_trips_cte.c.static_trip_first_stop == sa.true())
+        .cte(name="first_stop_static_cte")
     )
 
     static_trips_summary_cte = (
@@ -113,17 +123,19 @@ def process_trips_table(db_manager: DatabaseManager, seed_start_date: int, seed_
             first_stop_static_cte.c.static_trip_first_stop,
             static_trips_cte.c.parent_station.label("static_trip_last_stop"),
             static_trips_cte.c.static_trip_stop_rank.label("static_stop_count"),
-        ).select_from(
-            static_trips_cte
-        ).join(
+        )
+        .select_from(static_trips_cte)
+        .join(
             first_stop_static_cte,
             sa.and_(
-                static_trips_cte.c.timestamp == first_stop_static_cte.c.timestamp,
-                static_trips_cte.c.static_trip_id == first_stop_static_cte.c.static_trip_id,
-            )
-        ).where(
-            static_trips_cte.c.static_trip_last_stop == sa.true()
-        ).cte(name="static_trips_summary_cte")
+                static_trips_cte.c.timestamp
+                == first_stop_static_cte.c.timestamp,
+                static_trips_cte.c.static_trip_id
+                == first_stop_static_cte.c.static_trip_id,
+            ),
+        )
+        .where(static_trips_cte.c.static_trip_last_stop == sa.true())
+        .cte(name="static_trips_summary_cte")
     )
 
     rt_trips_cte = get_rt_trips_cte(seed_start_date)
@@ -132,11 +144,9 @@ def process_trips_table(db_manager: DatabaseManager, seed_start_date: int, seed_
         sa.select(
             rt_trips_cte.c.trip_hash,
             rt_trips_cte.c.parent_station.label("rt_trip_first_stop"),
-        ).select_from(
-            rt_trips_cte
-        ).where(
-            rt_trips_cte.c.rt_trip_first_stop_flag == sa.true()
         )
+        .select_from(rt_trips_cte)
+        .where(rt_trips_cte.c.rt_trip_first_stop_flag == sa.true())
     ).cte(name="first_stop_rt_cte")
 
     rt_trips_summary_cte = (
@@ -150,15 +160,14 @@ def process_trips_table(db_manager: DatabaseManager, seed_start_date: int, seed_
             rt_trips_cte.c.vehicle_id,
             first_stop_rt_cte.c.rt_trip_first_stop,
             rt_trips_cte.c.parent_station.label("rt_trip_last_stop"),
-            rt_trips_cte.c.rt_trip_stop_rank.label("rt_stop_count")
-        ).select_from(
-            rt_trips_cte
-        ).join(
-            first_stop_rt_cte,
-            rt_trips_cte.c.trip_hash == first_stop_rt_cte.c.trip_hash
-        ).where(
-            rt_trips_cte.c.rt_trip_last_stop_flag == sa.true()
+            rt_trips_cte.c.rt_trip_stop_rank.label("rt_stop_count"),
         )
+        .select_from(rt_trips_cte)
+        .join(
+            first_stop_rt_cte,
+            rt_trips_cte.c.trip_hash == first_stop_rt_cte.c.trip_hash,
+        )
+        .where(rt_trips_cte.c.rt_trip_last_stop_flag == sa.true())
     ).cte(name="rt_trips_summary_cte")
 
     exact_trips_match = (
@@ -175,24 +184,38 @@ def process_trips_table(db_manager: DatabaseManager, seed_start_date: int, seed_
             static_trips_summary_cte.c.static_start_time,
             static_trips_summary_cte.c.static_stop_count,
             sa.literal(True).label("first_last_station_match"),
-        ).distinct(
+        )
+        .distinct(
             rt_trips_summary_cte.c.trip_hash,
-        ).select_from(
-            rt_trips_summary_cte
-        ).join(
+        )
+        .select_from(rt_trips_summary_cte)
+        .join(
             static_trips_summary_cte,
             sa.and_(
-                rt_trips_summary_cte.c.timestamp == static_trips_summary_cte.c.timestamp,
-                rt_trips_summary_cte.c.direction_id == static_trips_summary_cte.c.direction_id,
-                rt_trips_summary_cte.c.route_id == static_trips_summary_cte.c.route_id,
-                rt_trips_summary_cte.c.rt_trip_first_stop == static_trips_summary_cte.c.static_trip_first_stop,
-                rt_trips_summary_cte.c.rt_trip_last_stop == static_trips_summary_cte.c.static_trip_last_stop,
-                sa.func.abs(rt_trips_summary_cte.c.start_time - static_trips_summary_cte.c.static_start_time) < 3600,
+                rt_trips_summary_cte.c.timestamp
+                == static_trips_summary_cte.c.timestamp,
+                rt_trips_summary_cte.c.direction_id
+                == static_trips_summary_cte.c.direction_id,
+                rt_trips_summary_cte.c.route_id
+                == static_trips_summary_cte.c.route_id,
+                rt_trips_summary_cte.c.rt_trip_first_stop
+                == static_trips_summary_cte.c.static_trip_first_stop,
+                rt_trips_summary_cte.c.rt_trip_last_stop
+                == static_trips_summary_cte.c.static_trip_last_stop,
+                sa.func.abs(
+                    rt_trips_summary_cte.c.start_time
+                    - static_trips_summary_cte.c.static_start_time
+                )
+                < 3600,
             ),
-            isouter=True
-        ).order_by(
+            isouter=True,
+        )
+        .order_by(
             rt_trips_summary_cte.c.trip_hash,
-            sa.func.abs(rt_trips_summary_cte.c.start_time - static_trips_summary_cte.c.static_start_time),
+            sa.func.abs(
+                rt_trips_summary_cte.c.start_time
+                - static_trips_summary_cte.c.static_start_time
+            ),
         )
     ).cte(name="exact_trips_match")
 
@@ -210,28 +233,38 @@ def process_trips_table(db_manager: DatabaseManager, seed_start_date: int, seed_
             static_trips_summary_cte.c.static_start_time,
             static_trips_summary_cte.c.static_stop_count,
             sa.literal(False).label("first_last_station_match"),
-        ).distinct(
+        )
+        .distinct(
             exact_trips_match.c.trip_hash,
-        ).select_from(
-            exact_trips_match
-        ).join(
+        )
+        .select_from(exact_trips_match)
+        .join(
             static_trips_summary_cte,
             sa.and_(
-                exact_trips_match.c.timestamp == static_trips_summary_cte.c.timestamp,
-                exact_trips_match.c.direction_id == static_trips_summary_cte.c.direction_id,
-                exact_trips_match.c.route_id == static_trips_summary_cte.c.route_id,
+                exact_trips_match.c.timestamp
+                == static_trips_summary_cte.c.timestamp,
+                exact_trips_match.c.direction_id
+                == static_trips_summary_cte.c.direction_id,
+                exact_trips_match.c.route_id
+                == static_trips_summary_cte.c.route_id,
             ),
-        ).where(
-            exact_trips_match.c.static_trip_id == None
-        ).order_by(
+            isouter=True,
+        )
+        .where(exact_trips_match.c.static_trip_id.is_(None))
+        .order_by(
             exact_trips_match.c.trip_hash,
-            sa.func.abs(exact_trips_match.c.start_time - static_trips_summary_cte.c.static_start_time),
+            sa.func.abs(
+                exact_trips_match.c.start_time
+                - static_trips_summary_cte.c.static_start_time
+            ),
         )
     ).cte(name="backup_trips_match")
 
     all_new_trips = (
         sa.union(
-            sa.select(exact_trips_match).where(exact_trips_match.c.static_trip_id != None),
+            sa.select(exact_trips_match).where(
+                exact_trips_match.c.static_trip_id.is_not(None)
+            ),
             sa.select(backup_trips_match),
         )
     ).cte(name="all_new_trips")
@@ -242,6 +275,15 @@ def process_trips_table(db_manager: DatabaseManager, seed_start_date: int, seed_
             VehicleTrips.trip_hash.label("existing_trip_hash"),
             all_new_trips.c.direction_id,
             all_new_trips.c.route_id,
+            sa.case(
+                [
+                    (
+                        all_new_trips.c.route_id.like("Green%"),
+                        sa.literal("Green"),
+                    ),
+                ],
+                else_=all_new_trips.c.route_id,
+            ).label("trunk_route_id"),
             all_new_trips.c.start_date,
             all_new_trips.c.start_time,
             all_new_trips.c.vehicle_id,
@@ -254,20 +296,25 @@ def process_trips_table(db_manager: DatabaseManager, seed_start_date: int, seed_
                 [
                     (
                         sa.or_(
-                            all_new_trips.c.rt_stop_count != VehicleTrips.stop_count,
-                            all_new_trips.c.static_trip_id != VehicleTrips.static_trip_id_guess,
-                            all_new_trips.c.static_start_time != VehicleTrips.static_start_time,
-                            all_new_trips.c.static_stop_count != VehicleTrips.static_stop_count,
-                            all_new_trips.c.first_last_station_match != VehicleTrips.first_last_station_match,
+                            all_new_trips.c.rt_stop_count
+                            != VehicleTrips.stop_count,
+                            all_new_trips.c.static_trip_id
+                            != VehicleTrips.static_trip_id_guess,
+                            all_new_trips.c.static_start_time
+                            != VehicleTrips.static_start_time,
+                            all_new_trips.c.static_stop_count
+                            != VehicleTrips.static_stop_count,
+                            all_new_trips.c.first_last_station_match
+                            != VehicleTrips.first_last_station_match,
                         ),
-                        sa.literal(True)
+                        sa.literal(True),
                     )
                 ],
                 else_=sa.literal(False),
-            ).label("to_update")
-        ).select_from(
-            all_new_trips
-        ).join(
+            ).label("to_update"),
+        )
+        .select_from(all_new_trips)
+        .join(
             VehicleTrips,
             sa.and_(
                 all_new_trips.c.trip_hash == VehicleTrips.trip_hash,
@@ -287,11 +334,28 @@ def process_trips_table(db_manager: DatabaseManager, seed_start_date: int, seed_
         process_logger.log_complete()
         return
 
+    update_insert_trips["start_date"] = update_insert_trips[
+        "start_date"
+    ].astype("int64")
+    update_insert_trips["start_time"] = update_insert_trips[
+        "start_time"
+    ].astype("int64")
+    update_insert_trips["stop_count"] = update_insert_trips[
+        "stop_count"
+    ].astype("int64")
+    update_insert_trips["static_start_time"] = update_insert_trips[
+        "static_start_time"
+    ].astype("Int64")
+    update_insert_trips["static_stop_count"] = update_insert_trips[
+        "static_stop_count"
+    ].astype("Int64")
+    update_insert_trips = update_insert_trips.fillna(numpy.nan).replace(
+        [numpy.nan], [None]
+    )
 
     update_mask = (
-        (update_insert_trips["existing_trip_hash"].notna())
-        & (update_insert_trips["to_update"] == True)
-    )
+        update_insert_trips["existing_trip_hash"].notna()
+    ) & numpy.equal(update_insert_trips["to_update"], True)
     insert_mask = update_insert_trips["existing_trip_hash"].isna()
 
     process_logger.add_metadata(
@@ -306,22 +370,23 @@ def process_trips_table(db_manager: DatabaseManager, seed_start_date: int, seed_
             "static_trip_id_guess",
             "static_start_time",
             "static_stop_count",
-            "first_last_station_match"
+            "first_last_station_match",
         ]
         db_manager.execute_with_data(
             sa.update(VehicleTrips.__table__).where(
                 VehicleTrips.trip_hash == sa.bindparam("b_trip_hash"),
             ),
             update_insert_trips.loc[update_mask, update_cols].rename(
-                columns={"trip_hash":"b_trip_hash"}
-            )
+                columns={"trip_hash": "b_trip_hash"}
+            ),
         )
-    
+
     if insert_mask.sum() > 0:
         insert_cols = [
             "trip_hash",
             "direction_id",
             "route_id",
+            "trunk_route_id",
             "start_date",
             "start_time",
             "vehicle_id",
@@ -329,20 +394,311 @@ def process_trips_table(db_manager: DatabaseManager, seed_start_date: int, seed_
             "static_trip_id_guess",
             "static_start_time",
             "static_stop_count",
-            "first_last_station_match"
+            "first_last_station_match",
         ]
         db_manager.execute_with_data(
             sa.insert(VehicleTrips.__table__),
-            update_insert_trips.loc[insert_mask, insert_cols]
+            update_insert_trips.loc[insert_mask, insert_cols],
+        )
+
+    process_logger.log_complete()
+
+
+# pylint: enable=R0914
+
+
+def process_metrics_table(
+    db_manager: DatabaseManager,
+    seed_start_date: int,
+    seed_timestamps: List[int],
+) -> None:
+    """
+    processs updates to metrics table
+
+    """
+
+    process_logger = ProcessLogger("l1_rt_metrics_table_loader")
+    process_logger.log_start()
+
+    trips_for_metrics = get_trips_for_metrics(seed_timestamps, seed_start_date)
+
+    travel_times_cte = (
+        sa.select(
+            trips_for_metrics.c.trip_stop_hash,
+            (
+                trips_for_metrics.c.stop_timestamp
+                - trips_for_metrics.c.move_timestamp
+            ).label("travel_time_seconds"),
+        )
+        .where(
+            trips_for_metrics.c.first_stop_flag == sa.false(),
+            trips_for_metrics.c.stop_timestamp
+            > trips_for_metrics.c.move_timestamp,
+        )
+        .cte(name="travel_times")
+    )
+
+    dwell_times_cte = (
+        sa.select(
+            trips_for_metrics.c.trip_stop_hash,
+            sa.case(
+                [
+                    (
+                        sa.and_(
+                            trips_for_metrics.c.last_stop_flag == sa.false(),
+                            trips_for_metrics.c.first_stop_flag == sa.false(),
+                        ),
+                        sa.func.lead(trips_for_metrics.c.move_timestamp,).over(
+                            partition_by=trips_for_metrics.c.vehicle_id,
+                            order_by=trips_for_metrics.c.sort_timestamp,
+                        )
+                        - trips_for_metrics.c.stop_timestamp,
+                    ),
+                    (
+                        trips_for_metrics.c.first_stop_flag == sa.true(),
+                        sa.func.lead(trips_for_metrics.c.move_timestamp,).over(
+                            partition_by=trips_for_metrics.c.vehicle_id,
+                            order_by=trips_for_metrics.c.sort_timestamp,
+                        )
+                        - sa.func.lag(trips_for_metrics.c.stop_timestamp,).over(
+                            partition_by=trips_for_metrics.c.vehicle_id,
+                            order_by=trips_for_metrics.c.sort_timestamp,
+                        ),
+                    ),
+                ],
+                else_=sa.literal(None),
+            ).label("dwell_time_seconds"),
+        )
+        .where(
+            sa.or_(
+                trips_for_metrics.c.stop_count > 1,
+                trips_for_metrics.c.first_stop_flag == sa.false(),
+            ),
+        )
+        .cte(name="dwell_times")
+    )
+
+    headways_cte = (
+        sa.select(
+            trips_for_metrics.c.trip_stop_hash,
+            sa.case(
+                [
+                    (
+                        trips_for_metrics.c.first_stop_flag == sa.false(),
+                        trips_for_metrics.c.stop_timestamp
+                        - sa.func.lag(trips_for_metrics.c.stop_timestamp,).over(
+                            partition_by=(
+                                trips_for_metrics.c.parent_station,
+                                trips_for_metrics.c.route_id,
+                                trips_for_metrics.c.direction_id,
+                            ),
+                            order_by=trips_for_metrics.c.sort_timestamp,
+                        ),
+                    ),
+                ],
+                else_=trips_for_metrics.c.next_station_move
+                - sa.func.lag(trips_for_metrics.c.next_station_move,).over(
+                    partition_by=(
+                        trips_for_metrics.c.parent_station,
+                        trips_for_metrics.c.route_id,
+                        trips_for_metrics.c.direction_id,
+                    ),
+                    order_by=trips_for_metrics.c.sort_timestamp,
+                ),
+            ).label("headway_branch_seconds"),
+            sa.case(
+                [
+                    (
+                        trips_for_metrics.c.first_stop_flag == sa.false(),
+                        trips_for_metrics.c.stop_timestamp
+                        - sa.func.lag(trips_for_metrics.c.stop_timestamp,).over(
+                            partition_by=(
+                                trips_for_metrics.c.parent_station,
+                                trips_for_metrics.c.trunk_route_id,
+                                trips_for_metrics.c.direction_id,
+                            ),
+                            order_by=trips_for_metrics.c.sort_timestamp,
+                        ),
+                    ),
+                ],
+                else_=trips_for_metrics.c.next_station_move
+                - sa.func.lag(trips_for_metrics.c.next_station_move,).over(
+                    partition_by=(
+                        trips_for_metrics.c.parent_station,
+                        trips_for_metrics.c.trunk_route_id,
+                        trips_for_metrics.c.direction_id,
+                    ),
+                    order_by=trips_for_metrics.c.sort_timestamp,
+                ),
+            ).label("headway_trunk_seconds"),
+        )
+        .where(
+            sa.or_(
+                trips_for_metrics.c.stop_count > 1,
+                trips_for_metrics.c.first_stop_flag == sa.false(),
+            )
+        )
+        .cte(name="headways")
+    )
+
+    all_new_metrics = (
+        sa.select(
+            sa.func.coalesce(
+                travel_times_cte.c.trip_stop_hash,
+                dwell_times_cte.c.trip_stop_hash,
+                headways_cte.c.trip_stop_hash,
+            ).label("trip_stop_hash"),
+            travel_times_cte.c.travel_time_seconds,
+            dwell_times_cte.c.dwell_time_seconds,
+            headways_cte.c.headway_branch_seconds,
+            headways_cte.c.headway_trunk_seconds,
+        )
+        .select_from(
+            travel_times_cte,
+        )
+        .join(
+            dwell_times_cte,
+            sa.and_(
+                travel_times_cte.c.trip_stop_hash
+                == dwell_times_cte.c.trip_stop_hash,
+                sa.func.coalesce(dwell_times_cte.c.dwell_time_seconds, 0) > 0,
+            ),
+            full=True,
+        )
+        .join(
+            headways_cte,
+            sa.and_(
+                sa.func.coalesce(
+                    travel_times_cte.c.trip_stop_hash,
+                    dwell_times_cte.c.trip_stop_hash,
+                )
+                == headways_cte.c.trip_stop_hash,
+                sa.or_(
+                    sa.func.coalesce(headways_cte.c.headway_branch_seconds, 0)
+                    > 0,
+                    sa.func.coalesce(headways_cte.c.headway_trunk_seconds, 0)
+                    > 0,
+                ),
+            ),
+            full=True,
+        )
+        .where(
+            sa.or_(
+                sa.func.coalesce(travel_times_cte.c.travel_time_seconds, 0) > 0,
+                sa.func.coalesce(dwell_times_cte.c.dwell_time_seconds, 0) > 0,
+                sa.func.coalesce(headways_cte.c.headway_branch_seconds, 0) > 0,
+                sa.func.coalesce(headways_cte.c.headway_trunk_seconds, 0) > 0,
+            ),
+        )
+    ).cte(name="all_new_metrics")
+
+    update_insert_query = (
+        sa.select(
+            all_new_metrics.c.trip_stop_hash,
+            VehicleEventMetrics.trip_stop_hash.label("existing_trip_stop_hash"),
+            all_new_metrics.c.travel_time_seconds,
+            all_new_metrics.c.dwell_time_seconds,
+            all_new_metrics.c.headway_branch_seconds,
+            all_new_metrics.c.headway_trunk_seconds,
+            sa.case(
+                [
+                    (
+                        sa.or_(
+                            all_new_metrics.c.travel_time_seconds
+                            != VehicleEventMetrics.travel_time_seconds,
+                            all_new_metrics.c.dwell_time_seconds
+                            != VehicleEventMetrics.dwell_time_seconds,
+                            all_new_metrics.c.headway_branch_seconds
+                            != VehicleEventMetrics.headway_branch_seconds,
+                            all_new_metrics.c.headway_trunk_seconds
+                            != VehicleEventMetrics.headway_trunk_seconds,
+                        ),
+                        sa.literal(True),
+                    )
+                ],
+                else_=sa.literal(False),
+            ).label("to_update"),
+        )
+        .select_from(all_new_metrics)
+        .join(
+            VehicleEventMetrics,
+            all_new_metrics.c.trip_stop_hash
+            == VehicleEventMetrics.trip_stop_hash,
+            isouter=True,
+        )
+        .where(all_new_metrics.c.travel_time_seconds > 0)
+    )
+
+    update_insert_metrics = db_manager.select_as_dataframe(update_insert_query)
+
+    if update_insert_metrics.shape[0] == 0:
+        process_logger.add_metadata(
+            metric_insert_count=0,
+            metric_update_count=0,
+        )
+        process_logger.log_complete()
+        return
+
+    update_insert_metrics["travel_time_seconds"] = update_insert_metrics[
+        "travel_time_seconds"
+    ].astype("Int64")
+    update_insert_metrics["dwell_time_seconds"] = update_insert_metrics[
+        "dwell_time_seconds"
+    ].astype("Int64")
+    update_insert_metrics["headway_branch_seconds"] = update_insert_metrics[
+        "headway_branch_seconds"
+    ].astype("Int64")
+    update_insert_metrics["headway_trunk_seconds"] = update_insert_metrics[
+        "headway_trunk_seconds"
+    ].astype("Int64")
+    update_insert_metrics = update_insert_metrics.fillna(numpy.nan).replace(
+        [numpy.nan], [None]
+    )
+
+    update_mask = (
+        update_insert_metrics["existing_trip_stop_hash"].notna()
+    ) & numpy.equal(update_insert_metrics["to_update"], True)
+    insert_mask = update_insert_metrics["existing_trip_stop_hash"].isna()
+
+    process_logger.add_metadata(
+        metric_insert_count=insert_mask.sum(),
+        metric_update_count=update_mask.sum(),
+    )
+
+    db_columns = [
+        "trip_stop_hash",
+        "travel_time_seconds",
+        "dwell_time_seconds",
+        "headway_branch_seconds",
+        "headway_trunk_seconds",
+    ]
+    if update_mask.sum() > 0:
+        db_manager.execute_with_data(
+            sa.update(VehicleEventMetrics.__table__).where(
+                VehicleEventMetrics.trip_stop_hash
+                == sa.bindparam("b_trip_stop_hash"),
+            ),
+            update_insert_metrics.loc[update_mask, db_columns].rename(
+                columns={"trip_stop_hash": "b_trip_stop_hash"}
+            ),
+        )
+
+    if insert_mask.sum() > 0:
+        db_manager.execute_with_data(
+            sa.insert(VehicleEventMetrics.__table__),
+            update_insert_metrics.loc[insert_mask, db_columns],
         )
 
     process_logger.log_complete()
 
 
 def process_trips_and_metrics(db_manager: DatabaseManager) -> None:
+    """
+    insert and update trips and metrics tables, one day at a time
+    """
     try:
         seed_data = get_seed_data(db_manager)
-        process_trips_tables(db_manager, seed_data)
+        process_tables(db_manager, seed_data)
 
     except Exception as e:
         logging.exception(e)

--- a/performance_manager/lib/postgres_schema.py
+++ b/performance_manager/lib/postgres_schema.py
@@ -59,30 +59,25 @@ class VehicleEvents(SqlBase):  # pylint: disable=too-few-public-methods
 class VehicleTrips(SqlBase):  # pylint: disable=too-few-public-methods
     """
     Table that holds GTFS-RT Trips
-
-
     """
 
     __tablename__ = "vehicle_trips"
 
-    trip_hash = sa.Column(
-        sa.LargeBinary(16),
-        nullable=False,
-        primary_key=True
-    )
-    
+    trip_hash = sa.Column(sa.LargeBinary(16), nullable=False, primary_key=True)
+
     # trip identifiers
     direction_id = sa.Column(sa.Boolean, nullable=False)
     route_id = sa.Column(sa.String(60), nullable=False)
+    trunk_route_id = sa.Column(sa.String(60), nullable=False)
     start_date = sa.Column(sa.Integer, nullable=False)
     start_time = sa.Column(sa.Integer, nullable=False)
     vehicle_id = sa.Column(sa.String(60), nullable=False)
     stop_count = sa.Column(sa.SmallInteger, nullable=False)
 
     # static trip matching
-    static_trip_id_guess = sa.Column(sa.String(128), nullable=False)
-    static_start_time = sa.Column(sa.Integer, nullable=False)
-    static_stop_count = sa.Column(sa.SmallInteger, nullable=False)
+    static_trip_id_guess = sa.Column(sa.String(128), nullable=True)
+    static_start_time = sa.Column(sa.Integer, nullable=True)
+    static_stop_count = sa.Column(sa.SmallInteger, nullable=True)
     first_last_station_match = sa.Column(sa.Boolean, nullable=False)
 
     updated_on = sa.Column(sa.TIMESTAMP, server_default=sa.func.now())
@@ -96,9 +91,7 @@ class VehicleEventMetrics(SqlBase):  # pylint: disable=too-few-public-methods
     __tablename__ = "vehicle_event_metrics"
 
     trip_stop_hash = sa.Column(
-        sa.LargeBinary(16),
-        nullable=False,
-        primary_key=True
+        sa.LargeBinary(16), nullable=False, primary_key=True
     )
 
     travel_time_seconds = sa.Column(sa.Integer, nullable=True)

--- a/performance_manager/lib/postgres_schema.py
+++ b/performance_manager/lib/postgres_schema.py
@@ -56,6 +56,59 @@ class VehicleEvents(SqlBase):  # pylint: disable=too-few-public-methods
     updated_on = sa.Column(sa.TIMESTAMP, server_default=sa.func.now())
 
 
+class VehicleTrips(SqlBase):  # pylint: disable=too-few-public-methods
+    """
+    Table that holds GTFS-RT Trips
+
+
+    """
+
+    __tablename__ = "vehicle_trips"
+
+    trip_hash = sa.Column(
+        sa.LargeBinary(16),
+        nullable=False,
+        primary_key=True
+    )
+    
+    # trip identifiers
+    direction_id = sa.Column(sa.Boolean, nullable=False)
+    route_id = sa.Column(sa.String(60), nullable=False)
+    start_date = sa.Column(sa.Integer, nullable=False)
+    start_time = sa.Column(sa.Integer, nullable=False)
+    vehicle_id = sa.Column(sa.String(60), nullable=False)
+    stop_count = sa.Column(sa.SmallInteger, nullable=False)
+
+    # static trip matching
+    static_trip_id_guess = sa.Column(sa.String(128), nullable=False)
+    static_start_time = sa.Column(sa.Integer, nullable=False)
+    static_stop_count = sa.Column(sa.SmallInteger, nullable=False)
+    first_last_station_match = sa.Column(sa.Boolean, nullable=False)
+
+    updated_on = sa.Column(sa.TIMESTAMP, server_default=sa.func.now())
+
+
+class VehicleEventMetrics(SqlBase):  # pylint: disable=too-few-public-methods
+    """
+    Tables that holds pre-computed metrics for GTFS-RT Events
+    """
+
+    __tablename__ = "vehicle_event_metrics"
+
+    trip_stop_hash = sa.Column(
+        sa.LargeBinary(16),
+        nullable=False,
+        primary_key=True
+    )
+
+    travel_time_seconds = sa.Column(sa.Integer, nullable=True)
+    dwell_time_seconds = sa.Column(sa.Integer, nullable=True)
+    headway_trunk_seconds = sa.Column(sa.Integer, nullable=True)
+    headway_branch_seconds = sa.Column(sa.Integer, nullable=True)
+
+    updated_on = sa.Column(sa.TIMESTAMP, server_default=sa.func.now())
+
+
 class TempHashCompare(SqlBase):  # pylint: disable=too-few-public-methods
     """Hold temporary hash values for comparison to Vehicle Events table"""
 

--- a/performance_manager/startup.py
+++ b/performance_manager/startup.py
@@ -19,23 +19,7 @@ from lib import (
     process_trips_and_metrics,
 )
 
-
-
-# logging.getLogger().setLevel("INFO")
-
-formatter = logging.Formatter(logging.BASIC_FORMAT)
-
-fh = logging.FileHandler("error.log")
-fh.setLevel(logging.INFO)
-fh.setFormatter(formatter)
-
-sh = logging.StreamHandler()
-sh.setLevel(logging.INFO)
-sh.setFormatter(formatter)
-
-logging.getLogger().addHandler(sh)
-logging.getLogger().addHandler(fh)
-logging.getLogger().setLevel(logging.INFO)
+logging.getLogger().setLevel("INFO")
 
 DESCRIPTION = """Entry Point to Performance Manager"""
 HERE = os.path.dirname(os.path.abspath(__file__))
@@ -130,6 +114,20 @@ def parse_args(args: List[str]) -> argparse.Namespace:
         help="if set, verbose sql logging",
     )
 
+    parser.add_argument(
+        "--clear-rt",
+        action="store_true",
+        dest="clear_rt",
+        help="if set, clear gtfs-rt database tables",
+    )
+
+    parser.add_argument(
+        "--clear-static",
+        action="store_true",
+        dest="clear_static",
+        help="if set, clear gtfs static database tables",
+    )
+
     return parser.parse_args(args)
 
 
@@ -139,8 +137,12 @@ def main(args: argparse.Namespace) -> None:
     main_process_logger.log_start()
 
     # get the engine that manages sessions that read and write to the db
-    db_manager = DatabaseManager(verbose=args.verbose, seed=args.seed)
-    db_manager.reset_tables()
+    db_manager = DatabaseManager(
+        verbose=args.verbose,
+        seed=args.seed,
+        clear_rt=args.clear_rt,
+        clear_static=args.clear_static,
+    )
 
     # schedule object that will control the "event loop"
     scheduler = sched.scheduler(time.time, time.sleep)

--- a/performance_manager/startup.py
+++ b/performance_manager/startup.py
@@ -16,9 +16,26 @@ from lib import (
     process_gtfs_rt_files,
     handle_ecs_sigterm,
     check_for_sigterm,
+    process_trips_and_metrics,
 )
 
-logging.getLogger().setLevel("INFO")
+
+
+# logging.getLogger().setLevel("INFO")
+
+formatter = logging.Formatter(logging.BASIC_FORMAT)
+
+fh = logging.FileHandler("error.log")
+fh.setLevel(logging.INFO)
+fh.setFormatter(formatter)
+
+sh = logging.StreamHandler()
+sh.setLevel(logging.INFO)
+sh.setFormatter(formatter)
+
+logging.getLogger().addHandler(sh)
+logging.getLogger().addHandler(fh)
+logging.getLogger().setLevel(logging.INFO)
 
 DESCRIPTION = """Entry Point to Performance Manager"""
 HERE = os.path.dirname(os.path.abspath(__file__))
@@ -123,6 +140,7 @@ def main(args: argparse.Namespace) -> None:
 
     # get the engine that manages sessions that read and write to the db
     db_manager = DatabaseManager(verbose=args.verbose, seed=args.seed)
+    db_manager.reset_tables()
 
     # schedule object that will control the "event loop"
     scheduler = sched.scheduler(time.time, time.sleep)
@@ -138,6 +156,7 @@ def main(args: argparse.Namespace) -> None:
         try:
             process_static_tables(db_manager)
             process_gtfs_rt_files(db_manager)
+            process_trips_and_metrics(db_manager)
 
             process_logger.log_complete()
         except Exception as exception:


### PR DESCRIPTION
Working version of Trips table and Metrics table loading.

Lots of SQL business logic in this change. For both the Trips and Metrics table loading, all load and compare logic is done SQL server side. Update / Insert query cleanly pulls all records requiring update and insert into dataframe.

Additional comments are needed for SQL CTE's and identification of possible edge cases that are not currently being handled. 

Asana Task: https://app.asana.com/0/1203655790984044/1203879577067931
Asana Task: https://app.asana.com/0/1203655790984044/1203655790983994
Asana Task: https://app.asana.com/0/1203655790984044/1203655790983996
