### PR TITLE
change `timestamp` to `static_version_key`

### DIFF
--- a/api/lib/api/performance_manager/static_calendar.ex
+++ b/api/lib/api/performance_manager/static_calendar.ex
@@ -13,6 +13,6 @@ defmodule Api.PerformanceManager.StaticCalendar do
     field(:sunday, :boolean)
     field(:start_date, :integer)
     field(:end_date, :integer)
-    field(:timestamp, :integer)
+    field(:static_version_key, :integer)
   end
 end

--- a/api/lib/api/performance_manager/static_calendar_dates.ex
+++ b/api/lib/api/performance_manager/static_calendar_dates.ex
@@ -7,6 +7,6 @@ defmodule Api.PerformanceManager.StaticCalendarDates do
     field(:date, :integer)
     field(:exception_type, :integer)
     field(:holiday_name, :string)
-    field(:timestamp, :integer)
+    field(:static_version_key, :integer)
   end
 end

--- a/api/lib/api/performance_manager/static_feed_info.ex
+++ b/api/lib/api/performance_manager/static_feed_info.ex
@@ -7,7 +7,7 @@ defmodule Api.PerformanceManager.StaticFeedInfo do
     field(:feed_end_date, :integer)
     field(:feed_version, :string)
     field(:feed_active_date, :integer)
-    field(:timestamp, :integer)
+    field(:static_version_key, :integer)
     field(:created_on, :utc_datetime)
   end
 end

--- a/api/lib/api/performance_manager/static_routes.ex
+++ b/api/lib/api/performance_manager/static_routes.ex
@@ -12,6 +12,6 @@ defmodule Api.PerformanceManager.StaticRoutes do
     field(:route_sort_order, :integer)
     field(:route_fare_class, :string)
     field(:line_id, :string)
-    field(:timestamp, :integer)
+    field(:static_version_key, :integer)
   end
 end

--- a/api/lib/api/performance_manager/static_stop_times.ex
+++ b/api/lib/api/performance_manager/static_stop_times.ex
@@ -11,6 +11,6 @@ defmodule Api.PerformanceManager.StaticStopTimes do
     field(:schedule_headway_branch_seconds, :integer)
     field(:stop_id, :string)
     field(:stop_sequence, :integer)
-    field(:timestamp, :integer)
+    field(:static_version_key, :integer)
   end
 end

--- a/api/lib/api/performance_manager/static_stops.ex
+++ b/api/lib/api/performance_manager/static_stops.ex
@@ -9,6 +9,6 @@ defmodule Api.PerformanceManager.StaticStops do
     field(:platform_code, :string)
     field(:platform_name, :string)
     field(:parent_station, :string)
-    field(:timestamp, :integer)
+    field(:static_version_key, :integer)
   end
 end

--- a/api/lib/api/performance_manager/static_trips.ex
+++ b/api/lib/api/performance_manager/static_trips.ex
@@ -9,6 +9,6 @@ defmodule Api.PerformanceManager.StaticTrips do
     field(:service_id, :string)
     field(:trip_id, :string)
     field(:direction_id, :boolean)
-    field(:timestamp, :integer)
+    field(:static_version_key, :integer)
   end
 end

--- a/api/lib/api/performance_manager/vehicle_events.ex
+++ b/api/lib/api/performance_manager/vehicle_events.ex
@@ -3,13 +3,6 @@ defmodule Api.PerformanceManager.VehicleEvents do
 
   @primary_key {:pk_id, :id, autogenerate: true}
   schema "vehicle_events" do
-    # trip identifiers
-    field(:direction_id, :boolean)
-    field(:route_id, :string)
-    field(:service_date, :integer)
-    field(:start_time, :integer)
-    field(:vehicle_id, :string)
-
     # hash of trip identifiers
     field(:trip_hash, :binary)
 
@@ -25,13 +18,6 @@ defmodule Api.PerformanceManager.VehicleEvents do
     field(:vp_move_timestamp, :integer)
     field(:vp_stop_timestamp, :integer)
     field(:tu_stop_timestamp, :integer)
-
-    # foreign key to static schedule expected values
-    belongs_to(:static_feed_info, Api.PerformanceManager.StaticFeedInfo,
-      foreign_key: :fk_static_timestamp,
-      references: :timestamp,
-      define_field: false
-    )
 
     field(:updated_on, :utc_datetime)
   end

--- a/api/lib/api/performance_manager/vehicle_trips.ex
+++ b/api/lib/api/performance_manager/vehicle_trips.ex
@@ -28,8 +28,8 @@ defmodule Api.PerformanceManager.VehicleTrips do
 
     # foreign key to static schedule expected values
     belongs_to(:static_feed_info, Api.PerformanceManager.StaticFeedInfo,
-      foreign_key: :fk_static_timestamp,
-      references: :timestamp,
+      foreign_key: :static_version_key,
+      references: :static_version_key,
       define_field: false
     )
 

