### PR TITLE
Skip directories in S3 file_list

### DIFF
--- a/python_src/src/lamp_py/aws/s3.py
+++ b/python_src/src/lamp_py/aws/s3.py
@@ -78,6 +78,8 @@ def file_list_from_s3(
             if page["KeyCount"] == 0:
                 continue
             for obj in page["Contents"]:
+                if obj["Size"] == 0:
+                    continue
                 filepaths.append(os.path.join("s3://", bucket_name, obj["Key"]))
 
             if len(filepaths) > max_list_size:


### PR DESCRIPTION
Returning directories from `file_list_from_s3` causes errors in some parts of performance_manager. 

The original version of `file_list_from_s3` had the same control logic.