### PR TITLE
Updated GFTFS RT to Static Trip ID Matching

### DIFF
--- a/python_src/src/lamp_py/migrations/versions/performance_manager/695ef31623ae_rt_trunk_id_and_route_id_processing.py
+++ b/python_src/src/lamp_py/migrations/versions/performance_manager/695ef31623ae_rt_trunk_id_and_route_id_processing.py
@@ -34,7 +34,7 @@ def upgrade() -> None:
                 vehicle_events ve
             WHERE 
                 ve.trip_hash = p_trip_hash
-                AND ve.stop_id IN ('70097', '70098', '70099', '70100', '70101', '70102', '70103', '70104', '70105')
+                AND ve.stop_id IN ('70097', '70098', '70099', '70100', '70101', '70102', '70103', '70104', '70105', '70095', '70096')
             LIMIT 1
             ;
             IF FOUND THEN
@@ -60,7 +60,7 @@ def upgrade() -> None:
                 vehicle_events ve
             WHERE 
                 ve.trip_hash = p_trip_hash
-                AND ve.stop_id IN ('70087', '70088', '70089', '70090', '70091', '70092', '70093', '70094')
+                AND ve.stop_id IN ('70087', '70088', '70089', '70090', '70091', '70092', '70093', '70094', '70085', '70086')
             LIMIT 1
             ;
             IF FOUND THEN
@@ -118,7 +118,7 @@ def upgrade() -> None:
             WHERE 
                 sst.trip_id = p_trip_id
                 AND sst."timestamp" = p_fk_ts
-                AND sst.stop_id IN ('70087', '70088', '70089', '70090', '70091', '70092', '70093', '70094')
+                AND sst.stop_id IN ('70087', '70088', '70089', '70090', '70091', '70092', '70093', '70094', '70085', '70086')
             LIMIT 1
             ;
 
@@ -146,7 +146,7 @@ def upgrade() -> None:
             WHERE 
                 sst.trip_id = p_trip_id
                 AND sst."timestamp" = p_fk_ts
-                AND sst.stop_id IN ('70097', '70098', '70099', '70100', '70101', '70102', '70103', '70104', '70105')
+                AND sst.stop_id IN ('70097', '70098', '70099', '70100', '70101', '70102', '70103', '70104', '70105', '70095', '70096')
             LIMIT 1
             ;
 

