### PR TITLE
Remove BUS events from GTFS Static Processing

### DIFF
--- a/python_src/tests/performance_manager/test_performance_manager.py
+++ b/python_src/tests/performance_manager/test_performance_manager.py
@@ -233,10 +233,10 @@ def test_static_tables(
     # processing the static tables our db tables should have these many record
     # counts.
     row_counts = {
-        StaticTrips: 64879,
-        StaticRoutes: 234,
+        StaticTrips: 9731,
+        StaticRoutes: 24,
         StaticStops: 9706,
-        StaticStopTimes: 1676197,
+        StaticStopTimes: 160977,
         StaticCalendar: 76,
     }
 


### PR DESCRIPTION
Currently, performance manager processes ALL GTFS static events, loading them into the RDS. Most of these events are BUS related and can be removed from the performance manager pipeline.

This PR modifies the RDS loading pipeline to remove all BUS events for GTFS Static processing.

Asana Task: https://app.asana.com/0/1189492770004753/1204339091106883
