### PR TITLE
cleanup python init files in subdirs

### DIFF
--- a/python_src/src/lamp_py/aws/__init__.py
+++ b/python_src/src/lamp_py/aws/__init__.py
@@ -1,14 +1,1 @@
 """ Suite of utilities for dealing with AWS infrastructure """
-
-from .ecs import check_for_sigterm, handle_ecs_sigterm
-from .s3 import (
-    file_list_from_s3,
-    get_utc_from_partition_path,
-    get_zip_buffer,
-    move_s3_objects,
-    read_parquet,
-    read_parquet_chunks,
-    write_parquet_file,
-)
-
-__version__ = "0.1.0"

--- a/python_src/src/lamp_py/ingestion/__init__.py
+++ b/python_src/src/lamp_py/ingestion/__init__.py
@@ -1,11 +1,5 @@
 """
-This module is used by CTD's LAMP application to process rt gtfs json formatted
-data and convert it into a parquet format for more efficient data analysis.
+Pipeline for processing ingesting GTFS static schedule files and GTFS real time
+files from an s3 bucket. The realtime files are collapsed into parquet files
+for long term storage.
 """
-
-from .converter import ConfigType
-from .error import ArgumentException
-from .ingest import ingest_files
-from .utils import group_sort_file_list, DEFAULT_S3_PREFIX
-
-__version__ = "0.1.0"

--- a/python_src/src/lamp_py/performance_manager/__init__.py
+++ b/python_src/src/lamp_py/performance_manager/__init__.py
@@ -1,10 +1,5 @@
 """
-This module is used by CTD's LAMP application to process gtfs parquet files to
-analize the performance of the MBTA system.
+Pipeline for consuming GTFS realtime parquet files and converting them into
+trip summaries that are compared to trips that are planned in the GTFS static
+schedule
 """
-
-from .l0_gtfs_rt_events import process_gtfs_rt_files
-from .l0_gtfs_static_table import process_static_tables
-from .l1_rt_metrics import process_trips_and_metrics
-
-__version__ = "0.1.0"

--- a/python_src/src/lamp_py/postgres/__init__.py
+++ b/python_src/src/lamp_py/postgres/__init__.py
@@ -1,3 +1,1 @@
 """ Suite of utilities for interacting with postgres database """
-
-__version__ = "0.1.0"

--- a/python_src/src/lamp_py/startup/__init__.py
+++ b/python_src/src/lamp_py/startup/__init__.py
@@ -1,0 +1,1 @@
+"""Entrypoints into various LAMP data pipelines"""

--- a/python_src/tests/ingestion/test_configuration.py
+++ b/python_src/tests/ingestion/test_configuration.py
@@ -1,6 +1,6 @@
 import pytest
 
-from lamp_py.ingestion import ConfigType
+from lamp_py.ingestion.converter import ConfigType
 from lamp_py.ingestion.error import ConfigTypeFromFilenameException
 
 UPDATE_FILENAME = "2022-01-01T00:00:02Z_https_cdn.mbta.com_realtime_TripUpdates_enhanced.json.gz"

--- a/python_src/tests/ingestion/test_gtfs_rt_converter.py
+++ b/python_src/tests/ingestion/test_gtfs_rt_converter.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 from pyarrow import fs
 
 from lamp_py.ingestion.convert_gtfs_rt import GtfsRtConverter
-from lamp_py.ingestion import ConfigType
+from lamp_py.ingestion.converter import ConfigType
 
 from ..test_resources import incoming_dir
 

--- a/python_src/tests/ingestion/test_ingest.py
+++ b/python_src/tests/ingestion/test_ingest.py
@@ -6,7 +6,7 @@ import os
 from multiprocessing import Queue
 import pytest
 
-from lamp_py.ingestion import ConfigType
+from lamp_py.ingestion.converter import ConfigType
 from lamp_py.ingestion.error import NoImplException
 from lamp_py.ingestion.ingest import get_converter
 from lamp_py.ingestion.convert_gtfs import GtfsConverter

--- a/python_src/tests/ingestion/test_py_gtfs_rt_ingestion.py
+++ b/python_src/tests/ingestion/test_py_gtfs_rt_ingestion.py
@@ -1,6 +1,0 @@
-from lamp_py.ingestion import __version__
-
-
-def test_version() -> None:
-    """simple test stub"""
-    assert __version__ == "0.1.0"

--- a/python_src/tests/performance_manager/test_performance_manager.py
+++ b/python_src/tests/performance_manager/test_performance_manager.py
@@ -9,8 +9,9 @@ import sqlalchemy as sa
 from _pytest.monkeypatch import MonkeyPatch
 from pyarrow import fs, parquet
 
-from lamp_py.performance_manager import process_static_tables
-
+from lamp_py.performance_manager.l0_gtfs_static_table import (
+    process_static_tables,
+)
 from lamp_py.performance_manager.l0_gtfs_rt_events import (
     combine_events,
     get_gtfs_rt_paths,


### PR DESCRIPTION
After migrating from multiple packages to a single package, the additional imports in our init files are going to lead us to bad practices, where we're not using the full paths on our imports from sibling directories. Clean those out and clean up imports that were not using the full paths.