--- a/python_src/src/lamp_py/migrations/versions/performance_manager/695ef31623ae_rt_trunk_id_and_route_id_processing.py
+++ b/python_src/src/lamp_py/migrations/versions/performance_manager/695ef31623ae_rt_trunk_id_and_route_id_processing.py
@@ -1,0 +1,308 @@
+"""RT trunk_id and route_id processing
+
+Revision ID: 695ef31623ae
+Revises: de55dc40315d
+Create Date: 2023-05-05 08:20:37.529875
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "695ef31623ae"
+down_revision = "de55dc40315d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "vehicle_trips",
+        sa.Column("branch_route_id", sa.String(60), nullable=True),
+    )
+    create_rt_braintree_function = """
+        CREATE OR REPLACE FUNCTION rt_red_is_braintree_branch(p_trip_hash bytea) RETURNS boolean AS $$ 
+        DECLARE
+            found_check bool;
+        BEGIN 
+            SELECT
+                true
+            INTO
+                found_check
+            FROM 
+                vehicle_events ve
+            WHERE 
+                ve.trip_hash = p_trip_hash
+                AND ve.stop_id IN ('70097', '70098', '70099', '70100', '70101', '70102', '70103', '70104', '70105')
+            LIMIT 1
+            ;
+            IF FOUND THEN
+                RETURN true;
+            ELSE
+                RETURN false;
+            END IF;
+        END;
+        $$ LANGUAGE plpgsql;
+    """
+    op.execute(create_rt_braintree_function)
+
+    create_rt_ashmont_function = """
+        CREATE OR REPLACE FUNCTION rt_red_is_ashmont_branch(p_trip_hash bytea) RETURNS boolean AS $$ 
+        DECLARE
+            found_check bool;
+        BEGIN 
+            SELECT
+                true
+            INTO
+                found_check
+            FROM 
+                vehicle_events ve
+            WHERE 
+                ve.trip_hash = p_trip_hash
+                AND ve.stop_id IN ('70087', '70088', '70089', '70090', '70091', '70092', '70093', '70094')
+            LIMIT 1
+            ;
+            IF FOUND THEN
+                RETURN true;
+            ELSE
+                RETURN false;
+            END IF;
+        END;
+        $$ LANGUAGE plpgsql;
+    """
+    op.execute(create_rt_ashmont_function)
+
+    create_get_rt_branch_trunk_id = """
+        CREATE OR REPLACE FUNCTION update_rt_branch_trunk_id() RETURNS TRIGGER AS $$ 
+        BEGIN 
+            IF NEW.route_id ~ 'Green-' THEN
+                NEW.branch_route_id := NEW.route_id;
+                NEW.trunk_route_id := 'Green';
+            ELSEIF NEW.route_id = 'Red' THEN
+                IF rt_red_is_braintree_branch(NEW.trip_hash) THEN
+                    NEW.branch_route_id := 'Red-Braintree';
+                ELSEIF rt_red_is_ashmont_branch(NEW.trip_hash) THEN
+                    NEW.branch_route_id := 'Red-Ashmont';
+                ELSE
+                    NEW.branch_route_id := null;
+                END IF;
+                NEW.trunk_route_id := NEW.route_id;
+            ELSE
+                NEW.branch_route_id := null;
+                NEW.trunk_route_id := NEW.route_id;
+            END IF;
+            RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql;
+    """
+    op.execute(create_get_rt_branch_trunk_id)
+
+    create_trigger = """
+        CREATE TRIGGER rt_trips_update_branch_trunk BEFORE INSERT OR UPDATE ON vehicle_trips 
+        FOR EACH ROW EXECUTE PROCEDURE update_rt_branch_trunk_id();
+    """
+    op.execute(create_trigger)
+
+    update_static_ashmont_func = """
+        CREATE OR REPLACE FUNCTION red_is_ashmont_branch(p_trip_id varchar, p_fk_ts int) RETURNS boolean AS $$ 
+        DECLARE
+            is_ashmont boolean;
+        BEGIN 
+            SELECT
+                true
+            INTO
+                is_ashmont
+            FROM 
+                static_stop_times sst
+            WHERE 
+                sst.trip_id = p_trip_id
+                AND sst."timestamp" = p_fk_ts
+                AND sst.stop_id IN ('70087', '70088', '70089', '70090', '70091', '70092', '70093', '70094')
+            LIMIT 1
+            ;
+
+            IF FOUND THEN
+                RETURN true;
+            ELSE
+                RETURN false;
+            END IF;
+        END;
+        $$ LANGUAGE plpgsql;
+    """
+    op.execute(update_static_ashmont_func)
+
+    update_static_braintree_func = """
+        CREATE OR REPLACE FUNCTION red_is_braintree_branch(p_trip_id varchar, p_fk_ts int) RETURNS boolean AS $$ 
+        DECLARE	
+            is_braintree boolean;
+        BEGIN 
+            SELECT
+                true
+            INTO
+                is_braintree
+            FROM 
+                static_stop_times sst
+            WHERE 
+                sst.trip_id = p_trip_id
+                AND sst."timestamp" = p_fk_ts
+                AND sst.stop_id IN ('70097', '70098', '70099', '70100', '70101', '70102', '70103', '70104', '70105')
+            LIMIT 1
+            ;
+
+            IF FOUND THEN
+                RETURN true;
+            ELSE
+                RETURN false;
+            END IF;
+        END;
+        $$ LANGUAGE plpgsql;
+    """
+    op.execute(update_static_braintree_func)
+
+    update_view = """
+        CREATE OR REPLACE VIEW static_service_id_lookup AS 
+        WITH mod_feed_dates AS (
+            SELECT 
+                feed_start_date::text::date AS start_date,
+                feed_end_date::text::date AS end_date,
+                "timestamp"
+            FROM public.static_feed_info
+        ), sd_match AS (
+            SELECT 
+                replace(mod_sd::date::text, '-', '')::integer AS service_date,
+                mod_feed_dates."timestamp"
+            FROM mod_feed_dates,
+                generate_series(mod_feed_dates.start_date, mod_feed_dates.end_date, '1 day') AS mod_sd
+        ), static_cal AS (
+            SELECT
+                service_id, 
+                start_date::text::date AS start_date, 
+                end_date::text::date AS end_date,
+                "timestamp",
+                monday,
+                tuesday,
+                wednesday,
+                thursday,
+                friday,
+                saturday,
+                sunday
+            FROM 
+                public.static_calendar
+            WHERE 
+                public.static_calendar."timestamp" >= (SELECT min("timestamp") FROM public.static_calendar_dates)
+        ), service_ids AS (
+            SELECT
+                static_cal.service_id,
+                replace(new_sd::date::text, '-', '')::integer AS service_date,
+                static_cal."timestamp" as "timestamp"
+            FROM static_cal,
+                generate_series(static_cal.start_date, static_cal.end_date, '1 day') AS new_sd
+            WHERE 
+                (extract(dow from new_sd) = 0 AND static_cal.sunday)
+                OR (extract(dow from new_sd) = 1 AND static_cal.monday)
+                OR (extract(dow from new_sd) = 2 AND static_cal.tuesday)
+                OR (extract(dow from new_sd) = 3 AND static_cal.wednesday)
+                OR (extract(dow from new_sd) = 4 AND static_cal.thursday)
+                OR (extract(dow from new_sd) = 5 AND static_cal.friday)
+                OR (extract(dow from new_sd) = 6 AND static_cal.saturday)
+        ), service_ids_special AS (
+            SELECT 
+                scd.service_id,
+                scd."date" AS service_date,
+                scd."timestamp"
+            FROM 
+                public.static_calendar_dates scd
+            WHERE 
+                exception_type = 1
+        ), service_ids_exclude AS (
+            SELECT 
+                scd.service_id,
+                scd."date" AS service_date,
+                scd."timestamp",
+                true AS to_exclude
+            FROM 
+                public.static_calendar_dates scd
+            WHERE 
+                exception_type = 2
+        ), all_service_ids AS (
+            SELECT 
+                service_id,
+                service_date,
+                "timestamp"
+            FROM 
+                service_ids
+            UNION
+            SELECT
+                service_id,
+                service_date,
+                "timestamp"
+            FROM 
+                service_ids_special
+        ), trips_start_dates AS (
+            SELECT
+                start_date,
+                min(fk_static_timestamp) AS fk_timestamp
+            FROM
+                public.vehicle_trips
+            GROUP BY
+                start_date
+        )
+        SELECT
+            st.route_id,
+            a_sid.service_id,
+            a_sid.service_date,
+            a_sid."timestamp"
+        FROM 
+            all_service_ids a_sid
+        FULL OUTER JOIN
+            service_ids_exclude e_sid
+        ON 
+            a_sid.service_id = e_sid.service_id
+            AND a_sid.service_date = e_sid.service_date
+            AND a_sid."timestamp" = e_sid."timestamp"
+        JOIN sd_match
+        ON
+            sd_match."timestamp" = a_sid."timestamp"
+            AND sd_match.service_date = a_sid.service_date
+        JOIN 
+            public.static_trips st 
+        ON
+            a_sid.service_id = st.service_id 
+            AND a_sid."timestamp" = st."timestamp"
+        WHERE
+            e_sid.to_exclude IS null
+        GROUP BY
+            st.route_id,
+            a_sid.service_id,
+            a_sid.service_date,
+            a_sid."timestamp"
+        ;
+    """
+    op.execute(update_view)
+
+
+def downgrade() -> None:
+    op.execute("DROP VIEW IF EXISTS static_service_id_lookup;")
+
+    drop_trigger = (
+        "DROP TRIGGER IF EXISTS rt_trips_update_branch_trunk ON vehicle_trips;"
+    )
+    op.execute(drop_trigger)
+
+    drop_get_rt_branch_trunk = (
+        "DROP function IF EXISTS public.update_rt_branch_trunk_id();"
+    )
+    op.execute(drop_get_rt_branch_trunk)
+
+    drop_rt_ashmont_func = (
+        "DROP function IF EXISTS public.rt_red_is_ashmont_branch();"
+    )
+    op.execute(drop_rt_ashmont_func)
+
+    drop_rt_braintree_func = (
+        "DROP function IF EXISTS public.rt_red_is_braintree_branch();"
+    )
+    op.execute(drop_rt_braintree_func)
+
+    op.drop_column("vehicle_trips", "branch_route_id")

--- a/python_src/src/lamp_py/performance_manager/l1_rt_trips.py
+++ b/python_src/src/lamp_py/performance_manager/l1_rt_trips.py
@@ -43,7 +43,7 @@ def load_new_trip_data(
     This guarantees that all events represented in the events dataframe will have
     matching trips data in the "vehicle_trips" table
     """
