### PR TITLE
RDS Triggers for `version_pub_date` and Static Trips trunk/branch designations

### DIFF
--- a/api/lib/api/performance_manager/static_feed_info.ex
+++ b/api/lib/api/performance_manager/static_feed_info.ex
@@ -6,6 +6,7 @@ defmodule Api.PerformanceManager.StaticFeedInfo do
     field(:feed_start_date, :integer)
     field(:feed_end_date, :integer)
     field(:feed_version, :string)
+    field(:feed_active_date, :integer)
     field(:timestamp, :integer)
     field(:created_on, :utc_datetime)
   end

--- a/api/lib/api/performance_manager/static_trips.ex
+++ b/api/lib/api/performance_manager/static_trips.ex
@@ -4,6 +4,8 @@ defmodule Api.PerformanceManager.StaticTrips do
   @primary_key {:pk_id, :id, autogenerate: true}
   schema "static_trips" do
     field(:route_id, :string)
+    field(:branch_route_id, :string)
+    field(:trunk_route_id, :string)
     field(:service_id, :string)
     field(:trip_id, :string)
     field(:direction_id, :boolean)

--- a/python_src/src/lamp_py/migrations/versions/performance_manager/43153d536c2a_feed_info_init_date_trigger.py
+++ b/python_src/src/lamp_py/migrations/versions/performance_manager/43153d536c2a_feed_info_init_date_trigger.py
@@ -1,0 +1,67 @@
+"""feed_info init_date trigger
+
+Revision ID: 43153d536c2a
+Revises: 98aa70293578
+Create Date: 2023-04-25 06:53:09.672206
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "43153d536c2a"
+down_revision = "98aa70293578"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "static_feed_info",
+        sa.Column("version_pub_date", sa.Integer(), nullable=True),
+    )
+
+    op.create_index(
+        op.f("ix_static_feed_info_version_pub_date"),
+        "static_feed_info",
+        ["version_pub_date"],
+        unique=False,
+    )
+
+    create_feed_info_insert_function = """
+        CREATE OR REPLACE FUNCTION insert_feed_info() RETURNS TRIGGER AS $$ 
+        BEGIN 
+            IF NEW.feed_version ~ '\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+\d{2}:\d{2}' THEN
+                NEW.version_pub_date := replace((substring(NEW.feed_version from '\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+\d{2}:\d{2}')::timestamptz at time zone 'US/Eastern')::date::text,'-','')::integer;
+            ELSE
+                NEW.version_pub_date := NEW.feed_start_date;
+            END IF;
+            RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql;
+    """
+    op.execute(create_feed_info_insert_function)
+
+    create_trigger = """
+        CREATE TRIGGER insert_into_feed_info BEFORE INSERT ON static_feed_info 
+        FOR EACH ROW EXECUTE PROCEDURE insert_feed_info();
+    """
+    op.execute(create_trigger)
+
+
+def downgrade() -> None:
+    drop_trigger = (
+        "DROP TRIGGER IF EXISTS insert_into_feed_info ON static_feed_info;"
+    )
+    op.execute(drop_trigger)
+
+    drop_function = "DROP function IF EXISTS public.insert_feed_info();"
+    op.execute(drop_function)
+
+    op.drop_index(
+        op.f("ix_static_feed_info_version_pub_date"),
+        table_name="static_feed_info",
+    )
+
+    op.drop_column("static_feed_info", "version_pub_date")

--- a/python_src/src/lamp_py/migrations/versions/performance_manager/7f4bbec1b669_static_trips_branch_and_trunk_route_id_.py
+++ b/python_src/src/lamp_py/migrations/versions/performance_manager/7f4bbec1b669_static_trips_branch_and_trunk_route_id_.py
@@ -80,14 +80,12 @@ def upgrade() -> None:
             ELSEIF NEW.route_id = 'Red' THEN
                 IF red_is_braintree_branch(NEW.trip_id, NEW."timestamp") THEN
                     NEW.branch_route_id := 'Red-Braintree';
-                    NEW.trunk_route_id := NEW.route_id;
                 ELSEIF red_is_ashmont_branch(NEW.trip_id, NEW."timestamp") THEN
                     NEW.branch_route_id := 'Red-Ashmont';
-                    NEW.trunk_route_id := NEW.route_id;
                 ELSE
                     NEW.branch_route_id := null;
-                    NEW.trunk_route_id := NEW.route_id;
                 END IF;
+                NEW.trunk_route_id := NEW.route_id;
             ELSE
                 NEW.branch_route_id := null;
                 NEW.trunk_route_id := NEW.route_id;

--- a/python_src/src/lamp_py/migrations/versions/performance_manager/7f4bbec1b669_static_trips_branch_and_trunk_route_id_.py
+++ b/python_src/src/lamp_py/migrations/versions/performance_manager/7f4bbec1b669_static_trips_branch_and_trunk_route_id_.py
@@ -1,0 +1,124 @@
+"""static_trips branch and trunk route_id trigger
+
+Revision ID: 7f4bbec1b669
+Revises: 43153d536c2a
+Create Date: 2023-04-25 10:29:30.479958
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "7f4bbec1b669"
+down_revision = "43153d536c2a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "static_trips",
+        sa.Column("branch_route_id", sa.String(60), nullable=True),
+    )
+    op.add_column(
+        "static_trips",
+        sa.Column("trunk_route_id", sa.String(60), nullable=True),
+    )
+    create_red_braintree_branch = """
+        CREATE OR REPLACE FUNCTION red_is_braintree_branch(p_trip_id varchar, p_fk_ts int) RETURNS boolean AS $$ 
+        DECLARE
+            is_braintree boolean;
+        BEGIN 
+            SELECT
+                count(*) > 0
+            INTO
+                is_braintree
+            FROM 
+                static_stop_times sst
+            WHERE 
+                sst.trip_id = p_trip_id
+                AND sst."timestamp" = p_fk_ts
+                AND sst.stop_id IN ('70097', '70098', '70099', '70100', '70101', '70102', '70103', '70104', '70105')
+            ;
+ 
+            RETURN is_braintree;
+        END;
+        $$ LANGUAGE plpgsql;
+    """
+    op.execute(create_red_braintree_branch)
+
+    create_red_ashmont_branch = """
+        CREATE OR REPLACE FUNCTION red_is_ashmont_branch(p_trip_id varchar, p_fk_ts int) RETURNS boolean AS $$ 
+        DECLARE
+            is_ashmont boolean;
+        BEGIN 
+            SELECT
+                count(*) > 0
+            INTO
+                is_ashmont
+            FROM 
+                static_stop_times sst
+            WHERE 
+                sst.trip_id = p_trip_id
+                AND sst."timestamp" = p_fk_ts
+                AND sst.stop_id IN ('70087', '70088', '70089', '70090', '70091', '70092', '70093', '70094')
+            ;
+ 
+            RETURN is_ashmont;
+        END;
+        $$ LANGUAGE plpgsql;
+    """
+    op.execute(create_red_ashmont_branch)
+
+    create_branch_trunk_function = """
+        CREATE OR REPLACE FUNCTION insert_static_trips_branch_trunk() RETURNS TRIGGER AS $$ 
+        BEGIN 
+            IF NEW.route_id ~ 'Green-' THEN
+                NEW.branch_route_id := NEW.route_id;
+                NEW.trunk_route_id := 'Green';
+            ELSEIF NEW.route_id = 'Red' THEN
+                IF red_is_braintree_branch(NEW.trip_id, NEW."timestamp") THEN
+                    NEW.branch_route_id := 'Red-Braintree';
+                    NEW.trunk_route_id := NEW.route_id;
+                ELSEIF red_is_ashmont_branch(NEW.trip_id, NEW."timestamp") THEN
+                    NEW.branch_route_id := 'Red-Ashmont';
+                    NEW.trunk_route_id := NEW.route_id;
+                ELSE
+                    NEW.branch_route_id := null;
+                    NEW.trunk_route_id := NEW.route_id;
+                END IF;
+            ELSE
+                NEW.branch_route_id := null;
+                NEW.trunk_route_id := NEW.route_id;
+            END IF;
+            RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql;
+    """
+    op.execute(create_branch_trunk_function)
+
+    create_trigger = """
+        CREATE TRIGGER static_trips_create_branch_trunk BEFORE INSERT ON static_trips 
+        FOR EACH ROW EXECUTE PROCEDURE insert_static_trips_branch_trunk();
+    """
+    op.execute(create_trigger)
+
+
+def downgrade() -> None:
+    drop_trigger = "DROP TRIGGER IF EXISTS static_trips_create_branch_trunk ON static_trips;"
+    op.execute(drop_trigger)
+
+    drop_function = "DROP function IF EXISTS public.red_is_braintree_branch();"
+    op.execute(drop_function)
+
+    drop_function = "DROP function IF EXISTS public.red_is_ashmont_branch();"
+    op.execute(drop_function)
+
+    drop_function = (
+        "DROP function IF EXISTS public.insert_static_trips_branch_trunk();"
+    )
+    op.execute(drop_function)
+
+    op.drop_column("static_trips", "trunk_route_id")
+    op.drop_column("static_trips", "branch_route_id")

