### PR TITLE
Add `service_id_by_date_and_route` to RDS

### DIFF
--- a/python_src/src/lamp_py/migrations/versions/performance_manager/98aa70293578_add_heather_honorary_view.py
+++ b/python_src/src/lamp_py/migrations/versions/performance_manager/98aa70293578_add_heather_honorary_view.py
@@ -1,0 +1,123 @@
+"""add heather honorary view
+
+Revision ID: 98aa70293578
+Revises: 2e9d81949da8
+Create Date: 2023-04-18 15:30:40.821451
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "98aa70293578"
+down_revision = "2e9d81949da8"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    create_view_sql = """
+        CREATE OR REPLACE VIEW heather_davis_honorary_view AS 
+        WITH static_cal AS (
+            SELECT
+                service_id, 
+                start_date::text::date AS start_date, 
+                end_date::text::date AS end_date,
+                "timestamp",
+                monday,
+                tuesday,
+                wednesday,
+                thursday,
+                friday,
+                saturday,
+                sunday
+            FROM 
+                public.static_calendar
+            WHERE 
+                public.static_calendar."timestamp" >= (SELECT min("timestamp") FROM public.static_calendar_dates)
+        ), service_ids AS (
+            SELECT
+                static_cal.service_id,
+                replace(service_date::date::text, '-', '')::integer AS service_date,
+                static_cal."timestamp"
+            FROM static_cal,
+                generate_series(static_cal.start_date, static_cal.end_date, '1 day') AS service_date
+            WHERE 
+                (extract(dow from service_date) = 0 AND static_cal.sunday)
+                OR (extract(dow from service_date) = 1 AND static_cal.monday)
+                OR (extract(dow from service_date) = 2 AND static_cal.tuesday)
+                OR (extract(dow from service_date) = 3 AND static_cal.wednesday)
+                OR (extract(dow from service_date) = 4 AND static_cal.thursday)
+                OR (extract(dow from service_date) = 5 AND static_cal.friday)
+                OR (extract(dow from service_date) = 6 AND static_cal.saturday)
+        ), service_ids_special AS (
+            SELECT 
+                service_id,
+                "date" AS service_date,
+                "timestamp"
+            FROM 
+                public.static_calendar_dates
+            WHERE 
+                exception_type = 1
+        ), service_ids_exclude AS (
+            SELECT 
+                service_id,
+                "date" AS service_date,
+                "timestamp",
+                true AS to_exclude
+            FROM 
+                public.static_calendar_dates
+            WHERE 
+                exception_type = 2
+        ), all_service_ids AS (
+            SELECT 
+                service_id,
+                service_date,
+                "timestamp"
+            FROM 
+                service_ids
+            UNION
+            SELECT
+                service_id,
+                service_date,
+                "timestamp"
+            FROM 
+                service_ids_special
+        )
+        SELECT
+            st.route_id,
+            a_sid.service_id,
+            a_sid.service_date,
+            a_sid."timestamp"
+        FROM 
+            all_service_ids a_sid
+        FULL OUTER JOIN
+            service_ids_exclude e_sid
+        ON 
+            a_sid.service_id = e_sid.service_id
+            AND a_sid.service_date = e_sid.service_date
+            AND a_sid."timestamp" = e_sid."timestamp"
+        JOIN 
+            public.static_trips st 
+        ON
+            a_sid.service_id = st.service_id 
+            AND a_sid."timestamp" = st."timestamp"
+        WHERE
+            e_sid.to_exclude IS null
+            AND st.route_id IN ('Red', 'Mattapan', 'Orange', 'Green-B', 'Green-C', 'Green-D', 'Green-E', 'Blue')
+        GROUP BY
+            st.route_id,
+            a_sid.service_id,
+            a_sid.service_date,
+            a_sid."timestamp"
+        ;
+    """
+    op.execute(create_view_sql)
+
+
+def downgrade() -> None:
+    drop_view_sql = """
+        DROP VIEW IF EXISTS heather_davis_honorary_view;
+    """
+    op.execute(drop_view_sql)

--- a/python_src/src/lamp_py/migrations/versions/performance_manager/98aa70293578_add_heather_honorary_view.py
+++ b/python_src/src/lamp_py/migrations/versions/performance_manager/98aa70293578_add_heather_honorary_view.py
@@ -84,6 +84,14 @@ def upgrade() -> None:
                 "timestamp"
             FROM 
                 service_ids_special
+        ), trips_start_dates AS (
+            SELECT
+                start_date,
+                min(fk_static_timestamp) AS fk_timestamp
+            FROM
+                public.vehicle_trips
+            GROUP BY
+                start_date
         )
         SELECT
             st.route_id,
@@ -98,6 +106,11 @@ def upgrade() -> None:
             a_sid.service_id = e_sid.service_id
             AND a_sid.service_date = e_sid.service_date
             AND a_sid."timestamp" = e_sid."timestamp"
+        JOIN 
+            trips_start_dates trip_sd 
+        ON
+            trip_sd.start_date = a_sid.service_date
+            and trip_sd.fk_timestamp = a_sid."timestamp"
         JOIN 
             public.static_trips st 
         ON

--- a/python_src/src/lamp_py/migrations/versions/performance_manager/98aa70293578_add_heather_honorary_view.py
+++ b/python_src/src/lamp_py/migrations/versions/performance_manager/98aa70293578_add_heather_honorary_view.py
@@ -18,8 +18,20 @@ depends_on = None
 
 def upgrade() -> None:
     create_view_sql = """
