### PR TITLE
fix: skip migration 37d97f420d54

### DIFF
--- a/python_src/src/lamp_py/migrations/versions/performance_manager/017_37d97f420d54_add_prev_and_next_trip_stops.py
+++ b/python_src/src/lamp_py/migrations/versions/performance_manager/017_37d97f420d54_add_prev_and_next_trip_stops.py
@@ -25,8 +25,13 @@ down_revision = "171891fde1cf"
 branch_labels = None
 depends_on = None
 
+skip_revision = True
+
 
 def upgrade() -> None:
+    if skip_revision:
+        return
+
     op.add_column(
         "vehicle_events",
         sa.Column("previous_trip_stop_pk_id", sa.Integer(), nullable=True),
@@ -126,6 +131,9 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
+    if skip_revision:
+        return
+
     update_view = """
         CREATE OR REPLACE VIEW opmi_all_rt_fields_joined AS 
         SELECT

--- a/python_src/src/lamp_py/performance_manager/l1_rt_trips.py
+++ b/python_src/src/lamp_py/performance_manager/l1_rt_trips.py
@@ -280,7 +280,7 @@ def load_new_trips_records(
     Load data into "vehicle_trips" table for any new RT events
     """
     load_temp_for_hash_compare(db_manager, events)
-    update_prev_next_trip_stop(db_manager)
+    # update_prev_next_trip_stop(db_manager)
     load_new_trip_data(db_manager, events)
     update_trip_stop_counts(db_manager)
     update_static_trip_id_guess_exact(db_manager)

--- a/python_src/src/lamp_py/postgres/postgres_schema.py
+++ b/python_src/src/lamp_py/postgres/postgres_schema.py
@@ -30,8 +30,8 @@ class VehicleEvents(SqlBase):  # pylint: disable=too-few-public-methods
     parent_station = sa.Column(sa.String(60), nullable=False)
 
     # stop link fields
-    previous_trip_stop_pk_id = sa.Column(sa.Integer, nullable=True, index=True)
-    next_trip_stop_pk_id = sa.Column(sa.Integer, nullable=True, index=True)
+    # previous_trip_stop_pk_id = sa.Column(sa.Integer, nullable=True, index=True)
+    # next_trip_stop_pk_id = sa.Column(sa.Integer, nullable=True, index=True)
 
     # hash of trip and stop identifiers
     trip_stop_hash = sa.Column(

--- a/python_src/tests/performance_manager/test_performance_manager.py
+++ b/python_src/tests/performance_manager/test_performance_manager.py
@@ -366,8 +366,6 @@ def test_gtfs_rt_processing(
             "pk_id",
             "updated_on",
             "trip_hash",
-            "previous_trip_stop_pk_id",
-            "next_trip_stop_pk_id",
         }
         expected_columns.add("trip_id")
         expected_columns.add("vehicle_label")


### PR DESCRIPTION
Migration 37d97f420d54 has locked up the RDS for over a week. 

Since we don't know how long this migration could continue for, I believe it is prudent to just cancel the migration and implement this change on the PROD RDS during DB creation.