-    process_logger = ProcessLogger("l0_trips.load_new_trips")
+    process_logger = ProcessLogger("l1_trips.load_new_trips")
     process_logger.log_start()
     insert_columns = [
         "trip_hash",
@@ -135,7 +135,7 @@ def update_trip_stop_counts(db_manager: DatabaseManager) -> None:
         .values(stop_count=new_stop_counts_cte.c.stop_count)
     )
 
-    process_logger = ProcessLogger("l0_trips.update_trip_stop_counts")
+    process_logger = ProcessLogger("l1_trips.update_trip_stop_counts")
     process_logger.log_start()
     db_manager.execute(update_query)
     process_logger.log_complete()
@@ -180,7 +180,7 @@ def update_static_trip_id_guess_exact(db_manager: DatabaseManager) -> None:
         )
     )
 
-    process_logger = ProcessLogger("l0_trips.update_exact_trip_matches")
+    process_logger = ProcessLogger("l1_trips.update_exact_trip_matches")
     process_logger.log_start()
     db_manager.execute(update_query)
     process_logger.log_complete()
@@ -206,13 +206,11 @@ def backup_rt_static_trip_match(
     seed_timestamps: List[int],
 ) -> None:
     """
-    processs updates to trips table
+    perform "backup" match of RT trips to Static schedule trip
 
-    generate new trips table information
+    this matches an RT trip to a static trip with the same branch_route_id or trunk_route_id if branch is null
+    and direction with the closest start_time
     """