--- a/python_src/src/lamp_py/migrations/versions/performance_manager/015_4fe83fd4091d_timestamp_to_static_version_key.py
+++ b/python_src/src/lamp_py/migrations/versions/performance_manager/015_4fe83fd4091d_timestamp_to_static_version_key.py
@@ -1,0 +1,797 @@
+"""timestamp to static_version_key
+
+Revision ID: 4fe83fd4091d
+Revises: 18d962b3df59
+Create Date: 2023-05-19 09:52:16.177008
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "4fe83fd4091d"
+down_revision = "18d962b3df59"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_constraint(
+        "vehicle_events_fk_static_timestamp_fkey",
+        "vehicle_events",
+        type_="foreignkey",
+    )
+    op.drop_constraint(
+        "vehicle_trips_fk_static_timestamp_fkey",
+        "vehicle_trips",
+        type_="foreignkey",
+    )
+    op.drop_constraint(
+        "static_feed_info_timestamp_key", "static_feed_info", type_="unique"
+    )
+
+    op.drop_column("vehicle_events", "fk_static_timestamp")
+
+    op.alter_column(
+        "static_feed_info", "timestamp", new_column_name="static_version_key"
+    )
+    op.create_unique_constraint(
+        "static_feed_info_static_version_key",
+        "static_feed_info",
+        ["static_version_key"],
+    )
+
+    op.alter_column(
+        "vehicle_trips",
+        "fk_static_timestamp",
+        new_column_name="static_version_key",
+    )
+    op.create_foreign_key(
+        "vehicle_trips_static_version_key_fkey",
+        "vehicle_trips",
+        "static_feed_info",
+        ["static_version_key"],
+        ["static_version_key"],
+    )
+
+    op.alter_column(
+        "static_calendar", "timestamp", new_column_name="static_version_key"
+    )
+    op.create_index(
+        op.f("ix_static_calendar_static_version_key"),
+        "static_calendar",
+        ["static_version_key"],
+        unique=False,
+    )
+    op.alter_column(
+        "static_calendar_dates",
+        "timestamp",
+        new_column_name="static_version_key",
+    )
+    op.alter_column(
+        "static_directions", "timestamp", new_column_name="static_version_key"
+    )
+    op.alter_column(
+        "static_routes", "timestamp", new_column_name="static_version_key"
+    )
+    op.create_index(
+        op.f("ix_static_routes_static_version_key"),
+        "static_routes",
+        ["static_version_key"],
+        unique=False,
+    )
+    op.alter_column(
+        "static_stop_times", "timestamp", new_column_name="static_version_key"
+    )
+    op.alter_column(
+        "static_stops", "timestamp", new_column_name="static_version_key"
+    )
+    op.alter_column(
+        "static_trips", "timestamp", new_column_name="static_version_key"
+    )
+
+    upgrade_static_ashmont_func = """
+        CREATE OR REPLACE FUNCTION red_is_ashmont_branch(p_trip_id varchar, p_fk_ts int) RETURNS boolean AS $$ 
+        DECLARE
+            is_ashmont boolean;
+        BEGIN 
+            SELECT
+                true
+            INTO
+                is_ashmont
+            FROM 
+                static_stop_times sst
+            WHERE 
+                sst.trip_id = p_trip_id
+                AND sst.static_version_key = p_fk_ts
+                AND sst.stop_id IN ('70087', '70088', '70089', '70090', '70091', '70092', '70093', '70094', '70085', '70086')
+            LIMIT 1
+            ;
+
+            IF FOUND THEN
+                RETURN true;
+            ELSE
+                RETURN false;
+            END IF;
+        END;
+        $$ LANGUAGE plpgsql;
+    """
+    op.execute(upgrade_static_ashmont_func)
+
+    upgrade_static_braintree_func = """
+        CREATE OR REPLACE FUNCTION red_is_braintree_branch(p_trip_id varchar, p_fk_ts int) RETURNS boolean AS $$ 
+        DECLARE	
+            is_braintree boolean;
+        BEGIN 
+            SELECT
+                true
+            INTO
+                is_braintree
+            FROM 
+                static_stop_times sst
+            WHERE 
+                sst.trip_id = p_trip_id
+                AND sst.static_version_key = p_fk_ts
+                AND sst.stop_id IN ('70097', '70098', '70099', '70100', '70101', '70102', '70103', '70104', '70105', '70095', '70096')
+            LIMIT 1
+            ;
+
+            IF FOUND THEN
+                RETURN true;
+            ELSE
+                RETURN false;
+            END IF;
+        END;
+        $$ LANGUAGE plpgsql;
+    """
+    op.execute(upgrade_static_braintree_func)
+
+    upgrade_branch_trunk_function = """
+        CREATE OR REPLACE FUNCTION insert_static_trips_branch_trunk() RETURNS TRIGGER AS $$ 
+        BEGIN 
+            IF NEW.route_id ~ 'Green-' THEN
+                NEW.branch_route_id := NEW.route_id;
+                NEW.trunk_route_id := 'Green';
+            ELSEIF NEW.route_id = 'Red' THEN
+                IF red_is_braintree_branch(NEW.trip_id, NEW.static_version_key) THEN
+                    NEW.branch_route_id := 'Red-Braintree';
+                ELSEIF red_is_ashmont_branch(NEW.trip_id, NEW.static_version_key) THEN
+                    NEW.branch_route_id := 'Red-Ashmont';
+                ELSE
+                    NEW.branch_route_id := null;
+                END IF;
+                NEW.trunk_route_id := NEW.route_id;
+            ELSE
+                NEW.branch_route_id := null;
+                NEW.trunk_route_id := NEW.route_id;
+            END IF;
+            RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql;
+    """
+    op.execute(upgrade_branch_trunk_function)
+
+    alter_view = 'ALTER VIEW static_service_id_lookup RENAME COLUMN "timestamp" TO static_version_key;'
+    op.execute(alter_view)
+    upgrade_view = """
+        CREATE OR REPLACE VIEW static_service_id_lookup AS 
+        WITH mod_feed_dates AS (
+            SELECT 
+                feed_start_date::text::date AS start_date,
+                feed_end_date::text::date AS end_date,
+                static_version_key
+            FROM public.static_feed_info
+        ), sd_match AS (
+            SELECT 
+                replace(mod_sd::date::text, '-', '')::integer AS service_date,
+                mod_feed_dates.static_version_key
+            FROM mod_feed_dates,
+                generate_series(mod_feed_dates.start_date, mod_feed_dates.end_date, '1 day') AS mod_sd
+        ), static_cal AS (
+            SELECT
+                service_id, 
+                start_date::text::date AS start_date, 
+                end_date::text::date AS end_date,
+                static_version_key,
+                monday,
+                tuesday,
+                wednesday,
+                thursday,
+                friday,
+                saturday,
+                sunday
+            FROM 
+                public.static_calendar
+            WHERE 
+                public.static_calendar.static_version_key >= (SELECT min(static_version_key) FROM public.static_calendar_dates)
+        ), service_ids AS (
+            SELECT
+                static_cal.service_id,
+                replace(new_sd::date::text, '-', '')::integer AS service_date,
+                static_cal.static_version_key
+            FROM static_cal,
+                generate_series(static_cal.start_date, static_cal.end_date, '1 day') AS new_sd
+            WHERE 
+                (extract(dow from new_sd) = 0 AND static_cal.sunday)
+                OR (extract(dow from new_sd) = 1 AND static_cal.monday)
+                OR (extract(dow from new_sd) = 2 AND static_cal.tuesday)
+                OR (extract(dow from new_sd) = 3 AND static_cal.wednesday)
+                OR (extract(dow from new_sd) = 4 AND static_cal.thursday)
+                OR (extract(dow from new_sd) = 5 AND static_cal.friday)
+                OR (extract(dow from new_sd) = 6 AND static_cal.saturday)
+        ), service_ids_special AS (
+            SELECT 
+                scd.service_id,
+                scd."date" AS service_date,
+                scd.static_version_key
+            FROM 
+                public.static_calendar_dates scd
+            WHERE 
+                exception_type = 1
+        ), service_ids_exclude AS (
+            SELECT 
+                scd.service_id,
+                scd."date" AS service_date,
+                scd.static_version_key,
+                true AS to_exclude
+            FROM 
+                public.static_calendar_dates scd
+            WHERE 
+                exception_type = 2
+        ), all_service_ids AS (
+            SELECT 
+                service_id,
+                service_date,
+                static_version_key
+            FROM 
+                service_ids
+            UNION
+            SELECT
+                service_id,
+                service_date,
+                static_version_key
+            FROM 
+                service_ids_special
+        )
+        SELECT
+            st.route_id,
+            a_sid.service_id,
+            a_sid.service_date,
+            a_sid.static_version_key
+        FROM 
+            all_service_ids a_sid
+        FULL OUTER JOIN
+            service_ids_exclude e_sid
+        ON 
+            a_sid.service_id = e_sid.service_id
+            AND a_sid.service_date = e_sid.service_date
+            AND a_sid.static_version_key = e_sid.static_version_key
+        JOIN sd_match
+        ON
+            sd_match.static_version_key = a_sid.static_version_key
+            AND sd_match.service_date = a_sid.service_date
+        JOIN 
+            public.static_trips st 
+        ON
+            a_sid.service_id = st.service_id 
+            AND a_sid.static_version_key = st.static_version_key
+        WHERE
+            e_sid.to_exclude IS null
+        GROUP BY
+            st.route_id,
+            a_sid.service_id,
+            a_sid.service_date,
+            a_sid.static_version_key
+        ;
+    """
+    op.execute(upgrade_view)
+
+    alter_view = 'ALTER VIEW service_id_by_date_and_route RENAME COLUMN "timestamp" TO static_version_key;'
+    op.execute(alter_view)
+    upgrade_view = """
+        CREATE OR REPLACE VIEW service_id_by_date_and_route AS 
+        WITH mod_feed_dates AS (
+            SELECT 
+                feed_start_date::text::date AS start_date,
+                lead(feed_start_date,1,replace(CURRENT_DATE::text, '-', '')::integer) OVER (ORDER BY feed_start_date)::text::date - 1 AS end_date,
+                static_version_key
+            FROM public.static_feed_info
+        ), sd_match AS (
+            SELECT 
+                replace(mod_sd::date::text, '-', '')::integer AS service_date,
+                mod_feed_dates.static_version_key
+            FROM mod_feed_dates,
+                generate_series(mod_feed_dates.start_date, mod_feed_dates.end_date, '1 day') AS mod_sd
+        ), static_cal AS (
+            SELECT
+                service_id, 
+                start_date::text::date AS start_date, 
+                end_date::text::date AS end_date,
+                static_version_key,
+                monday,
+                tuesday,
+                wednesday,
+                thursday,
+                friday,
+                saturday,
+                sunday
+            FROM 
+                public.static_calendar
+            WHERE 
+                public.static_calendar.static_version_key >= (SELECT min(static_version_key) FROM public.static_calendar_dates)
+        ), service_ids AS (
+            SELECT
+                static_cal.service_id,
+                replace(new_sd::date::text, '-', '')::integer AS service_date,
+                static_cal.static_version_key
+            FROM static_cal,
+                generate_series(static_cal.start_date, static_cal.end_date, '1 day') AS new_sd
+            WHERE 
+                (extract(dow from new_sd) = 0 AND static_cal.sunday)
+                OR (extract(dow from new_sd) = 1 AND static_cal.monday)
+                OR (extract(dow from new_sd) = 2 AND static_cal.tuesday)
+                OR (extract(dow from new_sd) = 3 AND static_cal.wednesday)
+                OR (extract(dow from new_sd) = 4 AND static_cal.thursday)
+                OR (extract(dow from new_sd) = 5 AND static_cal.friday)
+                OR (extract(dow from new_sd) = 6 AND static_cal.saturday)
+        ), service_ids_special AS (
+            SELECT 
+                scd.service_id,
+                scd."date" AS service_date,
+                scd.static_version_key
+            FROM 
+                public.static_calendar_dates scd
+            WHERE 
+                exception_type = 1
+        ), service_ids_exclude AS (
+            SELECT 
+                scd.service_id,
+                scd."date" AS service_date,
+                scd.static_version_key,
+                true AS to_exclude
+            FROM 
+                public.static_calendar_dates scd
+            WHERE 
+                exception_type = 2
+        ), all_service_ids AS (
+            SELECT 
+                service_id,
+                service_date,
+                static_version_key
+            FROM 
+                service_ids
+            UNION
+            SELECT
+                service_id,
+                service_date,
+                static_version_key
+            FROM 
+                service_ids_special
+        )
+        SELECT
+            st.route_id,
+            a_sid.service_id,
+            a_sid.service_date,
+            a_sid.static_version_key
+        FROM 
+            all_service_ids a_sid
+        FULL OUTER JOIN
+            service_ids_exclude e_sid
+        ON 
+            a_sid.service_id = e_sid.service_id
+            AND a_sid.service_date = e_sid.service_date
+            AND a_sid.static_version_key = e_sid.static_version_key
+        JOIN sd_match
+        ON
+            sd_match.static_version_key = a_sid.static_version_key
+            AND sd_match.service_date = a_sid.service_date
+        JOIN 
+            public.static_trips st 
+        ON
+            a_sid.service_id = st.service_id 
+            AND a_sid.static_version_key = st.static_version_key
+        WHERE
+            e_sid.to_exclude IS null
+            AND st.route_id IN ('Red', 'Mattapan', 'Orange', 'Green-B', 'Green-C', 'Green-D', 'Green-E', 'Blue')
+        GROUP BY
+            st.route_id,
+            a_sid.service_id,
+            a_sid.service_date,
+            a_sid.static_version_key
+        ;
+    """
+    op.execute(upgrade_view)
+
+
+def downgrade() -> None:
+    op.drop_index(
+        op.f("ix_static_calendar_static_version_key"),
+        table_name="static_calendar",
+    )
+    op.alter_column(
+        "static_calendar", "static_version_key", new_column_name="timestamp"
+    )
+    op.alter_column(
+        "static_calendar_dates",
+        "static_version_key",
+        new_column_name="timestamp",
+    )
+    op.alter_column(
+        "static_directions", "static_version_key", new_column_name="timestamp"
+    )
+    op.drop_index(
+        op.f("ix_static_routes_static_version_key"), table_name="static_routes"
+    )
+    op.alter_column(
+        "static_routes", "static_version_key", new_column_name="timestamp"
+    )
+    op.alter_column(
+        "static_stop_times", "static_version_key", new_column_name="timestamp"
+    )
+    op.alter_column(
+        "static_stops", "static_version_key", new_column_name="timestamp"
+    )
+    op.alter_column(
+        "static_trips", "static_version_key", new_column_name="timestamp"
+    )
+
+    op.drop_constraint(
+        "vehicle_trips_static_version_key_fkey",
+        "vehicle_trips",
+        type_="foreignkey",
+    )
+    op.drop_constraint(
+        "static_feed_info_static_version_key",
+        "static_feed_info",
+        type_="unique",
+    )
+
+    op.alter_column(
+        "static_feed_info", "static_version_key", new_column_name="timestamp"
+    )
+    op.create_unique_constraint(
+        "static_feed_info_timestamp_key", "static_feed_info", ["timestamp"]
+    )
+
+    op.alter_column(
+        "vehicle_trips",
+        "static_version_key",
+        new_column_name="fk_static_timestamp",
+    )
+    op.create_foreign_key(
+        "vehicle_trips_fk_static_timestamp_fkey",
+        "vehicle_trips",
+        "static_feed_info",
+        ["fk_static_timestamp"],
+        ["timestamp"],
+    )
+
+    op.add_column(
+        "vehicle_events",
+        sa.Column(
+            "fk_static_timestamp",
+            sa.INTEGER(),
+            autoincrement=False,
+            nullable=True,
+        ),
+    )
+    op.create_foreign_key(
+        "vehicle_events_fk_static_timestamp_fkey",
+        "vehicle_events",
+        "static_feed_info",
+        ["fk_static_timestamp"],
+        ["timestamp"],
+    )
+
+    downgrade_static_ashmont_func = """
+        CREATE OR REPLACE FUNCTION red_is_ashmont_branch(p_trip_id varchar, p_fk_ts int) RETURNS boolean AS $$ 
+        DECLARE
+            is_ashmont boolean;
+        BEGIN 
+            SELECT
+                true
+            INTO
+                is_ashmont
+            FROM 
+                static_stop_times sst
+            WHERE 
+                sst.trip_id = p_trip_id
+                AND sst."timestamp" = p_fk_ts
+                AND sst.stop_id IN ('70087', '70088', '70089', '70090', '70091', '70092', '70093', '70094', '70085', '70086')
+            LIMIT 1
+            ;
+
+            IF FOUND THEN
+                RETURN true;
+            ELSE
+                RETURN false;
+            END IF;
+        END;
+        $$ LANGUAGE plpgsql;
+    """
+    op.execute(downgrade_static_ashmont_func)
+
+    downgrade_static_braintree_func = """
+        CREATE OR REPLACE FUNCTION red_is_braintree_branch(p_trip_id varchar, p_fk_ts int) RETURNS boolean AS $$ 
+        DECLARE	
+            is_braintree boolean;
+        BEGIN 
+            SELECT
+                true
+            INTO
+                is_braintree
+            FROM 
+                static_stop_times sst
+            WHERE 
+                sst.trip_id = p_trip_id
+                AND sst."timestamp" = p_fk_ts
+                AND sst.stop_id IN ('70097', '70098', '70099', '70100', '70101', '70102', '70103', '70104', '70105', '70095', '70096')
+            LIMIT 1
+            ;
+
+            IF FOUND THEN
+                RETURN true;
+            ELSE
+                RETURN false;
+            END IF;
+        END;
+        $$ LANGUAGE plpgsql;
+    """
+    op.execute(downgrade_static_braintree_func)
+
+    downgrade_branch_trunk_function = """
+        CREATE OR REPLACE FUNCTION insert_static_trips_branch_trunk() RETURNS TRIGGER AS $$ 
+        BEGIN 
+            IF NEW.route_id ~ 'Green-' THEN
+                NEW.branch_route_id := NEW.route_id;
+                NEW.trunk_route_id := 'Green';
+            ELSEIF NEW.route_id = 'Red' THEN
+                IF red_is_braintree_branch(NEW.trip_id, NEW."timestamp") THEN
+                    NEW.branch_route_id := 'Red-Braintree';
+                ELSEIF red_is_ashmont_branch(NEW.trip_id, NEW."timestamp") THEN
+                    NEW.branch_route_id := 'Red-Ashmont';
+                ELSE
+                    NEW.branch_route_id := null;
+                END IF;
+                NEW.trunk_route_id := NEW.route_id;
+            ELSE
+                NEW.branch_route_id := null;
+                NEW.trunk_route_id := NEW.route_id;
+            END IF;
+            RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql;
+    """
+    op.execute(downgrade_branch_trunk_function)
+
+    alter_view = 'ALTER VIEW static_service_id_lookup RENAME COLUMN static_version_key TO "timestamp";'
+    op.execute(alter_view)
+    downgrade_view = """
+        CREATE OR REPLACE VIEW static_service_id_lookup AS 
+        WITH mod_feed_dates AS (
+            SELECT 
+                feed_start_date::text::date AS start_date,
+                feed_end_date::text::date AS end_date,
+                "timestamp"
+            FROM public.static_feed_info
+        ), sd_match AS (
+            SELECT 
+                replace(mod_sd::date::text, '-', '')::integer AS service_date,
+                mod_feed_dates."timestamp"
+            FROM mod_feed_dates,
+                generate_series(mod_feed_dates.start_date, mod_feed_dates.end_date, '1 day') AS mod_sd
+        ), static_cal AS (
+            SELECT
+                service_id, 
+                start_date::text::date AS start_date, 
+                end_date::text::date AS end_date,
+                "timestamp",
+                monday,
+                tuesday,
+                wednesday,
+                thursday,
+                friday,
+                saturday,
+                sunday
+            FROM 
+                public.static_calendar
+            WHERE 
+                public.static_calendar."timestamp" >= (SELECT min("timestamp") FROM public.static_calendar_dates)
+        ), service_ids AS (
+            SELECT
+                static_cal.service_id,
+                replace(new_sd::date::text, '-', '')::integer AS service_date,
+                static_cal."timestamp" as "timestamp"
+            FROM static_cal,
+                generate_series(static_cal.start_date, static_cal.end_date, '1 day') AS new_sd
+            WHERE 
+                (extract(dow from new_sd) = 0 AND static_cal.sunday)
+                OR (extract(dow from new_sd) = 1 AND static_cal.monday)
+                OR (extract(dow from new_sd) = 2 AND static_cal.tuesday)
+                OR (extract(dow from new_sd) = 3 AND static_cal.wednesday)
+                OR (extract(dow from new_sd) = 4 AND static_cal.thursday)
+                OR (extract(dow from new_sd) = 5 AND static_cal.friday)
+                OR (extract(dow from new_sd) = 6 AND static_cal.saturday)
+        ), service_ids_special AS (
+            SELECT 
+                scd.service_id,
+                scd."date" AS service_date,
+                scd."timestamp"
+            FROM 
+                public.static_calendar_dates scd
+            WHERE 
+                exception_type = 1
+        ), service_ids_exclude AS (
+            SELECT 
+                scd.service_id,
+                scd."date" AS service_date,
+                scd."timestamp",
+                true AS to_exclude
+            FROM 
+                public.static_calendar_dates scd
+            WHERE 
+                exception_type = 2
+        ), all_service_ids AS (
+            SELECT 
+                service_id,
+                service_date,
+                "timestamp"
+            FROM 
+                service_ids
+            UNION
+            SELECT
+                service_id,
+                service_date,
+                "timestamp"
+            FROM 
+                service_ids_special
+        )
+        SELECT
+            st.route_id,
+            a_sid.service_id,
+            a_sid.service_date,
+            a_sid."timestamp"
+        FROM 
+            all_service_ids a_sid
+        FULL OUTER JOIN
+            service_ids_exclude e_sid
+        ON 
+            a_sid.service_id = e_sid.service_id
+            AND a_sid.service_date = e_sid.service_date
+            AND a_sid."timestamp" = e_sid."timestamp"
+        JOIN sd_match
+        ON
+            sd_match."timestamp" = a_sid."timestamp"
+            AND sd_match.service_date = a_sid.service_date
+        JOIN 
+            public.static_trips st 
+        ON
+            a_sid.service_id = st.service_id 
+            AND a_sid."timestamp" = st."timestamp"
+        WHERE
+            e_sid.to_exclude IS null
+        GROUP BY
+            st.route_id,
+            a_sid.service_id,
+            a_sid.service_date,
+            a_sid."timestamp"
+        ;
+    """
+    op.execute(downgrade_view)
+
+    alter_view = 'ALTER VIEW service_id_by_date_and_route RENAME COLUMN static_version_key TO "timestamp";'
+    op.execute(alter_view)
+    downgrade_view = """
+        CREATE OR REPLACE VIEW service_id_by_date_and_route AS 
+        WITH mod_feed_dates AS (
+            SELECT 
+                feed_start_date::text::date AS start_date,
+                lead(feed_start_date,1,replace(CURRENT_DATE::text, '-', '')::integer) OVER (ORDER BY feed_start_date)::text::date - 1 AS end_date,
+                "timestamp"
+            FROM public.static_feed_info
+        ), sd_match AS (
+            SELECT 
+                replace(mod_sd::date::text, '-', '')::integer AS service_date,
+                mod_feed_dates."timestamp"
+            FROM mod_feed_dates,
+                generate_series(mod_feed_dates.start_date, mod_feed_dates.end_date, '1 day') AS mod_sd
+        ), static_cal AS (
+            SELECT
+                service_id, 
+                start_date::text::date AS start_date, 
+                end_date::text::date AS end_date,
+                "timestamp",
+                monday,
+                tuesday,
+                wednesday,
+                thursday,
+                friday,
+                saturday,
+                sunday
+            FROM 
+                public.static_calendar
+            WHERE 
+                public.static_calendar."timestamp" >= (SELECT min("timestamp") FROM public.static_calendar_dates)
+        ), service_ids AS (
+            SELECT
+                static_cal.service_id,
+                replace(new_sd::date::text, '-', '')::integer AS service_date,
+                static_cal."timestamp" as "timestamp"
+            FROM static_cal,
+                generate_series(static_cal.start_date, static_cal.end_date, '1 day') AS new_sd
+            WHERE 
+                (extract(dow from new_sd) = 0 AND static_cal.sunday)
+                OR (extract(dow from new_sd) = 1 AND static_cal.monday)
+                OR (extract(dow from new_sd) = 2 AND static_cal.tuesday)
+                OR (extract(dow from new_sd) = 3 AND static_cal.wednesday)
+                OR (extract(dow from new_sd) = 4 AND static_cal.thursday)
+                OR (extract(dow from new_sd) = 5 AND static_cal.friday)
+                OR (extract(dow from new_sd) = 6 AND static_cal.saturday)
+        ), service_ids_special AS (
+            SELECT 
+                scd.service_id,
+                scd."date" AS service_date,
+                scd."timestamp"
+            FROM 
+                public.static_calendar_dates scd
+            WHERE 
+                exception_type = 1
+        ), service_ids_exclude AS (
+            SELECT 
+                scd.service_id,
+                scd."date" AS service_date,
+                scd."timestamp",
+                true AS to_exclude
+            FROM 
+                public.static_calendar_dates scd
+            WHERE 
+                exception_type = 2
+        ), all_service_ids AS (
+            SELECT 
+                service_id,
+                service_date,
+                "timestamp"
+            FROM 
+                service_ids
+            UNION
+            SELECT
+                service_id,
+                service_date,
+                "timestamp"
+            FROM 
+                service_ids_special
+        )
+        SELECT
+            st.route_id,
+            a_sid.service_id,
+            a_sid.service_date,
+            a_sid."timestamp"
+        FROM 
+            all_service_ids a_sid
+        FULL OUTER JOIN
+            service_ids_exclude e_sid
+        ON 
+            a_sid.service_id = e_sid.service_id
+            AND a_sid.service_date = e_sid.service_date
+            AND a_sid."timestamp" = e_sid."timestamp"
+        JOIN sd_match
+        ON
+            sd_match."timestamp" = a_sid."timestamp"
+            AND sd_match.service_date = a_sid.service_date
+        JOIN 
+            public.static_trips st 
+        ON
+            a_sid.service_id = st.service_id 
+            AND a_sid."timestamp" = st."timestamp"
+        WHERE
+            e_sid.to_exclude IS null
+            AND st.route_id IN ('Red', 'Mattapan', 'Orange', 'Green-B', 'Green-C', 'Green-D', 'Green-E', 'Blue')
+        GROUP BY
+            st.route_id,
+            a_sid.service_id,
+            a_sid.service_date,
+            a_sid."timestamp"
+        ;
+    """
+    op.execute(downgrade_view)

--- a/python_src/src/lamp_py/performance_manager/gtfs_utils.py
+++ b/python_src/src/lamp_py/performance_manager/gtfs_utils.py
@@ -65,14 +65,14 @@ def start_time_to_seconds(
     return int(hour) * 3600 + int(minute) * 60 + int(second)
 
 
-def add_fk_static_timestamp_column(
+def add_static_version_key_column(
     events_dataframe: pandas.DataFrame,
     db_manager: DatabaseManager,
 ) -> pandas.DataFrame:
     """
