### PR TITLE
Fix Constraint Names in migration 015

### DIFF
--- a/python_src/src/lamp_py/migrations/versions/performance_manager/001_be4c10c548f0_initial_rds_schema.py
+++ b/python_src/src/lamp_py/migrations/versions/performance_manager/001_be4c10c548f0_initial_rds_schema.py
@@ -62,9 +62,11 @@ def upgrade() -> None:
             server_default=sa.text("now()"),
             nullable=True,
         ),
-        sa.PrimaryKeyConstraint("pk_id"),
-        sa.UniqueConstraint("feed_version"),
-        sa.UniqueConstraint("timestamp"),
+        sa.PrimaryKeyConstraint("pk_id", name="staticFeedInfo_pkey"),
+        sa.UniqueConstraint(
+            "feed_version", name="staticFeedInfo_feed_version_key"
+        ),
+        sa.UniqueConstraint("timestamp", name="staticFeedInfo_timestamp_key"),
     )
     op.create_table(
         "static_routes",

--- a/python_src/src/lamp_py/migrations/versions/performance_manager/015_4fe83fd4091d_timestamp_to_static_version_key.py
+++ b/python_src/src/lamp_py/migrations/versions/performance_manager/015_4fe83fd4091d_timestamp_to_static_version_key.py
@@ -28,7 +28,7 @@ def upgrade() -> None:
         type_="foreignkey",
     )
     op.drop_constraint(
-        "static_feed_info_timestamp_key", "static_feed_info", type_="unique"
+        "staticFeedInfo_timestamp_key", "static_feed_info", type_="unique"
     )
 
     op.drop_column("vehicle_events", "fk_static_timestamp")


### PR DESCRIPTION
Deploy to dev failed on mis-matched constraint names in AWS RDS. 

This fixes the constraint names so that migration occurs correctly. 

Asana Task: https://app.asana.com/0/1204614792357231/1204659932565030