-        CREATE OR REPLACE VIEW heather_davis_honorary_view AS 
-        WITH static_cal AS (
+        CREATE OR REPLACE VIEW service_id_by_date_and_route AS 
+        WITH mod_feed_dates AS (
+            SELECT 
+                feed_start_date::text::date AS start_date,
+                lead(feed_start_date,1,replace(CURRENT_DATE::text, '-', '')::integer) OVER (ORDER BY feed_start_date)::text::date - 1 AS end_date,
+                "timestamp"
+            FROM public.static_feed_info
+        ), sd_match AS (
+            SELECT 
+                replace(mod_sd::date::text, '-', '')::integer AS service_date,
+                mod_feed_dates."timestamp"
+            FROM mod_feed_dates,
+                generate_series(mod_feed_dates.start_date, mod_feed_dates.end_date, '1 day') AS mod_sd
+        ), static_cal AS (
             SELECT
                 service_id, 
                 start_date::text::date AS start_date, 
@@ -39,35 +51,35 @@ def upgrade() -> None:
         ), service_ids AS (
             SELECT
                 static_cal.service_id,
-                replace(service_date::date::text, '-', '')::integer AS service_date,
-                static_cal."timestamp"
+                replace(new_sd::date::text, '-', '')::integer AS service_date,
+                static_cal."timestamp" as "timestamp"
             FROM static_cal,
-                generate_series(static_cal.start_date, static_cal.end_date, '1 day') AS service_date
+                generate_series(static_cal.start_date, static_cal.end_date, '1 day') AS new_sd
             WHERE 
-                (extract(dow from service_date) = 0 AND static_cal.sunday)
-                OR (extract(dow from service_date) = 1 AND static_cal.monday)
-                OR (extract(dow from service_date) = 2 AND static_cal.tuesday)
-                OR (extract(dow from service_date) = 3 AND static_cal.wednesday)
-                OR (extract(dow from service_date) = 4 AND static_cal.thursday)
-                OR (extract(dow from service_date) = 5 AND static_cal.friday)
-                OR (extract(dow from service_date) = 6 AND static_cal.saturday)
+                (extract(dow from new_sd) = 0 AND static_cal.sunday)
+                OR (extract(dow from new_sd) = 1 AND static_cal.monday)
+                OR (extract(dow from new_sd) = 2 AND static_cal.tuesday)
+                OR (extract(dow from new_sd) = 3 AND static_cal.wednesday)
+                OR (extract(dow from new_sd) = 4 AND static_cal.thursday)
+                OR (extract(dow from new_sd) = 5 AND static_cal.friday)
+                OR (extract(dow from new_sd) = 6 AND static_cal.saturday)
         ), service_ids_special AS (
             SELECT 
-                service_id,
-                "date" AS service_date,
-                "timestamp"
+                scd.service_id,
+                scd."date" AS service_date,
+                scd."timestamp"
             FROM 
-                public.static_calendar_dates
+                public.static_calendar_dates scd
             WHERE 
                 exception_type = 1
         ), service_ids_exclude AS (
             SELECT 
-                service_id,
-                "date" AS service_date,
-                "timestamp",
+                scd.service_id,
+                scd."date" AS service_date,
+                scd."timestamp",
                 true AS to_exclude
             FROM 
-                public.static_calendar_dates
+                public.static_calendar_dates scd
             WHERE 
                 exception_type = 2
         ), all_service_ids AS (
@@ -106,11 +118,10 @@ def upgrade() -> None:
             a_sid.service_id = e_sid.service_id
             AND a_sid.service_date = e_sid.service_date
             AND a_sid."timestamp" = e_sid."timestamp"
-        JOIN 
-            trips_start_dates trip_sd 
+        JOIN sd_match
         ON
-            trip_sd.start_date = a_sid.service_date
-            and trip_sd.fk_timestamp = a_sid."timestamp"
+            sd_match."timestamp" = a_sid."timestamp"
+            AND sd_match.service_date = a_sid.service_date
         JOIN 
             public.static_trips st 
         ON
@@ -131,6 +142,6 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     drop_view_sql = """
-        DROP VIEW IF EXISTS heather_davis_honorary_view;
+        DROP VIEW IF EXISTS service_id_by_date_and_route;
     """
     op.execute(drop_view_sql)


### PR DESCRIPTION
This PR adds the view requested by Heather Davis of OPMI. The view provides all valid combinations of route_id's and service_id's from GTFS static files that can be joined to events and trips. 

Asana Task: https://app.asana.com/0/1204389777951216/1204410607657215
