### PR TITLE
Update github workflows for more deploy options

### DIFF
--- a/.github/actions/deploy/action.yaml
+++ b/.github/actions/deploy/action.yaml
@@ -1,0 +1,39 @@
+name: Deploy To Environment
+description: Build docker image and deploy it for each data pipeline.
+inputs:
+  env-name:
+    description: One of 'prod', 'staging', or 'dev'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - uses: actions/checkout@v2
+      - uses: mbta/actions/build-push-ecr@v1
+        id: build-push
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          docker-repo: ${{ secrets.LAMP_DOCKER_URI }}
+          dockerfile-path: ./python_src/
+      - uses: mbta/actions/deploy-ecs@v1
+        id: deploy-ingestion
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          ecs-cluster: lamp
+          ecs-service: lamp-ingestion-${{env-name}}
+          docker-tag: ${{ steps.build-push.outputs.docker-tag }}
+      - uses: mbta/actions/deploy-ecs@v1
+        id: deploy-performance-manager
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          ecs-cluster: lamp
+          ecs-service: lamp-performance-manager-${{env-name}}
+          docker-tag: ${{ steps.build-push.outputs.docker-tag }}
+      - uses: mbta/actions/notify-slack-deploy@v1
+        if: ${{ !cancelled() }}
+        with:
+          webhook-url: ${{ secrets.SLACK_WEBHOOK }}
+          job-status: ${{ job.status }}

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -1,4 +1,4 @@
-name: Deploy to Dev Environment
+name: Deploy to Production Environment
 
 on:
   workflow_dispatch:
@@ -9,4 +9,4 @@ jobs:
     steps:
       - uses: ./.github/actions/deploy
         with:
-          env-name: dev 
+          env-name: prod

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -1,0 +1,17 @@
+name: Deploy to Staging Environment
+
+on:
+  workflow_run:
+    workflows: ["Continuous Integration"]
+    types: [completed]
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/actions/deploy
+        with:
+          env-name: staging


### PR DESCRIPTION
We want to be able to deploy to our dev, staging, and production environments. To do so, add in two new workflows for prod and staging.

Now is also a sensible time for us to change our behavior on merges to main to run CI and update our staging environment rather than our dev one. This will leave our dev one locked until we manually deploy using the github UI.

For now, prod is also going to be deployed via manual clicks on the github UI until we figure out how we want to control versioning via tags.

Asana Task: https://app.asana.com/0/0/1204283360272394/f
