### PR TITLE
ECS Logging Fix

### DIFF
--- a/python_src/src/lamp_py/aws/ecs.py
+++ b/python_src/src/lamp_py/aws/ecs.py
@@ -1,16 +1,20 @@
-import logging
+import time
 import os
 import sys
 from multiprocessing import Process, Queue
 from typing import Any, Optional
+
+from lamp_py.runtime_utils.process_logger import ProcessLogger
 
 
 def handle_ecs_sigterm(_: int, __: Any) -> None:
     """
     handler function for when ECS recieves ECS SIGTERM
     """
-    logging.info("AWS ECS SIGTERM received")
+    process_logger = ProcessLogger("sigterm_received")
+    process_logger.log_start()
     os.environ["GOT_SIGTERM"] = "TRUE"
+    process_logger.log_complete()
 
 
 def check_for_sigterm(
@@ -21,12 +25,18 @@ def check_for_sigterm(
     check if SIGTERM recived from ECS. If found, terminate process.
     """
     if os.environ.get("GOT_SIGTERM") is not None:
-        logging.info("SIGTERM received, terminating process...")
+        process_logger = ProcessLogger("stopping_ecs")
+        process_logger.log_start()
 
         # send signal to stop rds writer process and wait for exit
         if metadata_queue is not None:
             metadata_queue.put(None)
         if rds_process is not None:
             rds_process.join()
+
+        process_logger.log_complete()
+
+        # delay for log statements to write before ecs death
+        time.sleep(5)
 
         sys.exit()

--- a/python_src/src/lamp_py/postgres/postgres_utils.py
+++ b/python_src/src/lamp_py/postgres/postgres_utils.py
@@ -370,10 +370,8 @@ def _rds_writer_process(metadata_queue: Queue) -> None:
         insert_statement = sa.insert(MetadataLog.__table__).values(
             processed=False, path=metadata_path
         )
-        process_logger = ProcessLogger(
-            "metadata_insert", filepath=metadata_path
-        )
-        process_logger.log_start()
+        insert_logger = ProcessLogger("metadata_insert", filepath=metadata_path)
+        insert_logger.log_start()
         retry_attempt = 0
 
         # All metatdata_insert attempts must succeed, keep attempting until success
@@ -388,8 +386,8 @@ def _rds_writer_process(metadata_queue: Queue) -> None:
                 time.sleep(15)
 
             else:
-                process_logger.add_metadata(retry_attempts=retry_attempt)
-                process_logger.log_complete()
+                insert_logger.add_metadata(retry_attempts=retry_attempt)
+                insert_logger.log_complete()
                 break
 
     process_logger.log_complete()


### PR DESCRIPTION
This PR adds more verbose logging to our AWS ECS sigterm handling utils. 

Also includes fix to `_rds_writer_process` logging for overwrite of `process_logger` variable name. 

Asana Task: https://app.asana.com/0/1204389777951216/1204442411295589