-    adds "fk_static_timestamp" column to dataframe
+    adds "static_version_key" column to dataframe
 
-    using "fk_static_timestamp" column, events dataframe records may be joined to
+    using "static_version_key" column, events dataframe records may be joined to
     gtfs static record tables
     """
     # based on discussions with OPMI, matching of GTFS-RT events to GTFS-static schedule versions
@@ -85,13 +85,13 @@ def add_fk_static_timestamp_column(
     # is currently handled by an DB Trigger function added by alembic migration Revision ID: 43153d536c2a
 
     process_logger = ProcessLogger(
-        "add_fk_static_timestamp",
+        "add_static_version_key",
         row_count=events_dataframe.shape[0],
     )
     process_logger.log_start()
 
-    # initialize fk_static_timestamp column
-    events_dataframe["fk_static_timestamp"] = 0
+    # initialize static_version_key column
+    events_dataframe["static_version_key"] = 0
 
     for date in events_dataframe["service_date"].unique():
         date = int(date)
@@ -101,7 +101,7 @@ def add_fk_static_timestamp_column(
         # this should deal with multiple static schedules being issued on the same day
         # if this occurs we will use the latest issued schedule
         live_match_query = (
-            sa.select(StaticFeedInfo.timestamp)
+            sa.select(StaticFeedInfo.static_version_key)
             .where(
                 StaticFeedInfo.feed_start_date <= date,
                 StaticFeedInfo.feed_end_date >= date,
@@ -118,7 +118,7 @@ def add_fk_static_timestamp_column(
         # If processing archived static schedules, these alternate rules must be used for matching
         # GTFS static to GTFS-RT data
         archive_match_query = (
-            sa.select(StaticFeedInfo.timestamp)
+            sa.select(StaticFeedInfo.static_version_key)
             .where(
                 StaticFeedInfo.feed_start_date <= date,
                 StaticFeedInfo.feed_end_date >= date,
@@ -145,8 +145,8 @@ def add_fk_static_timestamp_column(
             )
 
         service_date_mask = events_dataframe["service_date"] == date
-        events_dataframe.loc[service_date_mask, "fk_static_timestamp"] = int(
-            result[0]["timestamp"]
+        events_dataframe.loc[service_date_mask, "static_version_key"] = int(
+            result[0]["static_version_key"]
         )
 
     process_logger.log_complete()
@@ -161,7 +161,7 @@ def add_parent_station_column(
     """
     adds "parent_station" column to dataframe
 
