### PR TITLE
Use one impl of file_list_from_s3

### DIFF
--- a/python_src/src/lamp_py/aws/__init__.py
+++ b/python_src/src/lamp_py/aws/__init__.py
@@ -2,8 +2,7 @@
 
 from .ecs import check_for_sigterm, handle_ecs_sigterm
 from .s3 import (
-    file_list_from_s3_ingestion,
-    file_list_from_s3_pm,
+    file_list_from_s3,
     get_utc_from_partition_path,
     get_zip_buffer,
     move_s3_objects,

--- a/python_src/src/lamp_py/aws/s3.py
+++ b/python_src/src/lamp_py/aws/s3.py
@@ -52,7 +52,7 @@ def get_zip_buffer(filename: str) -> Tuple[IO[bytes], int]:
     )
 
 
-def file_list_from_s3_ingestion(
+def file_list_from_s3(
     bucket_name: str, file_prefix: str, max_list_size: int = 250_000
 ) -> List[str]:
     """
@@ -89,29 +89,6 @@ def file_list_from_s3_ingestion(
     except Exception as exception:
         process_logger.log_failure(exception)
         return []
-
-
-def file_list_from_s3_pm(bucket_name: str, file_prefix: str) -> Iterator[str]:
-    """
-    generate filename, filesize tuples for every file in an s3 bucket
-
-    :param bucket_name: the name of the bucket to look inside of
-    :param file_prefix: prefix for files to generate
-
-    :yield filename, filesize tuples from inside of the bucket
-    """
-    s3_client = boto3.client("s3")
-    paginator = s3_client.get_paginator("list_objects_v2")
-    pages = paginator.paginate(Bucket=bucket_name, Prefix=file_prefix)
-    for page in pages:
-        if page["KeyCount"] == 0:
-            continue
-        for obj in page["Contents"]:
-            # skip if this object is a "directory"
-            if obj["Size"] == 0:
-                continue
-            uri = os.path.join("s3://", bucket_name, obj["Key"])
-            yield uri
 
 
 def _move_s3_object(filename: str, to_bucket: str) -> Optional[str]:

--- a/python_src/src/lamp_py/performance_manager/l0_gtfs_static_table.py
+++ b/python_src/src/lamp_py/performance_manager/l0_gtfs_static_table.py
@@ -7,7 +7,7 @@ import numpy
 import pandas
 import sqlalchemy as sa
 from lamp_py.aws.ecs import check_for_sigterm
-from lamp_py.aws.s3 import file_list_from_s3_pm, read_parquet
+from lamp_py.aws.s3 import file_list_from_s3, read_parquet
 from lamp_py.logging_utils import ProcessLogger
 from lamp_py.postgres.postgres_schema import (
     MetadataLog,
@@ -187,9 +187,7 @@ def get_static_parquet_paths(table_type: str, feed_info_path: str) -> List[str]:
     springboard_bucket = os.environ["SPRINGBOARD_BUCKET"]
     static_prefix = feed_info_path.replace("FEED_INFO", table_type)
     static_prefix = static_prefix.replace(f"{springboard_bucket}/", "")
-    return list(
-        uri for uri in file_list_from_s3_pm(springboard_bucket, static_prefix)
-    )
+    return file_list_from_s3(springboard_bucket, static_prefix)
 
 
 def load_parquet_files(

--- a/python_src/src/lamp_py/startup/start_ingestion.py
+++ b/python_src/src/lamp_py/startup/start_ingestion.py
@@ -9,7 +9,7 @@ import time
 import schedule
 
 from lamp_py.aws.ecs import handle_ecs_sigterm, check_for_sigterm
-from lamp_py.aws.s3 import file_list_from_s3_ingestion
+from lamp_py.aws.s3 import file_list_from_s3
 from lamp_py.import_env import load_environment
 from lamp_py.ingestion import ingest_files, DEFAULT_S3_PREFIX
 from lamp_py.logging_utils import ProcessLogger
@@ -65,7 +65,7 @@ def ingest(metadata_queue: Queue) -> None:
     process_logger = ProcessLogger("ingest_all")
     process_logger.log_start()
 
-    files = file_list_from_s3_ingestion(
+    files = file_list_from_s3(
         bucket_name=os.environ["INCOMING_BUCKET"],
         file_prefix=DEFAULT_S3_PREFIX,
     )

--- a/python_src/tests/aws/test_s3_utils.py
+++ b/python_src/tests/aws/test_s3_utils.py
@@ -14,7 +14,7 @@ import pytest
 from botocore.stub import Stubber
 from botocore.stub import ANY
 
-from lamp_py.aws.s3 import file_list_from_s3_ingestion
+from lamp_py.aws.s3 import file_list_from_s3
 from lamp_py.aws.s3 import move_s3_objects
 
 from ..test_resources import incoming_dir
@@ -45,7 +45,7 @@ def test_file_list_s3(s3_stub):  # type: ignore
     }
     s3_stub.add_response("list_objects_v2", page_obj_response, page_obj_params)
     with s3_stub:
-        files = list(file_list_from_s3_ingestion("mbta-gtfs-s3", ""))
+        files = file_list_from_s3("mbta-gtfs-s3", "")
 
     assert len(files) == page_obj_response["KeyCount"]
     assert not files
@@ -71,7 +71,7 @@ def test_file_list_s3(s3_stub):  # type: ignore
     }
     s3_stub.add_response("list_objects_v2", page_obj_response, page_obj_params)
     with s3_stub:
-        files = list(file_list_from_s3_ingestion("mbta-gtfs-s3", ""))
+        files = file_list_from_s3("mbta-gtfs-s3", "")
 
     assert len(files) == page_obj_response["KeyCount"]
     should_files = []
@@ -97,7 +97,7 @@ def test_file_list_s3(s3_stub):  # type: ignore
     s3_stub.add_response("list_objects_v2", page_obj_response, page_obj_params)
 
     with s3_stub:
-        files = list(file_list_from_s3_ingestion("mbta-gtfs-s3", ""))
+        files = file_list_from_s3("mbta-gtfs-s3", "")
 
     assert len(files) == page_obj_response["KeyCount"]
 


### PR DESCRIPTION
After combining both python packages into one, we were left with a duplicate `file_list_from_s3` functionality that had slightly different signatures (one had a threshold while the other didn't and one returned and iter of string while the other returned a list of them. We now just have on impl that all pipelines share.

* rename `file_list_from_s3_ingestion` as `file_list_from_s3` and use that one everywhere.
* get rid of itr -> list conversions that were surrounding the other impl that returned an itr
* remove uneeded imports from the aws.__init__.py file.

Asana Task: https://app.asana.com/0/0/1204188000578028/f
