### PR TITLE
fix: 017 Migrate Order of Operations

### DIFF
--- a/python_src/src/lamp_py/migrations/versions/performance_manager/017_37d97f420d54_add_prev_and_next_trip_stops.py
+++ b/python_src/src/lamp_py/migrations/versions/performance_manager/017_37d97f420d54_add_prev_and_next_trip_stops.py
@@ -35,19 +35,6 @@ def upgrade() -> None:
         "vehicle_events",
         sa.Column("next_trip_stop_pk_id", sa.Integer(), nullable=True),
     )
-    op.create_index(
-        op.f("ix_vehicle_events_next_trip_stop_pk_id"),
-        "vehicle_events",
-        ["next_trip_stop_pk_id"],
-        unique=False,
-    )
-    op.create_index(
-        op.f("ix_vehicle_events_previous_trip_stop_pk_id"),
-        "vehicle_events",
-        ["previous_trip_stop_pk_id"],
-        unique=False,
-    )
-
     update_columns = """
         WITH prev_next_trip_stops AS (
             SELECT 
@@ -69,6 +56,19 @@ def upgrade() -> None:
         ;
     """
     op.execute(update_columns)
+
+    op.create_index(
+        op.f("ix_vehicle_events_next_trip_stop_pk_id"),
+        "vehicle_events",
+        ["next_trip_stop_pk_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_vehicle_events_previous_trip_stop_pk_id"),
+        "vehicle_events",
+        ["previous_trip_stop_pk_id"],
+        unique=False,
+    )
 
     update_view = """
         CREATE OR REPLACE VIEW opmi_all_rt_fields_joined AS 


### PR DESCRIPTION
Alembic migration 017_37d97f420d54 has caused our RDS to lock up for 24 hours.

Re-ordering the migration steps should allow the migration to actually complete in a reasonable time.

Previously we were adding two new columns, creating an index for those columns and then doing a large UPDATE-FROM command to populate the columns. 

This change moves the index creation to after the UPDATE-FROM operation completes. 