-    process_logger = ProcessLogger("l1_rt_trips_table_loader")
-    process_logger.log_start()
-
     static_trips_cte = get_static_trips_cte(seed_timestamps, seed_start_date)
 
     # to build a 'summary' trips table only the first and last records for each
@@ -324,7 +322,6 @@ def backup_rt_static_trip_match(
     )
 
     db_manager.execute(update_query)
-    process_logger.log_complete()
 
 
 def process_trips(
@@ -336,7 +333,7 @@ def process_trips(
     """
     load_new_trips_records(db_manager, events)
 
-    process_logger = ProcessLogger("l0_trips.update_backup_trip_matches")
+    process_logger = ProcessLogger("l1_trips.update_backup_trip_matches")
     process_logger.log_start()
     for start_date in events["start_date"].unique():
         timestamps = [

--- a/python_src/src/lamp_py/postgres/postgres_schema.py
+++ b/python_src/src/lamp_py/postgres/postgres_schema.py
@@ -68,6 +68,7 @@ class VehicleTrips(SqlBase):  # pylint: disable=too-few-public-methods
     # trip identifiers
     direction_id = sa.Column(sa.Boolean, nullable=False)
     route_id = sa.Column(sa.String(60), nullable=False)
+    branch_route_id = sa.Column(sa.String(60), nullable=True)
     trunk_route_id = sa.Column(sa.String(60), nullable=True)
     start_date = sa.Column(sa.Integer, nullable=False)
     start_time = sa.Column(sa.Integer, nullable=False)
@@ -262,3 +263,17 @@ class TempStaticHeadwaysGen(SqlBase):  # pylint: disable=too-few-public-methods
     direction_id = sa.Column(sa.Boolean)
     trunk_route_id = sa.Column(sa.String(60), nullable=True)
     branch_route_id = sa.Column(sa.String(60), nullable=True)
+
+
+class ServiceIdDates(SqlBase):  # pylint: disable=too-few-public-methods
+    """
+    Table representing service_id_by_date_and_route VIEW for use by performance_manager
+    """
+
+    __tablename__ = "static_service_id_lookup"
+
+    dummy_pk = sa.Column(sa.Integer, primary_key=True)
+    route_id = sa.Column(sa.String(60))
+    service_id = sa.Column(sa.String(60))
+    service_date = sa.Column(sa.Integer)
+    timestamp = sa.Column(sa.Integer)

--- a/python_src/src/lamp_py/postgres/postgres_utils.py
+++ b/python_src/src/lamp_py/postgres/postgres_utils.py
@@ -289,6 +289,7 @@ class DatabaseManager:
             truncate_query = f"{truncate_query} CASCADE"
 
         self.execute(sa.text(f"{truncate_query};"))
+        self.execute(sa.text(f"ANALYZE {truncat_as};"))
 
     def add_metadata_paths(self, paths: List[str]) -> None:
         """


### PR DESCRIPTION
This PR updates the business logic of matching GTFS-RT trips to GTFS Static Trip ID's `static_trip_id_guess`. 

This methodology was agreed to by OPMI during QA discussions.

Exact matching is attempted between the `trip_id` recorded for the GTFS-RT trip to scheduled `trip_id`'s from the static schedule. 

Backup matching occurs by finding the scheduled trip with the closest matching parameters for the active service on the specified service date:
- `direction_id` 
- `branch_route_id` >> `trunk_route_id`


Asana Task: https://app.asana.com/0/1204517240145658/1204500786018315
Asana Task: https://app.asana.com/0/1204517240145658/1204449669814308