### PR TITLE
Feat: update `add_fk_static_timestamp_column` with new match logic

### DIFF
--- a/python_src/src/lamp_py/performance_manager/gtfs_utils.py
+++ b/python_src/src/lamp_py/performance_manager/gtfs_utils.py
@@ -75,6 +75,15 @@ def add_fk_static_timestamp_column(
     using "fk_static_timestamp" column, events dataframe records may be joined to
     gtfs static record tables
     """
+    # based on discussions with OPMI, matching of GTFS-RT events to GTFS-static schedule versions
+    # will occur on a whole 'start_date' / service date basis
+    #
+    # when processing live GTFS-static schedule versions, matching can only apply to, at the earliest,
+    # the current `start_date` / service date when processed, no retroactive assignment to past days will occur.
+    #
+    # extraction of `feed_active_date` from `feed_version` of the GTFS-static FEED_INFO table
+    # is currently handled by an DB Trigger function added by alembic migration Revision ID: 43153d536c2a
+
     process_logger = ProcessLogger(
         "add_fk_static_timestamp",
         row_count=events_dataframe.shape[0],

--- a/python_src/src/lamp_py/performance_manager/l0_rt_trip_updates.py
+++ b/python_src/src/lamp_py/performance_manager/l0_rt_trip_updates.py
@@ -227,9 +227,7 @@ def process_tu_files(
     process_logger.log_start()
 
     trip_updates = get_and_unwrap_tu_dataframe(paths)
-    trip_updates = add_fk_static_timestamp_column(
-        trip_updates, "tu_stop_timestamp", db_manager
-    )
+    trip_updates = add_fk_static_timestamp_column(trip_updates, db_manager)
     trip_updates = remove_bus_records(trip_updates, db_manager)
     trip_updates = add_parent_station_column(trip_updates, db_manager)
     trip_updates = reduce_trip_updates(trip_updates)

--- a/python_src/src/lamp_py/performance_manager/l0_rt_vehicle_positions.py
+++ b/python_src/src/lamp_py/performance_manager/l0_rt_vehicle_positions.py
@@ -205,7 +205,7 @@ def process_vp_files(
     vehicle_positions = get_vp_dataframe(paths)
     vehicle_positions = transform_vp_datatypes(vehicle_positions)
     vehicle_positions = add_fk_static_timestamp_column(
-        vehicle_positions, "vehicle_timestamp", db_manager
+        vehicle_positions, db_manager
     )
     vehicle_positions = remove_bus_records(vehicle_positions, db_manager)
     vehicle_positions = add_parent_station_column(vehicle_positions, db_manager)

--- a/python_src/tests/performance_manager/test_performance_manager.py
+++ b/python_src/tests/performance_manager/test_performance_manager.py
@@ -308,9 +308,7 @@ def test_gtfs_rt_processing(
         assert position_size == positions.shape[0]
 
         # check that it can be combined with the static schedule
-        positions = add_fk_static_timestamp_column(
-            positions, "vehicle_timestamp", db_manager
-        )
+        positions = add_fk_static_timestamp_column(positions, db_manager)
         assert positions.shape[1] == 10
         assert position_size == positions.shape[0]
 
@@ -333,9 +331,7 @@ def test_gtfs_rt_processing(
         assert trip_updates.shape[1] == 9
 
         # check that it can be combined with the static schedule
-        trip_updates = add_fk_static_timestamp_column(
-            trip_updates, "tu_stop_timestamp", db_manager
-        )
+        trip_updates = add_fk_static_timestamp_column(trip_updates, db_manager)
         assert trip_updates.shape[1] == 10
         assert trip_update_size == trip_updates.shape[0]
 


### PR DESCRIPTION
After discussions with OPMI, new rules to match GTFS-RT events to GTFS schedules are as follows:

Matching between a GTFS-RT events and a GTFS-static schedule version will be done on a whole `start_date` / "service_date" basis. Each distinct `start_date` / "service_date" of GTFS-RT data will be matched to only one GTFS-static version. 

When ingesting live GTFS Schedule files, the `feed_active_date` will be extracted from the ISO timestamp found in the `feed_version` field of the FEED_INFO table. This will be the first date that a GTFS-static version can be applied to GTFS-RT events. 

GTFS-RT `start_date` must be between `feed_start_date` and `feed_end_date` in FEED_INFO, `start_date` must also be less than or equal to `feed_active_date`.  The most recent schedule that meets these criteria will be matched

When processing archived GTFS-static schedules, these rules change because `feed_start_date` and `feed_end_date` are retroactively modified in archived schedules so that only one GTFS-static version is applicable per calendar day. 

If the initial matching fails, we will drop the requirements of matching on `feed_active_date` and just match `start_date` by `feed_start_date` and `feed_end_date`. 

Asana Task: https://app.asana.com/0/1204389777951216/1204500786018314