-    events_dataframe must have "fk_static_timestamp" and "stop_id" columns
+    events_dataframe must have "static_version_key" and "stop_id" columns
 
     if "parent_station" value does not exist for a specific "stop_id", then
     "stop_id" is used as "parent_station"
@@ -178,24 +178,23 @@ def add_parent_station_column(
         process_logger.log_complete()
         return events_dataframe
 
-    # unique list of "fk_static_timestamp" values for pulling parent stations
-    static_timestamps = [
-        int(timestamp)
-        for timestamp in events_dataframe["fk_static_timestamp"].unique()
+    # unique list of "static_version_key" values for pulling parent stations
+    lookup_v_keys = [
+        int(s_v_key)
+        for s_v_key in events_dataframe["static_version_key"].unique()
     ]
 
     # pull parent station data for joining to events dataframe
     parent_station_query = sa.select(
-        StaticStops.timestamp.label("fk_static_timestamp"),
+        StaticStops.static_version_key,
         StaticStops.stop_id,
         StaticStops.parent_station,
-    ).where(StaticStops.timestamp.in_(static_timestamps))
+    ).where(StaticStops.static_version_key.in_(lookup_v_keys))
     parent_stations = db_manager.select_as_dataframe(parent_station_query)
 
-    # join parent stations to events on "stop_id" and gtfs static
-    # timestamp foreign key
+    # join parent stations to events on "stop_id" and "static_version_key" foreign key
     events_dataframe = events_dataframe.merge(
-        parent_stations, how="left", on=["fk_static_timestamp", "stop_id"]
+        parent_stations, how="left", on=["static_version_key", "stop_id"]
     )
     # is parent station is not provided, transfer "stop_id" value to
     # "parent_station" column
@@ -217,7 +216,7 @@ def remove_bus_records(
     """
     remove all records from dataframe associated with bus trips
 
-    events_dataframe must have "fk_static_timestamp" and "route_id" columns
+    events_dataframe must have "static_version_key" and "route_id" columns
 
     route_type == 3 from the routes table indicates bus service, drop all records
     assocated with route_type == 3
@@ -228,25 +227,25 @@ def remove_bus_records(
     )
     process_logger.log_start()
 
-    # unique list of "fk_static_timestamp" values for pulling route info
-    static_timestamps = [
-        int(timestamp)
-        for timestamp in events_dataframe["fk_static_timestamp"].unique()
+    # unique list of "static_version_key" values for pulling route info
+    lookup_v_keys = [
+        int(s_v_key)
+        for s_v_key in events_dataframe["static_version_key"].unique()
     ]
 
     # pull non-bus route_id's from RDS
     non_bus_id_query = sa.select(
-        StaticRoutes.timestamp.label("fk_static_timestamp"),
+        StaticRoutes.static_version_key,
         StaticRoutes.route_id,
     ).where(
-        StaticRoutes.timestamp.in_(static_timestamps),
+        StaticRoutes.static_version_key.in_(lookup_v_keys),
         StaticRoutes.route_type != 3,
     )
     non_bus_ids = db_manager.select_as_dataframe(non_bus_id_query)
 
-    # join events on non-bus "route_id"s and gtfs static timestamp foreign key
+    # join events on non-bus "route_id"s and "static_version_key" foreign key
     events_dataframe = events_dataframe.merge(
-        non_bus_ids, how="inner", on=["fk_static_timestamp", "route_id"]
+        non_bus_ids, how="inner", on=["static_version_key", "route_id"]
     )
 
     process_logger.add_metadata(after_row_count=events_dataframe.shape[0])

--- a/python_src/src/lamp_py/performance_manager/l0_gtfs_rt_events.py
+++ b/python_src/src/lamp_py/performance_manager/l0_gtfs_rt_events.py
@@ -101,7 +101,7 @@ def combine_events(
     #  add more intelligent trip_id processing, this approach will randomly select trip_id record to keep
     details_columns = [
         "direction_id",
-        "fk_static_timestamp",
+        "static_version_key",
         "parent_station",
         "route_id",
         "service_date",
@@ -318,7 +318,6 @@ def upload_to_database(
             "vp_move_timestamp",
             "vp_stop_timestamp",
             "tu_stop_timestamp",
-            "fk_static_timestamp",
         ]
 
         result = db_manager.execute_with_data(

--- a/python_src/src/lamp_py/performance_manager/l0_gtfs_static_load.py
+++ b/python_src/src/lamp_py/performance_manager/l0_gtfs_static_load.py
@@ -284,6 +284,12 @@ def transform_data_tables(static_tables: Dict[str, StaticTableDetails]) -> None:
         )
         table.data_table = table.data_table.replace([""], [None])
 
+        table.data_table = table.data_table.rename(
+            columns={
+                "timestamp": "static_version_key",
+            }
+        )
+
 
 def drop_bus_records(static_tables: Dict[str, StaticTableDetails]) -> None:
     """
@@ -375,11 +381,13 @@ def process_static_tables(db_manager: DatabaseManager) -> None:
             drop_bus_records(static_tables)
             insert_data_tables(static_tables, db_manager)
 
-            static_timestamp = int(
-                static_tables["feed_info"].data_table.loc[0, "timestamp"]
+            static_version_key = int(
+                static_tables["feed_info"].data_table.loc[
+                    0, "static_version_key"
+                ]
             )
 
-            modify_static_tables(static_timestamp, db_manager)
+            modify_static_tables(static_version_key, db_manager)
 
             update_md_log = (
                 sa.update(MetadataLog.__table__)

--- a/python_src/src/lamp_py/performance_manager/l0_rt_trip_updates.py
+++ b/python_src/src/lamp_py/performance_manager/l0_rt_trip_updates.py
@@ -9,7 +9,7 @@ from lamp_py.runtime_utils.process_logger import ProcessLogger
 from .gtfs_utils import (
     add_event_hash_column,
     start_time_to_seconds,
-    add_fk_static_timestamp_column,
+    add_static_version_key_column,
     add_parent_station_column,
     remove_bus_records,
 )
@@ -240,7 +240,7 @@ def process_tu_files(
     process_logger.log_start()
 
     trip_updates = get_and_unwrap_tu_dataframe(paths)
-    trip_updates = add_fk_static_timestamp_column(trip_updates, db_manager)
+    trip_updates = add_static_version_key_column(trip_updates, db_manager)
     trip_updates = remove_bus_records(trip_updates, db_manager)
     trip_updates = add_parent_station_column(trip_updates, db_manager)
     trip_updates = reduce_trip_updates(trip_updates)

--- a/python_src/src/lamp_py/performance_manager/l0_rt_vehicle_positions.py
+++ b/python_src/src/lamp_py/performance_manager/l0_rt_vehicle_positions.py
@@ -9,7 +9,7 @@ from lamp_py.runtime_utils.process_logger import ProcessLogger
 from .gtfs_utils import (
     add_event_hash_column,
     start_time_to_seconds,
-    add_fk_static_timestamp_column,
+    add_static_version_key_column,
     add_parent_station_column,
     remove_bus_records,
 )
@@ -220,7 +220,7 @@ def process_vp_files(
 
     vehicle_positions = get_vp_dataframe(paths)
     vehicle_positions = transform_vp_datatypes(vehicle_positions)
-    vehicle_positions = add_fk_static_timestamp_column(
+    vehicle_positions = add_static_version_key_column(
         vehicle_positions, db_manager
     )
     vehicle_positions = remove_bus_records(vehicle_positions, db_manager)

--- a/python_src/src/lamp_py/performance_manager/l1_rt_metrics.py
+++ b/python_src/src/lamp_py/performance_manager/l1_rt_metrics.py
@@ -17,7 +17,7 @@ from .l1_cte_statements import get_trips_for_metrics
 def process_metrics_table(
     db_manager: DatabaseManager,
     seed_service_date: int,
-    seed_timestamps: List[int],
+    version_keys: List[int],
 ) -> None:
     """
     processs updates to metrics table
@@ -27,9 +27,7 @@ def process_metrics_table(
     process_logger = ProcessLogger("l1_rt_metrics_table_loader")
     process_logger.log_start()
 
-    trips_for_metrics = get_trips_for_metrics(
-        seed_timestamps, seed_service_date
-    )
+    trips_for_metrics = get_trips_for_metrics(version_keys, seed_service_date)
 
     # travel_times calculation:
     # limited to records where stop_timestamp > move_timestamp to avoid negative travel times
@@ -414,15 +412,15 @@ def process_metrics(
     insert and update metrics table
     """
     for service_date in events["service_date"].unique():
-        timestamps = [
+        version_keys = [
             int(s_d)
             for s_d in events.loc[
-                events["service_date"] == service_date, "fk_static_timestamp"
+                events["service_date"] == service_date, "static_version_key"
             ].unique()
         ]
 
         process_metrics_table(
             db_manager,
             seed_service_date=int(service_date),
-            seed_timestamps=timestamps,
+            version_keys=version_keys,
         )

--- a/python_src/src/lamp_py/postgres/postgres_schema.py
+++ b/python_src/src/lamp_py/postgres/postgres_schema.py
@@ -39,13 +39,6 @@ class VehicleEvents(SqlBase):  # pylint: disable=too-few-public-methods
     vp_stop_timestamp = sa.Column(sa.Integer, nullable=True)
     tu_stop_timestamp = sa.Column(sa.Integer, nullable=True)
 
-    # forign key to static schedule expected values
-    fk_static_timestamp = sa.Column(
-        sa.Integer,
-        sa.ForeignKey("static_feed_info.timestamp"),
-        nullable=False,
-    )
-
     updated_on = sa.Column(sa.TIMESTAMP, server_default=sa.func.now())
 
 
@@ -83,9 +76,9 @@ class VehicleTrips(SqlBase):  # pylint: disable=too-few-public-methods
     )
 
     # forign key to static schedule expected values
-    fk_static_timestamp = sa.Column(
+    static_version_key = sa.Column(
         sa.Integer,
-        sa.ForeignKey("static_feed_info.timestamp"),
+        sa.ForeignKey("static_feed_info.static_version_key"),
         nullable=False,
     )
 
@@ -143,7 +136,7 @@ class StaticFeedInfo(SqlBase):  # pylint: disable=too-few-public-methods
     feed_end_date = sa.Column(sa.Integer, nullable=False)
     feed_version = sa.Column(sa.String(75), nullable=False, unique=True)
     feed_active_date = sa.Column(sa.Integer, nullable=False, index=True)
-    timestamp = sa.Column(sa.Integer, nullable=False, unique=True)
+    static_version_key = sa.Column(sa.Integer, nullable=False, unique=True)
     created_on = sa.Column(
         sa.DateTime(timezone=True), server_default=sa.func.now()
     )
@@ -162,7 +155,7 @@ class StaticTrips(SqlBase):  # pylint: disable=too-few-public-methods
     trip_id = sa.Column(sa.String(128), nullable=False, index=True)
     direction_id = sa.Column(sa.Boolean, index=True)
     block_id = sa.Column(sa.String(128), nullable=True)
-    timestamp = sa.Column(sa.Integer, nullable=False, index=True)
+    static_version_key = sa.Column(sa.Integer, nullable=False, index=True)
 
 
 class StaticRoutes(SqlBase):  # pylint: disable=too-few-public-methods
@@ -180,7 +173,7 @@ class StaticRoutes(SqlBase):  # pylint: disable=too-few-public-methods
     route_sort_order = sa.Column(sa.Integer, nullable=False)
     route_fare_class = sa.Column(sa.String(30), nullable=False)
     line_id = sa.Column(sa.String(30), nullable=True)
-    timestamp = sa.Column(sa.Integer, nullable=False)
+    static_version_key = sa.Column(sa.Integer, nullable=False, index=True)
 
 
 class StaticStops(SqlBase):  # pylint: disable=too-few-public-methods
@@ -195,7 +188,7 @@ class StaticStops(SqlBase):  # pylint: disable=too-few-public-methods
     platform_code = sa.Column(sa.String(10), nullable=True)
     platform_name = sa.Column(sa.String(60), nullable=True)
     parent_station = sa.Column(sa.String(30), nullable=True)
-    timestamp = sa.Column(sa.Integer, nullable=False, index=True)
+    static_version_key = sa.Column(sa.Integer, nullable=False, index=True)
 
 
 class StaticStopTimes(SqlBase):  # pylint: disable=too-few-public-methods
@@ -212,7 +205,7 @@ class StaticStopTimes(SqlBase):  # pylint: disable=too-few-public-methods
     schedule_headway_branch_seconds = sa.Column(sa.Integer, nullable=True)
     stop_id = sa.Column(sa.String(30), nullable=False, index=True)
     stop_sequence = sa.Column(sa.SmallInteger, nullable=False)
-    timestamp = sa.Column(sa.Integer, nullable=False, index=True)
+    static_version_key = sa.Column(sa.Integer, nullable=False, index=True)
 
 
 class StaticCalendar(SqlBase):  # pylint: disable=too-few-public-methods
@@ -231,7 +224,7 @@ class StaticCalendar(SqlBase):  # pylint: disable=too-few-public-methods
     sunday = sa.Column(sa.Boolean)
     start_date = sa.Column(sa.Integer, nullable=False)
     end_date = sa.Column(sa.Integer, nullable=False)
-    timestamp = sa.Column(sa.Integer, nullable=False)
+    static_version_key = sa.Column(sa.Integer, nullable=False, index=True)
 
 
 class StaticCalendarDates(SqlBase):  # pylint: disable=too-few-public-methods
@@ -244,7 +237,7 @@ class StaticCalendarDates(SqlBase):  # pylint: disable=too-few-public-methods
     date = sa.Column(sa.Integer, nullable=False, index=True)
     exception_type = sa.Column(sa.SmallInteger, nullable=False)
     holiday_name = sa.Column(sa.String(128), nullable=True)
-    timestamp = sa.Column(sa.Integer, nullable=False, index=True)
+    static_version_key = sa.Column(sa.Integer, nullable=False, index=True)
 
 
 class StaticDirections(SqlBase):  # pylint: disable=too-few-public-methods
@@ -257,7 +250,7 @@ class StaticDirections(SqlBase):  # pylint: disable=too-few-public-methods
     direction_id = sa.Column(sa.Boolean, index=True)
     direction = sa.Column(sa.String(30), nullable=False)
     direction_destination = sa.Column(sa.String(60), nullable=False)
-    timestamp = sa.Column(sa.Integer, nullable=False, index=True)
+    static_version_key = sa.Column(sa.Integer, nullable=False, index=True)
 
 
 class TempStaticHeadwaysGen(SqlBase):  # pylint: disable=too-few-public-methods
@@ -288,4 +281,4 @@ class ServiceIdDates(SqlBase):  # pylint: disable=too-few-public-methods
     route_id = sa.Column(sa.String(60))
     service_id = sa.Column(sa.String(60))
     service_date = sa.Column(sa.Integer)
-    timestamp = sa.Column(sa.Integer)
+    static_version_key = sa.Column(sa.Integer)

--- a/python_src/tests/performance_manager/test_performance_manager.py
+++ b/python_src/tests/performance_manager/test_performance_manager.py
@@ -45,7 +45,7 @@ from lamp_py.runtime_utils.alembic_migration import (
 )
 
 from lamp_py.performance_manager.gtfs_utils import (
-    add_fk_static_timestamp_column,
+    add_static_version_key_column,
     remove_bus_records,
     add_parent_station_column,
 )
@@ -316,7 +316,7 @@ def test_gtfs_rt_processing(
         assert position_size == positions.shape[0]
 
         # check that it can be combined with the static schedule
-        positions = add_fk_static_timestamp_column(positions, db_manager)
+        positions = add_static_version_key_column(positions, db_manager)
         assert positions.shape[1] == 13
         assert position_size == positions.shape[0]
 
@@ -339,7 +339,7 @@ def test_gtfs_rt_processing(
         assert trip_updates.shape[1] == 10
 
         # check that it can be combined with the static schedule
-        trip_updates = add_fk_static_timestamp_column(trip_updates, db_manager)
+        trip_updates = add_static_version_key_column(trip_updates, db_manager)
         assert trip_updates.shape[1] == 11
         assert trip_update_size == trip_updates.shape[0]
 
@@ -375,6 +375,7 @@ def test_gtfs_rt_processing(
         expected_columns.add("service_date")
         expected_columns.add("start_time")
         expected_columns.add("vehicle_id")
+        expected_columns.add("static_version_key")
         assert len(expected_columns) == len(events.columns)
 
         missing_columns = set(events.columns) - expected_columns


### PR DESCRIPTION
Our use of `timestamp` as a foreign key column that represents GTFS Static Schedule versions is very confusing.

This change renames the `timestamp` columns to `static_version_key` across the performance manager application. 

Asana Task: https://app.asana.com/0/1204614792357231/1204616772301260
