### PR TITLE
chore: drop trips columns from `vehicle_events` table

### DIFF
--- a/python_src/src/lamp_py/migrations/versions/performance_manager/014_18d962b3df59_remove_trip_fields_from_events.py
+++ b/python_src/src/lamp_py/migrations/versions/performance_manager/014_18d962b3df59_remove_trip_fields_from_events.py
@@ -1,0 +1,63 @@
+"""remove trip fields from events
+
+Revision ID: 18d962b3df59
+Revises: 97f5fb821b8a
+Create Date: 2023-05-17 13:06:46.832362
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "18d962b3df59"
+down_revision = "97f5fb821b8a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_column("vehicle_events", "service_date")
+    op.drop_column("vehicle_events", "route_id")
+    op.drop_column("vehicle_events", "vehicle_id")
+    op.drop_column("vehicle_events", "start_time")
+    op.drop_column("vehicle_events", "direction_id")
+
+
+def downgrade() -> None:
+    op.add_column(
+        "vehicle_events",
+        sa.Column(
+            "direction_id", sa.BOOLEAN(), autoincrement=False, nullable=True
+        ),
+    )
+    op.add_column(
+        "vehicle_events",
+        sa.Column(
+            "start_time", sa.INTEGER(), autoincrement=False, nullable=True
+        ),
+    )
+    op.add_column(
+        "vehicle_events",
+        sa.Column(
+            "vehicle_id",
+            sa.VARCHAR(length=60),
+            autoincrement=False,
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "vehicle_events",
+        sa.Column(
+            "route_id",
+            sa.VARCHAR(length=60),
+            autoincrement=False,
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "vehicle_events",
+        sa.Column(
+            "service_date", sa.INTEGER(), autoincrement=False, nullable=True
+        ),
+    )

--- a/python_src/src/lamp_py/performance_manager/l0_gtfs_rt_events.py
+++ b/python_src/src/lamp_py/performance_manager/l0_gtfs_rt_events.py
@@ -310,11 +310,6 @@ def upload_to_database(
     process_logger.add_metadata(insert_event_count=events["do_insert"].sum())
     if events["do_insert"].sum() > 0:
         insert_cols = [
-            "direction_id",
-            "route_id",
-            "service_date",
-            "start_time",
-            "vehicle_id",
             "trip_hash",
             "stop_sequence",
             "stop_id",

--- a/python_src/src/lamp_py/postgres/postgres_schema.py
+++ b/python_src/src/lamp_py/postgres/postgres_schema.py
@@ -19,13 +19,6 @@ class VehicleEvents(SqlBase):  # pylint: disable=too-few-public-methods
 
     pk_id = sa.Column(sa.Integer, primary_key=True)
 
-    # trip identifiers
-    direction_id = sa.Column(sa.Boolean, nullable=False)
-    route_id = sa.Column(sa.String(60), nullable=False)
-    service_date = sa.Column(sa.Integer, nullable=False)
-    start_time = sa.Column(sa.Integer, nullable=False)
-    vehicle_id = sa.Column(sa.String(60), nullable=False)
-
     # hash of trip identifiers
     trip_hash = sa.Column(
         sa.LargeBinary(16), nullable=False, index=True, unique=False

--- a/python_src/tests/performance_manager/test_performance_manager.py
+++ b/python_src/tests/performance_manager/test_performance_manager.py
@@ -370,6 +370,11 @@ def test_gtfs_rt_processing(
         expected_columns.add("trip_id")
         expected_columns.add("vehicle_label")
         expected_columns.add("vehicle_consist")
+        expected_columns.add("direction_id")
+        expected_columns.add("route_id")
+        expected_columns.add("service_date")
+        expected_columns.add("start_time")
+        expected_columns.add("vehicle_id")
         assert len(expected_columns) == len(events.columns)
 
         missing_columns = set(events.columns) - expected_columns


### PR DESCRIPTION
Our `vehicle_events` table still contains columns that are duplicated in the `vehicle_trips` table. This change removes the following columns from `vehicle_events`:

- service_date
- route_id
- vehicle_id
- start_time
- direction_id

Asana Task: https://app.asana.com/0/1204614792357231/1204616772301249