--- a/python_src/src/lamp_py/performance_manager/l0_gtfs_static_load.py
+++ b/python_src/src/lamp_py/performance_manager/l0_gtfs_static_load.py
@@ -188,6 +188,9 @@ def get_table_objects() -> Dict[str, StaticTableDetails]:
         ],
     )
 
+    # this return order also dictates the order that tables are loaded into the RDS
+    # the 'static_trips_create_branch_trunk' trigger requires that the `stop_times` table
+    # be loaded prior to the `trips` table
     return {
         "feed_info": feed_info,
         "routes": routes,

--- a/python_src/src/lamp_py/performance_manager/l0_gtfs_static_load.py
+++ b/python_src/src/lamp_py/performance_manager/l0_gtfs_static_load.py
@@ -190,10 +190,10 @@ def get_table_objects() -> Dict[str, StaticTableDetails]:
 
     return {
         "feed_info": feed_info,
-        "trips": trips,
         "routes": routes,
         "stops": stops,
         "stop_times": stop_times,
+        "trips": trips,
         "calendar": calendar,
         "calendar_dates": calendar_dates,
     }

--- a/python_src/src/lamp_py/performance_manager/pipeline.py
+++ b/python_src/src/lamp_py/performance_manager/pipeline.py
@@ -15,7 +15,7 @@ from lamp_py.runtime_utils.import_env import load_environment
 from lamp_py.runtime_utils.process_logger import ProcessLogger
 from lamp_py.runtime_utils.alembic_migration import alembic_upgrade_to_head
 
-from .l0_gtfs_static_table import process_static_tables
+from .l0_gtfs_static_load import process_static_tables
 from .l0_gtfs_rt_events import process_gtfs_rt_files
 
 logging.getLogger().setLevel("INFO")

--- a/python_src/src/lamp_py/postgres/postgres_schema.py
+++ b/python_src/src/lamp_py/postgres/postgres_schema.py
@@ -144,6 +144,7 @@ class StaticFeedInfo(SqlBase):  # pylint: disable=too-few-public-methods
     feed_start_date = sa.Column(sa.Integer, nullable=False)
     feed_end_date = sa.Column(sa.Integer, nullable=False)
     feed_version = sa.Column(sa.String(75), nullable=False, unique=True)
+    version_pub_date = sa.Column(sa.Integer, nullable=True, index=True)
     timestamp = sa.Column(sa.Integer, nullable=False, unique=True)
     created_on = sa.Column(
         sa.DateTime(timezone=True), server_default=sa.func.now()
@@ -157,6 +158,8 @@ class StaticTrips(SqlBase):  # pylint: disable=too-few-public-methods
 
     pk_id = sa.Column(sa.Integer, primary_key=True)
     route_id = sa.Column(sa.String(60), nullable=False)
+    branch_route_id = sa.Column(sa.String(60), nullable=True)
+    trunk_route_id = sa.Column(sa.String(60), nullable=True)
     service_id = sa.Column(sa.String(60), nullable=False)
     trip_id = sa.Column(sa.String(128), nullable=False)
     direction_id = sa.Column(sa.Boolean)

--- a/python_src/src/lamp_py/postgres/postgres_schema.py
+++ b/python_src/src/lamp_py/postgres/postgres_schema.py
@@ -144,7 +144,7 @@ class StaticFeedInfo(SqlBase):  # pylint: disable=too-few-public-methods
     feed_start_date = sa.Column(sa.Integer, nullable=False)
     feed_end_date = sa.Column(sa.Integer, nullable=False)
     feed_version = sa.Column(sa.String(75), nullable=False, unique=True)
-    version_pub_date = sa.Column(sa.Integer, nullable=True, index=True)
+    feed_active_date = sa.Column(sa.Integer, nullable=False, index=True)
     timestamp = sa.Column(sa.Integer, nullable=False, unique=True)
     created_on = sa.Column(
         sa.DateTime(timezone=True), server_default=sa.func.now()

--- a/python_src/tests/performance_manager/test_performance_manager.py
+++ b/python_src/tests/performance_manager/test_performance_manager.py
@@ -9,7 +9,7 @@ import sqlalchemy as sa
 from _pytest.monkeypatch import MonkeyPatch
 from pyarrow import fs, parquet
 
-from lamp_py.performance_manager.l0_gtfs_static_table import (
+from lamp_py.performance_manager.l0_gtfs_static_load import (
     process_static_tables,
 )
 from lamp_py.performance_manager.l0_gtfs_rt_events import (
@@ -126,7 +126,7 @@ def fixture_s3_patch(monkeypatch: MonkeyPatch) -> Iterator[None]:
         return files
 
     monkeypatch.setattr(
-        "lamp_py.performance_manager.l0_gtfs_static_table.get_static_parquet_paths",
+        "lamp_py.performance_manager.l0_gtfs_static_load.get_static_parquet_paths",
         mock_get_static_parquet_paths,
     )
 


### PR DESCRIPTION
Feat: Add `version_pub_date` column to `static_feed_info` table

LAMP will begin using new GTFS static schedule versions on the day they are issued. 

The `feed_version` field of all GTFS static `feed_info` tables is supposed to contain an ISO UTC timestamp representing the issued datetime of the schedule. This datetime will be extracted (with an RDS trigger function) from `feed_version`, converted to the Eastern timezone service date, and inserted as an integer of `YYYYMMDD` representing the service date the schedule version should be active. 

Feat: Add branch & trunk route id processing to the `static_trips` table

In preparation for the per-caculation of scheduled metrics, `branch_route_id` and `trunk_route_id` columns are being added to the `static_trips` table. These columns will be populated with an RDS trigger function on INSERT. 

Currently only the Green and Red Line routes will have `branch_route_id` values, with all other routes being `null`. 

Green line `route_id`'s will having their alpha designation dropped (-B, -C, -D, -E) for a `trunk_route_id` value of `Green` 

Red Line trips containing stops at Savin Hill, Fields Corner, Shawmut or Ashmont will be tagged as `Red-Ashmont` for `branch_route_id`. Trips containing stops at North Quincy, Wollaston, Quincy Center, Quincy Adams or Braintree will be tagged as `Red-Braintree` for `branch_route_id`. Otherwise, `branch_route_id` will be null and `trunk_route_id` will always be `Red`. 

Asana Task: https://app.asana.com/0/1204389777951216/1204449669814305
Asana Task: https://app.asana.com/0/1204389777951216/1204449669814306
