### PR TITLE
feat: Remove all `hash` columns from RDS

### DIFF
--- a/python_src/src/lamp_py/migrations/versions/performance_manager/018_a4870e30ec68_remove_hash_columns.py
+++ b/python_src/src/lamp_py/migrations/versions/performance_manager/018_a4870e30ec68_remove_hash_columns.py
@@ -177,8 +177,7 @@ def upgrade() -> None:
         CREATE OR REPLACE VIEW opmi_all_rt_fields_joined AS 
         SELECT
             vt.service_date
-            , ve.pm_trip_id as trip_hash
-            , NULL as trip_stop_hash
+            , ve.pm_trip_id
             , ve.stop_sequence
             , ve.stop_id
             , LAG (ve.stop_id, 1) OVER (PARTITION BY ve.pm_trip_id ORDER BY COALESCE(ve.vp_stop_timestamp,  ve.tu_stop_timestamp, ve.vp_move_timestamp)) as previous_stop_id

--- a/python_src/src/lamp_py/migrations/versions/performance_manager/018_a4870e30ec68_remove_hash_columns.py
+++ b/python_src/src/lamp_py/migrations/versions/performance_manager/018_a4870e30ec68_remove_hash_columns.py
@@ -1,0 +1,615 @@
+"""remove hash columns
+
+Revision ID: a4870e30ec68
+Revises: 37d97f420d54
+Create Date: 2023-07-11 17:40:00.668485
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "a4870e30ec68"
+down_revision = "37d97f420d54"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("DROP VIEW IF EXISTS opmi_all_rt_fields_joined;")
+
+    op.create_table(
+        "temp_event_compare",
+        sa.Column("do_update", sa.Boolean(), nullable=True),
+        sa.Column("do_insert", sa.Boolean(), nullable=True),
+        sa.Column("pk_id", sa.Integer(), nullable=False),
+        sa.Column("new_trip", sa.Boolean(), nullable=True),
+        sa.Column("pm_trip_id", sa.Integer(), nullable=True),
+        sa.Column("service_date", sa.Integer(), nullable=False),
+        sa.Column("direction_id", sa.Boolean(), nullable=False),
+        sa.Column("route_id", sa.String(length=60), nullable=False),
+        sa.Column("start_time", sa.Integer(), nullable=False),
+        sa.Column("vehicle_id", sa.String(length=60), nullable=False),
+        sa.Column("stop_sequence", sa.SmallInteger(), nullable=True),
+        sa.Column("stop_id", sa.String(length=60), nullable=False),
+        sa.Column("parent_station", sa.String(length=60), nullable=False),
+        sa.Column("vp_move_timestamp", sa.Integer(), nullable=True),
+        sa.Column("vp_stop_timestamp", sa.Integer(), nullable=True),
+        sa.Column("tu_stop_timestamp", sa.Integer(), nullable=True),
+        sa.Column("trip_id", sa.String(length=128), nullable=True),
+        sa.Column("vehicle_label", sa.String(length=128), nullable=True),
+        sa.Column("vehicle_consist", sa.String(), nullable=True),
+        sa.Column("static_version_key", sa.Integer(), nullable=False),
+        sa.PrimaryKeyConstraint("pk_id"),
+    )
+    op.drop_table("vehicle_event_metrics")
+    op.drop_table("temp_hash_compare")
+    op.drop_index(
+        "ix_static_calendar_dates_timestamp", table_name="static_calendar_dates"
+    )
+    op.create_index(
+        op.f("ix_static_calendar_dates_static_version_key"),
+        "static_calendar_dates",
+        ["static_version_key"],
+        unique=False,
+    )
+    op.drop_index(
+        "ix_static_directions_timestamp", table_name="static_directions"
+    )
+    op.create_index(
+        op.f("ix_static_directions_static_version_key"),
+        "static_directions",
+        ["static_version_key"],
+        unique=False,
+    )
+    op.drop_index(
+        "ix_static_stop_times_stop_id", table_name="static_stop_times"
+    )
+    op.drop_index(
+        "ix_static_stop_times_timestamp", table_name="static_stop_times"
+    )
+    op.drop_index(
+        "ix_static_stop_times_trip_id", table_name="static_stop_times"
+    )
+    op.create_index(
+        "ix_static_stop_times_composite_1",
+        "static_stop_times",
+        ["static_version_key", "trip_id", "stop_id", "stop_sequence"],
+        unique=False,
+    )
+    op.drop_index("ix_static_stops_stop_id", table_name="static_stops")
+    op.drop_index("ix_static_stops_timestamp", table_name="static_stops")
+    op.create_index(
+        "ix_static_stops_composite_1",
+        "static_stops",
+        ["static_version_key", "stop_id"],
+        unique=False,
+    )
+    op.drop_index("ix_static_trips_service_id", table_name="static_trips")
+    op.drop_index("ix_static_trips_timestamp", table_name="static_trips")
+    op.drop_index("ix_static_trips_trip_id", table_name="static_trips")
+    op.create_index(
+        "ix_static_trips_composite_1",
+        "static_trips",
+        ["static_version_key", "trip_id", "service_id"],
+        unique=False,
+    )
+    op.add_column(
+        "vehicle_events",
+        sa.Column("service_date", sa.Integer(), nullable=False),
+    )
+    op.add_column(
+        "vehicle_events", sa.Column("pm_trip_id", sa.Integer(), nullable=False)
+    )
+    op.add_column(
+        "vehicle_events",
+        sa.Column("travel_time_seconds", sa.Integer(), nullable=True),
+    )
+    op.add_column(
+        "vehicle_events",
+        sa.Column("dwell_time_seconds", sa.Integer(), nullable=True),
+    )
+    op.add_column(
+        "vehicle_events",
+        sa.Column("headway_trunk_seconds", sa.Integer(), nullable=True),
+    )
+    op.add_column(
+        "vehicle_events",
+        sa.Column("headway_branch_seconds", sa.Integer(), nullable=True),
+    )
+    op.alter_column(
+        "vehicle_events",
+        "stop_sequence",
+        existing_type=sa.SmallInteger(),
+        nullable=True,
+    )
+    op.drop_index("ix_vehicle_events_trip_hash", table_name="vehicle_events")
+    op.drop_index(
+        "ix_vehicle_events_trip_stop_hash", table_name="vehicle_events"
+    )
+    op.create_index(
+        "ix_vehicle_events_composite_1",
+        "vehicle_events",
+        ["service_date", "pm_trip_id", "parent_station"],
+        unique=True,
+    )
+    op.drop_column("vehicle_events", "trip_hash")
+    op.drop_column("vehicle_events", "pk_id")
+    op.drop_column("vehicle_events", "trip_stop_hash")
+
+    ## TRIPS TABLE ##
+
+    op.create_unique_constraint(
+        "vehicle_trips_unique_trip",
+        "vehicle_trips",
+        [
+            "service_date",
+            "route_id",
+            "direction_id",
+            "start_time",
+            "vehicle_id",
+        ],
+    )
+    op.drop_column("vehicle_trips", "trip_hash")
+    op.add_column(
+        "vehicle_trips",
+        sa.Column(
+            "pm_trip_id",
+            sa.Integer(),
+            sa.Identity(always=True, start=1, increment=1, cycle=False),
+            nullable=False,
+        ),
+    )
+    op.create_primary_key(
+        "vehicle_trips_pk",
+        "vehicle_trips",
+        columns=["service_date", "pm_trip_id"],
+    )
+    op.create_index(
+        "ix_vehicle_trips_composite_1",
+        "vehicle_trips",
+        ["route_id", "direction_id", "vehicle_id"],
+        unique=False,
+    )
+
+    update_view = """
+        CREATE OR REPLACE VIEW opmi_all_rt_fields_joined AS 
+        SELECT
+            vt.service_date
+            , ve.pm_trip_id as trip_hash
+            , NULL as trip_stop_hash
+            , ve.stop_sequence
+            , ve.stop_id
+            , LAG (ve.stop_id, 1) OVER (PARTITION BY ve.pm_trip_id ORDER BY COALESCE(ve.vp_stop_timestamp,  ve.tu_stop_timestamp, ve.vp_move_timestamp)) as previous_stop_id
+            , ve.parent_station
+            , LAG (ve.parent_station, 1) OVER (PARTITION BY ve.pm_trip_id ORDER BY COALESCE(ve.vp_stop_timestamp,  ve.tu_stop_timestamp, ve.vp_move_timestamp)) as previous_parent_station
+            , ve.vp_move_timestamp
+            , COALESCE(ve.vp_stop_timestamp,  ve.tu_stop_timestamp) as vp_tu_stop_timestamp
+            , vt.direction_id
+            , vt.route_id
+            , vt.branch_route_id
+            , vt.trunk_route_id
+            , vt.start_time
+            , vt.vehicle_id
+            , vt.stop_count
+            , vt.trip_id
+            , vt.vehicle_label
+            , vt.vehicle_consist
+            , vt.direction
+            , vt.direction_destination
+            , vt.static_trip_id_guess
+            , vt.static_start_time
+            , vt.static_stop_count
+            , vt.first_last_station_match
+            , vt.static_version_key
+            , ve.travel_time_seconds
+            , ve.dwell_time_seconds
+            , ve.headway_trunk_seconds
+            , ve.headway_branch_seconds
+            , ve.updated_on
+        FROM 
+            vehicle_events ve
+        LEFT JOIN
+            vehicle_trips vt
+        ON 
+            ve.pm_trip_id = vt.pm_trip_id
+        ;
+    """
+    op.execute(update_view)
+
+    create_rt_braintree_function = """
+        CREATE OR REPLACE FUNCTION rt_red_is_braintree_branch(p_trip_id int) RETURNS boolean AS $$ 
+        DECLARE
+            found_check bool;
+        BEGIN 
+            SELECT
+                true
+            INTO
+                found_check
+            FROM 
+                vehicle_events ve
+            WHERE 
+                ve.pm_trip_id = p_trip_id
+                AND ve.stop_id IN ('70097', '70098', '70099', '70100', '70101', '70102', '70103', '70104', '70105', '70095', '70096')
+            LIMIT 1
+            ;
+            IF FOUND THEN
+                RETURN true;
+            ELSE
+                RETURN false;
+            END IF;
+        END;
+        $$ LANGUAGE plpgsql;
+    """
+    op.execute(create_rt_braintree_function)
+
+    create_rt_ashmont_function = """
+        CREATE OR REPLACE FUNCTION rt_red_is_ashmont_branch(p_trip_id int) RETURNS boolean AS $$ 
+        DECLARE
+            found_check bool;
+        BEGIN 
+            SELECT
+                true
+            INTO
+                found_check
+            FROM 
+                vehicle_events ve
+            WHERE 
+                ve.pm_trip_id = p_trip_id
+                AND ve.stop_id IN ('70087', '70088', '70089', '70090', '70091', '70092', '70093', '70094', '70085', '70086')
+            LIMIT 1
+            ;
+            IF FOUND THEN
+                RETURN true;
+            ELSE
+                RETURN false;
+            END IF;
+        END;
+        $$ LANGUAGE plpgsql;
+    """
+    op.execute(create_rt_ashmont_function)
+
+    create_get_rt_branch_trunk_id = """
+        CREATE OR REPLACE FUNCTION update_rt_branch_trunk_id() RETURNS TRIGGER AS $$ 
+        BEGIN 
+            IF NEW.route_id ~ 'Green-' THEN
+                NEW.branch_route_id := NEW.route_id;
+                NEW.trunk_route_id := 'Green';
+            ELSEIF NEW.route_id = 'Red' THEN
+                IF rt_red_is_braintree_branch(NEW.pm_trip_id) THEN
+                    NEW.branch_route_id := 'Red-Braintree';
+                ELSEIF rt_red_is_ashmont_branch(NEW.pm_trip_id) THEN
+                    NEW.branch_route_id := 'Red-Ashmont';
+                ELSE
+                    NEW.branch_route_id := null;
+                END IF;
+                NEW.trunk_route_id := NEW.route_id;
+            ELSE
+                NEW.branch_route_id := null;
+                NEW.trunk_route_id := NEW.route_id;
+            END IF;
+            RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql;
+    """
+    op.execute(create_get_rt_branch_trunk_id)
+    drop_trigger = (
+        "DROP TRIGGER IF EXISTS rt_trips_update_branch_trunk ON vehicle_trips;"
+    )
+    op.execute(drop_trigger)
+    create_trigger = """
+        CREATE TRIGGER rt_trips_update_branch_trunk BEFORE UPDATE ON vehicle_trips 
+        FOR EACH ROW EXECUTE PROCEDURE update_rt_branch_trunk_id();
+    """
+    op.execute(create_trigger)
+
+
+def downgrade() -> None:
+    op.execute("DROP VIEW IF EXISTS opmi_all_rt_fields_joined;")
+    op.execute("TRUNCATE vehicle_trips, vehicle_events;")
+
+    op.add_column(
+        "vehicle_trips",
+        sa.Column(
+            "trip_hash", postgresql.BYTEA(), autoincrement=False, nullable=False
+        ),
+    )
+    op.drop_constraint(
+        "vehicle_trips_unique_trip", "vehicle_trips", type_="unique"
+    )
+    op.drop_index("ix_vehicle_trips_composite_1", table_name="vehicle_trips")
+    op.drop_constraint("vehicle_trips_pk", "vehicle_trips", type_="primary")
+    op.drop_column("vehicle_trips", "pm_trip_id")
+    op.add_column(
+        "vehicle_events",
+        sa.Column(
+            "trip_stop_hash",
+            postgresql.BYTEA(),
+            autoincrement=False,
+            nullable=False,
+        ),
+    )
+    op.add_column(
+        "vehicle_events",
+        sa.Column("pk_id", sa.INTEGER(), autoincrement=True, nullable=False),
+    )
+    op.add_column(
+        "vehicle_events",
+        sa.Column(
+            "trip_hash", postgresql.BYTEA(), autoincrement=False, nullable=False
+        ),
+    )
+    op.drop_index("ix_vehicle_events_composite_1", table_name="vehicle_events")
+    op.create_index(
+        "ix_vehicle_events_trip_stop_hash",
+        "vehicle_events",
+        ["trip_stop_hash"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_vehicle_events_trip_hash",
+        "vehicle_events",
+        ["trip_hash"],
+        unique=False,
+    )
+    op.drop_column("vehicle_events", "headway_branch_seconds")
+    op.drop_column("vehicle_events", "headway_trunk_seconds")
+    op.drop_column("vehicle_events", "dwell_time_seconds")
+    op.drop_column("vehicle_events", "travel_time_seconds")
+    op.drop_column("vehicle_events", "pm_trip_id")
+    op.drop_column("vehicle_events", "service_date")
+    op.drop_index("ix_static_trips_composite_1", table_name="static_trips")
+    op.create_index(
+        "ix_static_trips_trip_id", "static_trips", ["trip_id"], unique=False
+    )
+    op.create_index(
+        "ix_static_trips_timestamp",
+        "static_trips",
+        ["static_version_key"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_static_trips_service_id",
+        "static_trips",
+        ["service_id"],
+        unique=False,
+    )
+    op.drop_index("ix_static_stops_composite_1", table_name="static_stops")
+    op.create_index(
+        "ix_static_stops_timestamp",
+        "static_stops",
+        ["static_version_key"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_static_stops_stop_id", "static_stops", ["stop_id"], unique=False
+    )
+    op.drop_index(
+        "ix_static_stop_times_composite_1", table_name="static_stop_times"
+    )
+    op.create_index(
+        "ix_static_stop_times_trip_id",
+        "static_stop_times",
+        ["trip_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_static_stop_times_timestamp",
+        "static_stop_times",
+        ["static_version_key"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_static_stop_times_stop_id",
+        "static_stop_times",
+        ["stop_id"],
+        unique=False,
+    )
+    op.drop_index(
+        op.f("ix_static_directions_static_version_key"),
+        table_name="static_directions",
+    )
+    op.create_index(
+        "ix_static_directions_timestamp",
+        "static_directions",
+        ["static_version_key"],
+        unique=False,
+    )
+    op.drop_index(
+        op.f("ix_static_calendar_dates_static_version_key"),
+        table_name="static_calendar_dates",
+    )
+    op.create_index(
+        "ix_static_calendar_dates_timestamp",
+        "static_calendar_dates",
+        ["static_version_key"],
+        unique=False,
+    )
+    op.create_table(
+        "temp_hash_compare",
+        sa.Column(
+            "hash", postgresql.BYTEA(), autoincrement=False, nullable=False
+        ),
+        sa.PrimaryKeyConstraint("hash", name="temp_hash_compare_pkey"),
+    )
+    op.create_table(
+        "vehicle_event_metrics",
+        sa.Column(
+            "trip_stop_hash",
+            postgresql.BYTEA(),
+            autoincrement=False,
+            nullable=False,
+        ),
+        sa.Column(
+            "travel_time_seconds",
+            sa.INTEGER(),
+            autoincrement=False,
+            nullable=True,
+        ),
+        sa.Column(
+            "dwell_time_seconds",
+            sa.INTEGER(),
+            autoincrement=False,
+            nullable=True,
+        ),
+        sa.Column(
+            "headway_trunk_seconds",
+            sa.INTEGER(),
+            autoincrement=False,
+            nullable=True,
+        ),
+        sa.Column(
+            "headway_branch_seconds",
+            sa.INTEGER(),
+            autoincrement=False,
+            nullable=True,
+        ),
+        sa.Column(
+            "updated_on",
+            postgresql.TIMESTAMP(),
+            server_default=sa.text("now()"),
+            autoincrement=False,
+            nullable=True,
+        ),
+        sa.PrimaryKeyConstraint(
+            "trip_stop_hash", name="vehicle_event_metrics_pkey"
+        ),
+    )
+    op.drop_table("temp_event_compare")
+
+    update_view = """
+        CREATE OR REPLACE VIEW opmi_all_rt_fields_joined AS 
+        SELECT
+            vt.service_date
+            , ve.trip_hash
+            , ve.trip_stop_hash
+            , ve.stop_sequence
+            , ve.stop_id
+            , LAG (ve.stop_id, 1) OVER (PARTITION BY ve.trip_hash ORDER BY COALESCE(ve.vp_stop_timestamp,  ve.tu_stop_timestamp, ve.vp_move_timestamp)) as previous_stop_id
+            , ve.parent_station
+            , LAG (ve.parent_station, 1) OVER (PARTITION BY ve.trip_hash ORDER BY COALESCE(ve.vp_stop_timestamp,  ve.tu_stop_timestamp, ve.vp_move_timestamp)) as previous_parent_station
+            , ve.vp_move_timestamp
+            , COALESCE(ve.vp_stop_timestamp,  ve.tu_stop_timestamp) as vp_tu_stop_timestamp
+            , vt.direction_id
+            , vt.route_id
+            , vt.branch_route_id
+            , vt.trunk_route_id
+            , vt.start_time
+            , vt.vehicle_id
+            , vt.stop_count
+            , vt.trip_id
+            , vt.vehicle_label
+            , vt.vehicle_consist
+            , vt.direction
+            , vt.direction_destination
+            , vt.static_trip_id_guess
+            , vt.static_start_time
+            , vt.static_stop_count
+            , vt.first_last_station_match
+            , vt.static_version_key
+            , vem.travel_time_seconds
+            , vem.dwell_time_seconds
+            , vem.headway_trunk_seconds
+            , vem.headway_branch_seconds
+            , COALESCE(vem.updated_on, ve.updated_on) as updated_on
+        FROM 
+            vehicle_events ve
+        LEFT JOIN
+            vehicle_trips vt
+        ON 
+            ve.trip_hash = vt.trip_hash
+        LEFT JOIN 
+            vehicle_event_metrics vem
+        ON
+            ve.trip_stop_hash = vem.trip_stop_hash
+        ;
+    """
+
+    op.execute(update_view)
+
+    create_rt_braintree_function = """
+        CREATE OR REPLACE FUNCTION rt_red_is_braintree_branch(p_trip_hash bytea) RETURNS boolean AS $$ 
+        DECLARE
+            found_check bool;
+        BEGIN 
+            SELECT
+                true
+            INTO
+                found_check
+            FROM 
+                vehicle_events ve
+            WHERE 
+                ve.trip_hash = p_trip_hash
+                AND ve.stop_id IN ('70097', '70098', '70099', '70100', '70101', '70102', '70103', '70104', '70105', '70095', '70096')
+            LIMIT 1
+            ;
+            IF FOUND THEN
+                RETURN true;
+            ELSE
+                RETURN false;
+            END IF;
+        END;
+        $$ LANGUAGE plpgsql;
+    """
+    op.execute(create_rt_braintree_function)
+
+    create_rt_ashmont_function = """
+        CREATE OR REPLACE FUNCTION rt_red_is_ashmont_branch(p_trip_hash bytea) RETURNS boolean AS $$ 
+        DECLARE
+            found_check bool;
+        BEGIN 
+            SELECT
+                true
+            INTO
+                found_check
+            FROM 
+                vehicle_events ve
+            WHERE 
+                ve.trip_hash = p_trip_hash
+                AND ve.stop_id IN ('70087', '70088', '70089', '70090', '70091', '70092', '70093', '70094', '70085', '70086')
+            LIMIT 1
+            ;
+            IF FOUND THEN
+                RETURN true;
+            ELSE
+                RETURN false;
+            END IF;
+        END;
+        $$ LANGUAGE plpgsql;
+    """
+    op.execute(create_rt_ashmont_function)
+
+    create_get_rt_branch_trunk_id = """
+        CREATE OR REPLACE FUNCTION update_rt_branch_trunk_id() RETURNS TRIGGER AS $$ 
+        BEGIN 
+            IF NEW.route_id ~ 'Green-' THEN
+                NEW.branch_route_id := NEW.route_id;
+                NEW.trunk_route_id := 'Green';
+            ELSEIF NEW.route_id = 'Red' THEN
+                IF rt_red_is_braintree_branch(NEW.trip_hash) THEN
+                    NEW.branch_route_id := 'Red-Braintree';
+                ELSEIF rt_red_is_ashmont_branch(NEW.trip_hash) THEN
+                    NEW.branch_route_id := 'Red-Ashmont';
+                ELSE
+                    NEW.branch_route_id := null;
+                END IF;
+                NEW.trunk_route_id := NEW.route_id;
+            ELSE
+                NEW.branch_route_id := null;
+                NEW.trunk_route_id := NEW.route_id;
+            END IF;
+            RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql;
+    """
+    op.execute(create_get_rt_branch_trunk_id)
+    drop_trigger = (
+        "DROP TRIGGER IF EXISTS rt_trips_update_branch_trunk ON vehicle_trips;"
+    )
+    op.execute(drop_trigger)
+    create_trigger = """
+        CREATE TRIGGER rt_trips_update_branch_trunk BEFORE INSERT OR UPDATE ON vehicle_trips 
+        FOR EACH ROW EXECUTE PROCEDURE update_rt_branch_trunk_id();
+    """
+    op.execute(create_trigger)

--- a/python_src/src/lamp_py/performance_manager/gtfs_utils.py
+++ b/python_src/src/lamp_py/performance_manager/gtfs_utils.py
@@ -25,7 +25,7 @@ def start_time_to_seconds(
     return int(hour) * 3600 + int(minute) * 60 + int(second)
 
 
-def get_unique_trip_stop_columns() -> List[str]:
+def unique_trip_stop_columns() -> List[str]:
     """
     columns used to determine if a event is a unique trip stop
     """

--- a/python_src/src/lamp_py/performance_manager/l0_gtfs_static_mod.py
+++ b/python_src/src/lamp_py/performance_manager/l0_gtfs_static_mod.py
@@ -118,7 +118,7 @@ def generate_scheduled_trunk_headways(db_manager: DatabaseManager) -> None:
         .where(
             TempStaticHeadwaysGen.trunk_route_id.is_not(None),
         )
-        .cte("scheduled_trunk_headways")
+        .subquery("scheduled_trunk_headways")
     )
 
     update_q = (
@@ -174,7 +174,11 @@ def load_temp_table_headway_gen(
                 == StaticStopTimes.static_version_key,
             ),
         )
-        .where(StaticStopTimes.static_version_key == static_version_key)
+        .where(
+            StaticStopTimes.static_version_key == static_version_key,
+            StaticStops.static_version_key == static_version_key,
+            StaticTrips.static_version_key == static_version_key,
+        )
     )
     columns_to_insert = [
         "pk_id",

--- a/python_src/src/lamp_py/performance_manager/l0_rt_trip_updates.py
+++ b/python_src/src/lamp_py/performance_manager/l0_rt_trip_updates.py
@@ -11,7 +11,7 @@ from .gtfs_utils import (
     add_static_version_key_column,
     add_parent_station_column,
     remove_bus_records,
-    get_unique_trip_stop_columns,
+    unique_trip_stop_columns,
 )
 
 
@@ -180,7 +180,7 @@ def reduce_trip_updates(trip_updates: pandas.DataFrame) -> pandas.DataFrame:
     )
     process_logger.log_start()
 
-    trip_stop_columns = get_unique_trip_stop_columns()
+    trip_stop_columns = unique_trip_stop_columns()
 
     # sort all trip updates by reverse timestamp, then drop all of the updates
     # for the same trip and same station but the first one. the first update will

--- a/python_src/src/lamp_py/performance_manager/l0_rt_trip_updates.py
+++ b/python_src/src/lamp_py/performance_manager/l0_rt_trip_updates.py
@@ -7,11 +7,11 @@ from lamp_py.postgres.postgres_utils import DatabaseManager
 from lamp_py.runtime_utils.process_logger import ProcessLogger
 
 from .gtfs_utils import (
-    add_event_hash_column,
     start_time_to_seconds,
     add_static_version_key_column,
     add_parent_station_column,
     remove_bus_records,
+    get_unique_trip_stop_columns,
 )
 
 
@@ -30,7 +30,6 @@ def get_tu_dataframe_chunks(
         "start_date",
         "start_time",
         "vehicle_id",
-        "trip_id",
     ]
     trip_update_filters = [
         ("direction_id", "in", (0, 1)),
@@ -59,7 +58,6 @@ def explode_stop_time_update(
     service_date: int,
     start_time: int,
     vehicle_id: Any,
-    trip_id: Any,
 ) -> Optional[List[dict]]:
     """
     explode nested list of dicts in stop_time_update column
@@ -73,7 +71,6 @@ def explode_stop_time_update(
         "service_date": service_date,
         "start_time": start_time,
         "vehicle_id": vehicle_id,
-        "trip_id": trip_id,
     }
     return_list: List[Dict[str, Any]] = []
 
@@ -96,7 +93,6 @@ def explode_stop_time_update(
         append_dict.update(
             {
                 "stop_id": record.get("stop_id"),
-                "stop_sequence": record.get("stop_sequence"),
                 "tu_stop_timestamp": arrival_time,
             }
         )
@@ -162,7 +158,6 @@ def get_and_unwrap_tu_dataframe(
                 batch_events.service_date,
                 batch_events.start_time,
                 batch_events.vehicle_id,
-                batch_events.trip_id,
             )
         ).dropna()
         events = pandas.concat([events, batch_events])
@@ -178,47 +173,35 @@ def get_and_unwrap_tu_dataframe(
 
 def reduce_trip_updates(trip_updates: pandas.DataFrame) -> pandas.DataFrame:
     """
-    add in the "trip_stop_hash" into trip updates and reduce the data frame to
-    a single record per trip / stop.
+    reduce the data frame to a single record per trip / stop.
     """
     process_logger = ProcessLogger(
         "tu.reduce", start_row_count=trip_updates.shape[0]
     )
     process_logger.log_start()
 
-    # add trip_stop_hash column that is unique to a trip and station
-    trip_updates = add_event_hash_column(
-        trip_updates,
-        hash_column_name="trip_stop_hash",
-        expected_hash_columns=[
-            "stop_sequence",
-            "parent_station",
-            "direction_id",
-            "route_id",
-            "service_date",
-            "start_time",
-            "vehicle_id",
-        ],
-    )
+    trip_stop_columns = get_unique_trip_stop_columns()
 
     # sort all trip updates by reverse timestamp, then drop all of the updates
     # for the same trip and same station but the first one. the first update will
     # be the most recent arrival time prediction
     trip_updates = trip_updates.sort_values(by=["timestamp"], ascending=False)
     trip_updates = trip_updates.drop_duplicates(
-        subset=["trip_stop_hash"], keep="first"
+        subset=trip_stop_columns, keep="first"
     )
 
-    # after hash and sort, "timestamp" longer needed
+    # after group and sort, "timestamp" longer needed
     trip_updates = trip_updates.drop(columns=["timestamp"])
 
     trip_updates["tu_stop_timestamp"] = trip_updates[
         "tu_stop_timestamp"
     ].astype("Int64")
 
-    # add vehicle_lable and vehicle_consist columns
+    # add selected columns
     # trip_updates and vehicle_positions dataframes must all have the same columns
     # available to be correctly joined in combine_events function of l0_gtfs_rt_events.py
+    trip_updates["trip_id"] = None
+    trip_updates["stop_sequence"] = None
     trip_updates["vehicle_label"] = None
     trip_updates["vehicle_consist"] = None
 
@@ -240,10 +223,11 @@ def process_tu_files(
     process_logger.log_start()
 
     trip_updates = get_and_unwrap_tu_dataframe(paths)
-    trip_updates = add_static_version_key_column(trip_updates, db_manager)
-    trip_updates = remove_bus_records(trip_updates, db_manager)
-    trip_updates = add_parent_station_column(trip_updates, db_manager)
-    trip_updates = reduce_trip_updates(trip_updates)
+    if trip_updates.shape[0] > 0:
+        trip_updates = add_static_version_key_column(trip_updates, db_manager)
+        trip_updates = remove_bus_records(trip_updates, db_manager)
+        trip_updates = add_parent_station_column(trip_updates, db_manager)
+        trip_updates = reduce_trip_updates(trip_updates)
 
     process_logger.add_metadata(vehicle_events_count=trip_updates.shape[0])
     process_logger.log_complete()

--- a/python_src/src/lamp_py/performance_manager/l0_rt_vehicle_positions.py
+++ b/python_src/src/lamp_py/performance_manager/l0_rt_vehicle_positions.py
@@ -11,7 +11,7 @@ from .gtfs_utils import (
     add_static_version_key_column,
     add_parent_station_column,
     remove_bus_records,
-    get_unique_trip_stop_columns,
+    unique_trip_stop_columns,
 )
 
 
@@ -118,8 +118,8 @@ def transform_vp_timestamps(
     convert raw vp data into a timestamped event data for each stop on a trip.
 
     this method will add
-    * "vp_move_timestamp" - when the vehicle begins moving towards the hashed stop
-    * "vp_stop_timestamp" - when the vehicle arrives at the hashed stop
+    * "vp_move_timestamp" - when the vehicle begins moving towards the event parent_staion
+    * "vp_stop_timestamp" - when the vehicle arrives at the event parent_station
 
     this method will remove "is_moving" and "vehicle_timestamp"
     """
@@ -128,7 +128,7 @@ def transform_vp_timestamps(
     )
     process_logger.log_start()
 
-    trip_stop_columns = get_unique_trip_stop_columns()
+    trip_stop_columns = unique_trip_stop_columns()
     # TODO: review trip_id processing # pylint: disable=fixme
     #  add more intelligent trip_id processing, this approach will randomly select trip_id record to keep
 

--- a/python_src/src/lamp_py/performance_manager/l1_cte_statements.py
+++ b/python_src/src/lamp_py/performance_manager/l1_cte_statements.py
@@ -1,5 +1,3 @@
-from typing import List
-
 import sqlalchemy as sa
 from lamp_py.postgres.postgres_schema import (
     ServiceIdDates,
@@ -13,8 +11,8 @@ from lamp_py.postgres.postgres_schema import (
 
 
 def get_static_trips_cte(
-    version_keys: List[int], service_date: int
-) -> sa.sql.selectable.CTE:
+    static_version_key: int, service_date: int
+) -> sa.sql.selectable.Subquery:
     """
     return CTE named "static_trip_cte" representing all static trips on given service date
 
@@ -105,15 +103,19 @@ def get_static_trips_cte(
             ),
         )
         .where(
-            StaticStopTimes.static_version_key.in_(version_keys),
+            StaticStopTimes.static_version_key == int(static_version_key),
+            StaticTrips.static_version_key == int(static_version_key),
+            StaticStops.static_version_key == int(static_version_key),
+            ServiceIdDates.static_version_key == int(static_version_key),
+            StaticRoutes.static_version_key == int(static_version_key),
             StaticRoutes.route_type != 3,
             ServiceIdDates.service_date == int(service_date),
         )
-        .cte(name="static_trips_cte")
+        .subquery(name="static_trips_cte")
     )
 
 
-def get_rt_trips_cte(service_date: int) -> sa.sql.selectable.CTE:
+def get_rt_trips_cte(service_date: int) -> sa.sql.selectable.Subquery:
     """
     return CTE named "rt_trips_cte" representing all RT trips on a given service date
 
@@ -135,32 +137,31 @@ def get_rt_trips_cte(service_date: int) -> sa.sql.selectable.CTE:
             VehicleTrips.vehicle_id,
             VehicleTrips.stop_count,
             VehicleTrips.static_trip_id_guess,
-            VehicleEvents.trip_hash,
+            VehicleEvents.pm_trip_id,
             VehicleEvents.stop_sequence,
             VehicleEvents.parent_station,
-            VehicleEvents.trip_stop_hash,
             VehicleEvents.vp_move_timestamp,
             VehicleEvents.vp_stop_timestamp,
             VehicleEvents.tu_stop_timestamp,
             (
-                sa.func.lag(VehicleEvents.trip_hash)
+                sa.func.lag(VehicleEvents.pm_trip_id)
                 .over(
-                    partition_by=(VehicleEvents.trip_hash),
+                    partition_by=(VehicleEvents.pm_trip_id),
                     order_by=VehicleEvents.stop_sequence,
                 )
                 .is_(None)
             ).label("rt_trip_first_stop_flag"),
             (
-                sa.func.lead(VehicleEvents.trip_hash)
+                sa.func.lead(VehicleEvents.pm_trip_id)
                 .over(
-                    partition_by=(VehicleEvents.trip_hash),
+                    partition_by=(VehicleEvents.pm_trip_id),
                     order_by=VehicleEvents.stop_sequence,
                 )
                 .is_(None)
             ).label("rt_trip_last_stop_flag"),
             sa.func.rank()
             .over(
-                partition_by=(VehicleEvents.trip_hash),
+                partition_by=(VehicleEvents.pm_trip_id),
                 order_by=VehicleEvents.stop_sequence,
             )
             .label("rt_trip_stop_rank"),
@@ -168,21 +169,22 @@ def get_rt_trips_cte(service_date: int) -> sa.sql.selectable.CTE:
         .select_from(VehicleEvents)
         .join(
             VehicleTrips,
-            VehicleTrips.trip_hash == VehicleEvents.trip_hash,
+            VehicleTrips.pm_trip_id == VehicleEvents.pm_trip_id,
         )
         .where(
             VehicleTrips.service_date == service_date,
+            VehicleEvents.service_date == service_date,
             sa.or_(
                 VehicleEvents.vp_move_timestamp.is_not(None),
                 VehicleEvents.vp_stop_timestamp.is_not(None),
             ),
         )
-    ).cte(name="rt_trips_cte")
+    ).subquery(name="rt_trips_cte")
 
 
 def get_trips_for_metrics(
-    version_keys: List[int], service_date: int
-) -> sa.sql.selectable.CTE:
+    static_version_key: int, service_date: int
+) -> sa.sql.selectable.Subquery:
     """
     return CTE named "trips_for_metrics" with fields needed to develop metrics tables
 
@@ -197,14 +199,14 @@ def get_trips_for_metrics(
     bus routes, so we may be able to drop this for performance_manager
     """
 
-    static_trips_cte = get_static_trips_cte(version_keys, service_date)
+    static_trips_cte = get_static_trips_cte(static_version_key, service_date)
     rt_trips_cte = get_rt_trips_cte(service_date)
 
     return (
         sa.select(
-            rt_trips_cte.c.trip_stop_hash,
             rt_trips_cte.c.static_version_key,
-            rt_trips_cte.c.trip_hash,
+            rt_trips_cte.c.pm_trip_id,
+            rt_trips_cte.c.service_date,
             rt_trips_cte.c.direction_id,
             rt_trips_cte.c.route_id,
             rt_trips_cte.c.branch_route_id,
@@ -247,7 +249,9 @@ def get_trips_for_metrics(
             .label("next_station_move"),
         )
         .distinct(
-            rt_trips_cte.c.trip_stop_hash,
+            rt_trips_cte.c.service_date,
+            rt_trips_cte.c.pm_trip_id,
+            rt_trips_cte.c.parent_station,
         )
         .select_from(rt_trips_cte)
         .join(
@@ -265,7 +269,9 @@ def get_trips_for_metrics(
             isouter=True,
         )
         .order_by(
-            rt_trips_cte.c.trip_stop_hash,
+            rt_trips_cte.c.service_date,
+            rt_trips_cte.c.pm_trip_id,
+            rt_trips_cte.c.parent_station,
             static_trips_cte.c.static_trip_stop_rank,
         )
-    ).cte(name="trip_for_metrics")
+    ).subquery(name="trip_for_metrics")

--- a/python_src/src/lamp_py/performance_manager/l1_cte_statements.py
+++ b/python_src/src/lamp_py/performance_manager/l1_cte_statements.py
@@ -10,13 +10,12 @@ from lamp_py.postgres.postgres_schema import (
 )
 
 
-def get_static_trips_cte(
+def static_trips_subquery(
     static_version_key: int, service_date: int
 ) -> sa.sql.selectable.Subquery:
     """
-    return CTE named "static_trip_cte" representing all static trips on given service date
-
-    a "set" of static trips will be returned for every "static_version_key" key value.
+    return Selectable representing all static trips on
+    given service_date and static_version_key value combo
 
     created fields to be returned:
         - static_trip_first_stop (bool indicating first stop of trip)
@@ -111,13 +110,13 @@ def get_static_trips_cte(
             StaticRoutes.route_type != 3,
             ServiceIdDates.service_date == int(service_date),
         )
-        .subquery(name="static_trips_cte")
+        .subquery(name="static_trips_sub")
     )
 
 
-def get_rt_trips_cte(service_date: int) -> sa.sql.selectable.Subquery:
+def rt_trips_subquery(service_date: int) -> sa.sql.selectable.Subquery:
     """
-    return CTE named "rt_trips_cte" representing all RT trips on a given service date
+    return Selectable representing all RT trips on a given service date
 
     created fields to be returned:
         - rt_trip_first_stop_flag (bool indicating first stop of trip by trip_hash)
@@ -179,99 +178,97 @@ def get_rt_trips_cte(service_date: int) -> sa.sql.selectable.Subquery:
                 VehicleEvents.vp_stop_timestamp.is_not(None),
             ),
         )
-    ).subquery(name="rt_trips_cte")
+    ).subquery(name="rt_trips_sub")
 
 
-def get_trips_for_metrics(
+def trips_for_metrics_subquery(
     static_version_key: int, service_date: int
 ) -> sa.sql.selectable.Subquery:
     """
-    return CTE named "trips_for_metrics" with fields needed to develop metrics tables
+    return Selectable named "trips_for_metrics" with fields needed to develop metrics tables
 
-    will return one record for every trip_stop_hash on 'service_date'
+    will return one record for every unique trip-stop on 'service_date'
 
-    joins rt_trips_cte to VehicleTrips on trip_hash field
-
-    then joins static_trips_cte on static_trip_id_guess, timestamp, parent_station and static_stop_rank,
+    joins rt_trips_sub to static_trips_sub on static_trip_id_guess, static_version_key, parent_station and static_stop_rank,
 
     the join with static_stop_rank is required for routes that may visit the same
     parent station more than once on the same route, I think this only occurs on
     bus routes, so we may be able to drop this for performance_manager
     """
 
-    static_trips_cte = get_static_trips_cte(static_version_key, service_date)
-    rt_trips_cte = get_rt_trips_cte(service_date)
+    static_trips_sub = static_trips_subquery(static_version_key, service_date)
+    rt_trips_sub = rt_trips_subquery(service_date)
 
     return (
         sa.select(
-            rt_trips_cte.c.static_version_key,
-            rt_trips_cte.c.pm_trip_id,
-            rt_trips_cte.c.service_date,
-            rt_trips_cte.c.direction_id,
-            rt_trips_cte.c.route_id,
-            rt_trips_cte.c.branch_route_id,
-            rt_trips_cte.c.trunk_route_id,
-            rt_trips_cte.c.stop_count,
-            rt_trips_cte.c.start_time,
-            rt_trips_cte.c.vehicle_id,
-            rt_trips_cte.c.parent_station,
-            rt_trips_cte.c.vp_move_timestamp.label("move_timestamp"),
+            rt_trips_sub.c.static_version_key,
+            rt_trips_sub.c.pm_trip_id,
+            rt_trips_sub.c.service_date,
+            rt_trips_sub.c.direction_id,
+            rt_trips_sub.c.route_id,
+            rt_trips_sub.c.branch_route_id,
+            rt_trips_sub.c.trunk_route_id,
+            rt_trips_sub.c.stop_count,
+            rt_trips_sub.c.start_time,
+            rt_trips_sub.c.vehicle_id,
+            rt_trips_sub.c.parent_station,
+            rt_trips_sub.c.vp_move_timestamp.label("move_timestamp"),
             sa.func.coalesce(
-                rt_trips_cte.c.vp_stop_timestamp,
-                rt_trips_cte.c.tu_stop_timestamp,
+                rt_trips_sub.c.vp_stop_timestamp,
+                rt_trips_sub.c.tu_stop_timestamp,
             ).label("stop_timestamp"),
             sa.func.coalesce(
-                rt_trips_cte.c.vp_move_timestamp,
-                rt_trips_cte.c.vp_stop_timestamp,
-                rt_trips_cte.c.tu_stop_timestamp,
+                rt_trips_sub.c.vp_move_timestamp,
+                rt_trips_sub.c.vp_stop_timestamp,
+                rt_trips_sub.c.tu_stop_timestamp,
             ).label("sort_timestamp"),
             sa.func.coalesce(
-                static_trips_cte.c.static_trip_first_stop,
-                rt_trips_cte.c.rt_trip_first_stop_flag,
+                static_trips_sub.c.static_trip_first_stop,
+                rt_trips_sub.c.rt_trip_first_stop_flag,
             ).label("first_stop_flag"),
             sa.func.coalesce(
-                static_trips_cte.c.static_trip_last_stop,
-                rt_trips_cte.c.rt_trip_last_stop_flag,
+                static_trips_sub.c.static_trip_last_stop,
+                rt_trips_sub.c.rt_trip_last_stop_flag,
             ).label("last_stop_flag"),
             sa.func.coalesce(
-                static_trips_cte.c.static_trip_stop_rank,
-                rt_trips_cte.c.rt_trip_stop_rank,
+                static_trips_sub.c.static_trip_stop_rank,
+                rt_trips_sub.c.rt_trip_stop_rank,
             ).label("stop_rank"),
-            sa.func.lead(rt_trips_cte.c.vp_move_timestamp)
+            sa.func.lead(rt_trips_sub.c.vp_move_timestamp)
             .over(
-                partition_by=rt_trips_cte.c.vehicle_id,
+                partition_by=rt_trips_sub.c.vehicle_id,
                 order_by=sa.func.coalesce(
-                    rt_trips_cte.c.vp_move_timestamp,
-                    rt_trips_cte.c.vp_stop_timestamp,
-                    rt_trips_cte.c.tu_stop_timestamp,
+                    rt_trips_sub.c.vp_move_timestamp,
+                    rt_trips_sub.c.vp_stop_timestamp,
+                    rt_trips_sub.c.tu_stop_timestamp,
                 ),
             )
             .label("next_station_move"),
         )
         .distinct(
-            rt_trips_cte.c.service_date,
-            rt_trips_cte.c.pm_trip_id,
-            rt_trips_cte.c.parent_station,
+            rt_trips_sub.c.service_date,
+            rt_trips_sub.c.pm_trip_id,
+            rt_trips_sub.c.parent_station,
         )
-        .select_from(rt_trips_cte)
+        .select_from(rt_trips_sub)
         .join(
-            static_trips_cte,
+            static_trips_sub,
             sa.and_(
-                rt_trips_cte.c.static_trip_id_guess
-                == static_trips_cte.c.static_trip_id,
-                rt_trips_cte.c.static_version_key
-                == static_trips_cte.c.static_version_key,
-                rt_trips_cte.c.parent_station
-                == static_trips_cte.c.parent_station,
-                rt_trips_cte.c.rt_trip_stop_rank
-                >= static_trips_cte.c.static_trip_stop_rank,
+                rt_trips_sub.c.static_trip_id_guess
+                == static_trips_sub.c.static_trip_id,
+                rt_trips_sub.c.static_version_key
+                == static_trips_sub.c.static_version_key,
+                rt_trips_sub.c.parent_station
+                == static_trips_sub.c.parent_station,
+                rt_trips_sub.c.rt_trip_stop_rank
+                >= static_trips_sub.c.static_trip_stop_rank,
             ),
             isouter=True,
         )
         .order_by(
-            rt_trips_cte.c.service_date,
-            rt_trips_cte.c.pm_trip_id,
-            rt_trips_cte.c.parent_station,
-            static_trips_cte.c.static_trip_stop_rank,
+            rt_trips_sub.c.service_date,
+            rt_trips_sub.c.pm_trip_id,
+            rt_trips_sub.c.parent_station,
+            static_trips_sub.c.static_trip_stop_rank,
         )
     ).subquery(name="trip_for_metrics")

--- a/python_src/src/lamp_py/performance_manager/l1_rt_metrics.py
+++ b/python_src/src/lamp_py/performance_manager/l1_rt_metrics.py
@@ -1,12 +1,9 @@
-from typing import List
-
-import numpy
-import pandas
 import sqlalchemy as sa
 
 from lamp_py.postgres.postgres_utils import DatabaseManager
 from lamp_py.postgres.postgres_schema import (
-    VehicleEventMetrics,
+    VehicleEvents,
+    TempEventCompare,
 )
 from lamp_py.runtime_utils.process_logger import ProcessLogger
 from .l1_cte_statements import get_trips_for_metrics
@@ -17,7 +14,7 @@ from .l1_cte_statements import get_trips_for_metrics
 def process_metrics_table(
     db_manager: DatabaseManager,
     seed_service_date: int,
-    version_keys: List[int],
+    static_version_key: int,
 ) -> None:
     """
     process updates to metrics table
@@ -27,29 +24,33 @@ def process_metrics_table(
     process_logger = ProcessLogger("l1_rt_metrics_table_loader")
     process_logger.log_start()
 
-    trips_for_metrics = get_trips_for_metrics(version_keys, seed_service_date)
+    trips_for_metrics = get_trips_for_metrics(
+        static_version_key, seed_service_date
+    )
 
     # travel_times calculation:
     # limited to records where stop_timestamp > move_timestamp to avoid negative travel times
     # limited to non NULL stop and move timestamps to avoid NULL results
     # negative travel times are error records, should flag???
-    travel_times_cte = (
-        sa.select(
-            trips_for_metrics.c.trip_stop_hash,
-            (
-                trips_for_metrics.c.stop_timestamp
-                - trips_for_metrics.c.move_timestamp
-            ).label("travel_time_seconds"),
+    update_travel_times = (
+        sa.update(VehicleEvents.__table__)
+        .values(
+            travel_time_seconds=trips_for_metrics.c.stop_timestamp
+            - trips_for_metrics.c.move_timestamp
         )
         .where(
+            VehicleEvents.pm_trip_id == trips_for_metrics.c.pm_trip_id,
+            VehicleEvents.service_date == trips_for_metrics.c.service_date,
+            VehicleEvents.parent_station == trips_for_metrics.c.parent_station,
             trips_for_metrics.c.first_stop_flag == sa.false(),
             trips_for_metrics.c.stop_timestamp.is_not(None),
             trips_for_metrics.c.move_timestamp.is_not(None),
             trips_for_metrics.c.stop_timestamp
             > trips_for_metrics.c.move_timestamp,
         )
-        .cte(name="travel_times")
     )
+
+    db_manager.execute(update_travel_times)
 
     # dwell_times calculations are different for the first stop of a trip
     # the first stop of a trip includes the dwell time since the stop_timestamp of
@@ -58,14 +59,16 @@ def process_metrics_table(
     # all remaining dwell_times calculations are based on subtracting the a stop_timestamp
     # of a vehicle from the next move_timestamp of a vehicle
     #
-    # the where statement of this CTE filters out any vehicle trips comprised of only 1 stop
+    # the where statement of this query filters out any vehicle trips comprised of only 1 stop
     # on the assumption that those are not valid trips to include in the metrics calculations
     #
     # for consecutive trips that do not have same vehicle ID the first_stop headway
     # logic could have issues
-    t_dwell_times_cte = (
+    t_dwell_times_sub = (
         sa.select(
-            trips_for_metrics.c.trip_stop_hash,
+            trips_for_metrics.c.pm_trip_id,
+            trips_for_metrics.c.service_date,
+            trips_for_metrics.c.parent_station,
             sa.case(
                 [
                     (
@@ -106,34 +109,39 @@ def process_metrics_table(
                 trips_for_metrics.c.first_stop_flag == sa.false(),
             ),
         )
-        .cte(name="t_dwell_times")
+        .subquery(name="t_dwell_times")
     )
 
     # limit dwell times calculations to NON-NULL positive integers
-    # would be nice if this could be done in the first CTE, but I can't
+    # would be nice if this could be done in the first query, but I can't
     # get it to work with sqlalchemy
-    dwell_times_cte = (
-        sa.select(
-            t_dwell_times_cte.c.trip_stop_hash,
-            t_dwell_times_cte.c.dwell_time_seconds,
+    update_dwell_times = (
+        sa.update(VehicleEvents.__table__)
+        .values(
+            dwell_time_seconds=t_dwell_times_sub.c.dwell_time_seconds,
         )
         .where(
-            t_dwell_times_cte.c.dwell_time_seconds.is_not(None),
-            t_dwell_times_cte.c.dwell_time_seconds > 0,
+            VehicleEvents.pm_trip_id == t_dwell_times_sub.c.pm_trip_id,
+            VehicleEvents.service_date == t_dwell_times_sub.c.service_date,
+            VehicleEvents.parent_station == t_dwell_times_sub.c.parent_station,
+            t_dwell_times_sub.c.dwell_time_seconds.is_not(None),
+            t_dwell_times_sub.c.dwell_time_seconds > 0,
         )
-        .cte(name="dwell_times")
     )
+    db_manager.execute(update_dwell_times)
 
-    # this headways CTE calculation is incomplete
+    # this headways calculation is incomplete
     #
     # trunk and branch headways are the same except for one is partitioned on
     # trunk_route_id and the later on branch_route_id.
     #
     # headways are calculated with stop_timestamp to stop_timestamp for the
     # next station in a trip
-    t_headways_branch_cte = (
+    t_headways_branch_sub = (
         sa.select(
-            trips_for_metrics.c.trip_stop_hash,
+            trips_for_metrics.c.pm_trip_id,
+            trips_for_metrics.c.service_date,
+            trips_for_metrics.c.parent_station,
             (
                 trips_for_metrics.c.next_station_move
                 - sa.func.lag(
@@ -155,27 +163,33 @@ def process_metrics_table(
             ),
             trips_for_metrics.c.branch_route_id.is_not(None),
         )
-        .cte(name="t_headways_branch")
+        .subquery(name="t_headways_branch")
     )
 
     # limit headways branch calculations to NON-NULL positive integers
-    # would be nice if this could be done in the first CTE, but I can't
+    # would be nice if this could be done in the first query, but I can't
     # get it to work with sqlalchemy
-    headways_branch_cte = (
-        sa.select(
-            t_headways_branch_cte.c.trip_stop_hash,
-            t_headways_branch_cte.c.headway_branch_seconds,
+    update_branch_headways = (
+        sa.update(VehicleEvents.__table__)
+        .values(
+            headway_branch_seconds=t_headways_branch_sub.c.headway_branch_seconds
         )
         .where(
-            t_headways_branch_cte.c.headway_branch_seconds.is_not(None),
-            t_headways_branch_cte.c.headway_branch_seconds > 0,
+            VehicleEvents.pm_trip_id == t_headways_branch_sub.c.pm_trip_id,
+            VehicleEvents.service_date == t_headways_branch_sub.c.service_date,
+            VehicleEvents.parent_station
+            == t_headways_branch_sub.c.parent_station,
+            t_headways_branch_sub.c.headway_branch_seconds.is_not(None),
+            t_headways_branch_sub.c.headway_branch_seconds > 0,
         )
-        .cte(name="headways_branch")
     )
+    db_manager.execute(update_branch_headways)
 
-    t_headways_trunk_cte = (
+    t_headways_trunk_sub = (
         sa.select(
-            trips_for_metrics.c.trip_stop_hash,
+            trips_for_metrics.c.pm_trip_id,
+            trips_for_metrics.c.service_date,
+            trips_for_metrics.c.parent_station,
             (
                 trips_for_metrics.c.next_station_move
                 - sa.func.lag(
@@ -197,172 +211,27 @@ def process_metrics_table(
             ),
             trips_for_metrics.c.trunk_route_id.is_not(None),
         )
-        .cte(name="t_headways_trunk")
+        .subquery(name="t_headways_trunk")
     )
 
     # limit headways trunk calculations to NON-NULL positive integers
     # would be nice if this could be done in the first CTE, but I can't
     # get it to work with sqlalchemy
-    headways_trunk_cte = (
-        sa.select(
-            t_headways_trunk_cte.c.trip_stop_hash,
-            t_headways_trunk_cte.c.headway_trunk_seconds,
+    update_trunk_headways = (
+        sa.update(VehicleEvents.__table__)
+        .values(
+            headway_trunk_seconds=t_headways_trunk_sub.c.headway_trunk_seconds
         )
         .where(
-            t_headways_trunk_cte.c.headway_trunk_seconds.is_not(None),
-            t_headways_trunk_cte.c.headway_trunk_seconds > 0,
-        )
-        .cte(name="headways_trunk")
-    )
-
-    # all_new_metrics combines travel_times, dwell_times and headways into one result set
-    # previous CTE's ensure that individual input tables will not have null or negative values
-    # would be nice to be able to use USING instead of COALESCE function for combining multiple
-    # tables with same key, but I can't locate support in sqlalchemy
-    all_new_metrics = (
-        sa.select(
-            sa.func.coalesce(
-                travel_times_cte.c.trip_stop_hash,
-                dwell_times_cte.c.trip_stop_hash,
-                headways_branch_cte.c.trip_stop_hash,
-                headways_trunk_cte.c.trip_stop_hash,
-            ).label("trip_stop_hash"),
-            travel_times_cte.c.travel_time_seconds,
-            dwell_times_cte.c.dwell_time_seconds,
-            headways_branch_cte.c.headway_branch_seconds,
-            headways_trunk_cte.c.headway_trunk_seconds,
-        )
-        .select_from(
-            travel_times_cte,
-        )
-        .join(
-            dwell_times_cte,
-            travel_times_cte.c.trip_stop_hash
-            == dwell_times_cte.c.trip_stop_hash,
-            full=True,
-        )
-        .join(
-            headways_branch_cte,
-            sa.func.coalesce(
-                travel_times_cte.c.trip_stop_hash,
-                dwell_times_cte.c.trip_stop_hash,
-            )
-            == headways_branch_cte.c.trip_stop_hash,
-            full=True,
-        )
-        .join(
-            headways_trunk_cte,
-            sa.func.coalesce(
-                travel_times_cte.c.trip_stop_hash,
-                dwell_times_cte.c.trip_stop_hash,
-                headways_branch_cte.c.trip_stop_hash,
-            )
-            == headways_trunk_cte.c.trip_stop_hash,
-            full=True,
-        )
-    ).cte(name="all_new_metrics")
-
-    # update / insert logic matches what is done for the trips table
-    # all_new_metrics are matched to existing RDS records by trip_stop_hash
-    # and flagged for update, if needed
-    update_insert_query = (
-        sa.select(
-            all_new_metrics.c.trip_stop_hash,
-            VehicleEventMetrics.trip_stop_hash.label("existing_trip_stop_hash"),
-            all_new_metrics.c.travel_time_seconds,
-            all_new_metrics.c.dwell_time_seconds,
-            all_new_metrics.c.headway_branch_seconds,
-            all_new_metrics.c.headway_trunk_seconds,
-            sa.case(
-                [
-                    (
-                        sa.or_(
-                            all_new_metrics.c.travel_time_seconds
-                            != VehicleEventMetrics.travel_time_seconds,
-                            all_new_metrics.c.dwell_time_seconds
-                            != VehicleEventMetrics.dwell_time_seconds,
-                            all_new_metrics.c.headway_branch_seconds
-                            != VehicleEventMetrics.headway_branch_seconds,
-                            all_new_metrics.c.headway_trunk_seconds
-                            != VehicleEventMetrics.headway_trunk_seconds,
-                        ),
-                        sa.literal(True),
-                    )
-                ],
-                else_=sa.literal(False),
-            ).label("to_update"),
-        )
-        .select_from(all_new_metrics)
-        .join(
-            VehicleEventMetrics,
-            all_new_metrics.c.trip_stop_hash
-            == VehicleEventMetrics.trip_stop_hash,
-            isouter=True,
+            VehicleEvents.pm_trip_id == t_headways_trunk_sub.c.pm_trip_id,
+            VehicleEvents.service_date == t_headways_trunk_sub.c.service_date,
+            VehicleEvents.parent_station
+            == t_headways_trunk_sub.c.parent_station,
+            t_headways_trunk_sub.c.headway_trunk_seconds.is_not(None),
+            t_headways_trunk_sub.c.headway_trunk_seconds > 0,
         )
     )
-
-    # this logic is again very similar to trips dataframe insert/update operation
-    # some possibility of removing duplicate code and having common insert/update
-    # function
-    update_insert_metrics = db_manager.select_as_dataframe(update_insert_query)
-
-    if update_insert_metrics.shape[0] == 0:
-        process_logger.add_metadata(
-            metric_insert_count=0,
-            metric_update_count=0,
-        )
-        process_logger.log_complete()
-        return
-
-    update_insert_metrics["travel_time_seconds"] = update_insert_metrics[
-        "travel_time_seconds"
-    ].astype("Int64")
-    update_insert_metrics["dwell_time_seconds"] = update_insert_metrics[
-        "dwell_time_seconds"
-    ].astype("Int64")
-    update_insert_metrics["headway_branch_seconds"] = update_insert_metrics[
-        "headway_branch_seconds"
-    ].astype("Int64")
-    update_insert_metrics["headway_trunk_seconds"] = update_insert_metrics[
-        "headway_trunk_seconds"
-    ].astype("Int64")
-    update_insert_metrics = update_insert_metrics.fillna(numpy.nan).replace(
-        [numpy.nan], [None]
-    )
-
-    update_mask = (
-        update_insert_metrics["existing_trip_stop_hash"].notna()
-    ) & numpy.equal(update_insert_metrics["to_update"], True)
-    insert_mask = update_insert_metrics["existing_trip_stop_hash"].isna()
-
-    process_logger.add_metadata(
-        metric_insert_count=insert_mask.sum(),
-        metric_update_count=update_mask.sum(),
-    )
-
-    db_columns = [
-        "trip_stop_hash",
-        "travel_time_seconds",
-        "dwell_time_seconds",
-        "headway_branch_seconds",
-        "headway_trunk_seconds",
-    ]
-    if update_mask.sum() > 0:
-        db_manager.execute_with_data(
-            sa.update(VehicleEventMetrics.__table__).where(
-                VehicleEventMetrics.trip_stop_hash
-                == sa.bindparam("b_trip_stop_hash"),
-            ),
-            update_insert_metrics.loc[update_mask, db_columns].rename(
-                columns={"trip_stop_hash": "b_trip_stop_hash"}
-            ),
-        )
-
-    if insert_mask.sum() > 0:
-        db_manager.execute_with_data(
-            sa.insert(VehicleEventMetrics.__table__),
-            update_insert_metrics.loc[insert_mask, db_columns],
-        )
+    db_manager.execute(update_trunk_headways)
 
     process_logger.log_complete()
 
@@ -370,22 +239,20 @@ def process_metrics_table(
 # pylint: enable=R0914
 
 
-def process_metrics(
-    db_manager: DatabaseManager, events: pandas.DataFrame
-) -> None:
+def process_metrics(db_manager: DatabaseManager) -> None:
     """
     insert and update metrics table
     """
-    for service_date in events["service_date"].unique():
-        version_keys = [
-            int(s_d)
-            for s_d in events.loc[
-                events["service_date"] == service_date, "static_version_key"
-            ].unique()
-        ]
+    service_date_query = sa.select(
+        TempEventCompare.service_date,
+        TempEventCompare.static_version_key,
+    ).distinct()
 
+    for result in db_manager.select_as_list(service_date_query):
+        service_date = int(result["service_date"])
+        static_version_key = int(result["static_version_key"])
         process_metrics_table(
-            db_manager,
-            seed_service_date=int(service_date),
-            version_keys=version_keys,
+            db_manager=db_manager,
+            seed_service_date=service_date,
+            static_version_key=static_version_key,
         )

--- a/python_src/src/lamp_py/performance_manager/l1_rt_trips.py
+++ b/python_src/src/lamp_py/performance_manager/l1_rt_trips.py
@@ -1,15 +1,12 @@
-from typing import List
-import binascii
-
-import pandas
 import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
 
 from lamp_py.postgres.postgres_utils import DatabaseManager
 from lamp_py.postgres.postgres_schema import (
     VehicleEvents,
     VehicleTrips,
     StaticTrips,
-    TempHashCompare,
+    TempEventCompare,
     StaticDirections,
 )
 from lamp_py.runtime_utils.process_logger import ProcessLogger
@@ -18,128 +15,195 @@ from .l1_cte_statements import (
 )
 
 
-def load_temp_for_hash_compare(
-    db_manager: DatabaseManager, events: pandas.DataFrame
-) -> None:
+# def update_prev_next_trip_stop(db_manager: DatabaseManager) -> None:
+#     """
+#     Update `previous_trip_stop_pk_id` and `next_trip_stop_pk_id` fields in `vehicle_events` table
+#     """
+#     prev_next_trip_stop_cte = (
+#         sa.select(
+#             VehicleEvents.pk_id,
+#             sa.func.lead(VehicleEvents.pk_id)
+#             .over(
+#                 partition_by=VehicleEvents.trip_hash,
+#                 order_by=VehicleEvents.stop_sequence,
+#             )
+#             .label("next_trip_stop_pk_id"),
+#             sa.func.lag(VehicleEvents.pk_id)
+#             .over(
+#                 partition_by=VehicleEvents.trip_hash,
+#                 order_by=VehicleEvents.stop_sequence,
+#             )
+#             .label("previous_trip_stop_pk_id"),
+#         ).join(
+#             TempHashCompare,
+#             TempHashCompare.hash == VehicleEvents.trip_hash,
+#         )
+#     ).cte(name="prev_next_trip_stops")
+
+#     update_query = (
+#         sa.update(VehicleEvents.__table__)
+#         .where(
+#             VehicleEvents.pk_id == prev_next_trip_stop_cte.c.pk_id,
+#         )
+#         .values(
+#             next_trip_stop_pk_id=prev_next_trip_stop_cte.c.next_trip_stop_pk_id,
+#             previous_trip_stop_pk_id=prev_next_trip_stop_cte.c.previous_trip_stop_pk_id,
+#         )
+#     )
+
+#     process_logger = ProcessLogger("l1_trips.update_prev_next_trip_stop")
+#     process_logger.log_start()
+#     db_manager.execute(update_query)
+#     process_logger.log_complete()
+
+
+def load_new_trip_data(db_manager: DatabaseManager) -> None:
     """
-    Load "temp_hash_compare" table with "trip_hash" from newly inserted RT events
-    """
-    new_trip_hash_bytes = events.loc[
-        events["do_insert"], "trip_hash"
-    ].drop_duplicates()
+    INSERT / UPDATE "vehicle_trip" table
 
-    db_manager.truncate_table(TempHashCompare)
-    db_manager.execute_with_data(
-        sa.insert(TempHashCompare.__table__),
-        new_trip_hash_bytes.to_frame("hash"),
-    )
-
-
-def update_prev_next_trip_stop(db_manager: DatabaseManager) -> None:
-    """
-    Update `previous_trip_stop_pk_id` and `next_trip_stop_pk_id` fields in `vehicle_events` table
-    """
-    prev_next_trip_stop_cte = (
-        sa.select(
-            VehicleEvents.pk_id,
-            sa.func.lead(VehicleEvents.pk_id)
-            .over(
-                partition_by=VehicleEvents.trip_hash,
-                order_by=VehicleEvents.stop_sequence,
-            )
-            .label("next_trip_stop_pk_id"),
-            sa.func.lag(VehicleEvents.pk_id)
-            .over(
-                partition_by=VehicleEvents.trip_hash,
-                order_by=VehicleEvents.stop_sequence,
-            )
-            .label("previous_trip_stop_pk_id"),
-        ).join(
-            TempHashCompare,
-            TempHashCompare.hash == VehicleEvents.trip_hash,
-        )
-    ).cte(name="prev_next_trip_stops")
-
-    update_query = (
-        sa.update(VehicleEvents.__table__)
-        .where(
-            VehicleEvents.pk_id == prev_next_trip_stop_cte.c.pk_id,
-        )
-        .values(
-            next_trip_stop_pk_id=prev_next_trip_stop_cte.c.next_trip_stop_pk_id,
-            previous_trip_stop_pk_id=prev_next_trip_stop_cte.c.previous_trip_stop_pk_id,
-        )
-    )
-
-    process_logger = ProcessLogger("l1_trips.update_prev_next_trip_stop")
-    process_logger.log_start()
-    db_manager.execute(update_query)
-    process_logger.log_complete()
-
-
-def load_new_trip_data(
-    db_manager: DatabaseManager, events: pandas.DataFrame
-) -> None:
-    """
-    Load new "vehicle_trip" table data columns into RDS
-
-    This guarantees that all events represented in the events dataframe will have
+    This guarantees that all events will have
     matching trips data in the "vehicle_trips" table
     """
     process_logger = ProcessLogger("l1_trips.load_new_trips")
     process_logger.log_start()
-    insert_columns = [
-        "trip_hash",
-        "static_version_key",
-        "direction_id",
-        "route_id",
+
+    distinct_trip_records = (
+        sa.select(
+            TempEventCompare.service_date,
+            TempEventCompare.route_id,
+            TempEventCompare.direction_id,
+            TempEventCompare.start_time,
+            TempEventCompare.vehicle_id,
+            TempEventCompare.trip_id,
+            TempEventCompare.vehicle_label,
+            TempEventCompare.vehicle_consist,
+            TempEventCompare.static_version_key,
+        )
+        .distinct(
+            TempEventCompare.service_date,
+            TempEventCompare.route_id,
+            TempEventCompare.direction_id,
+            TempEventCompare.start_time,
+            TempEventCompare.vehicle_id,
+        )
+        .order_by(
+            TempEventCompare.service_date,
+            TempEventCompare.route_id,
+            TempEventCompare.direction_id,
+            TempEventCompare.start_time,
+        )
+    )
+
+    trip_insert_columns = [
         "service_date",
+        "route_id",
+        "direction_id",
         "start_time",
         "vehicle_id",
         "trip_id",
         "vehicle_label",
         "vehicle_consist",
+        "static_version_key",
     ]
-    insert_events = events.loc[
-        events["do_insert"], insert_columns
-    ].drop_duplicates(subset="trip_hash")
 
-    db_trip_hashes = db_manager.select_as_dataframe(
+    trip_insert_query = (
+        postgresql.insert(VehicleTrips.__table__)
+        .from_select(trip_insert_columns, distinct_trip_records)
+        .on_conflict_do_nothing(
+            index_elements=[
+                VehicleTrips.service_date,
+                VehicleTrips.route_id,
+                VehicleTrips.direction_id,
+                VehicleTrips.start_time,
+                VehicleTrips.vehicle_id,
+            ],
+        )
+    )
+    db_manager.execute(trip_insert_query)
+
+    distinct_update_query = (
         sa.select(
-            VehicleTrips.trip_hash,
-        ).join(
-            TempHashCompare,
-            TempHashCompare.hash == VehicleTrips.trip_hash,
+            TempEventCompare.service_date,
+            TempEventCompare.route_id,
+            TempEventCompare.direction_id,
+            TempEventCompare.start_time,
+            TempEventCompare.vehicle_id,
+            TempEventCompare.trip_id,
+            TempEventCompare.vehicle_label,
+            TempEventCompare.vehicle_consist,
+        )
+        .distinct(
+            TempEventCompare.service_date,
+            TempEventCompare.route_id,
+            TempEventCompare.direction_id,
+            TempEventCompare.start_time,
+            TempEventCompare.vehicle_id,
+        )
+        .order_by(
+            TempEventCompare.service_date,
+            TempEventCompare.route_id,
+            TempEventCompare.direction_id,
+            TempEventCompare.start_time,
+        )
+        .where(
+            sa.or_(
+                TempEventCompare.vp_move_timestamp.is_not(None),
+                TempEventCompare.vp_stop_timestamp.is_not(None),
+            )
+        )
+        .subquery(name="trip_update")
+    )
+
+    trip_update_query = (
+        sa.update(VehicleTrips.__table__)
+        .values(
+            trip_id=distinct_update_query.c.trip_id,
+            vehicle_label=distinct_update_query.c.vehicle_label,
+            vehicle_consist=distinct_update_query.c.vehicle_consist,
+        )
+        .where(
+            VehicleTrips.service_date == distinct_update_query.c.service_date,
+            VehicleTrips.route_id == distinct_update_query.c.route_id,
+            VehicleTrips.direction_id == distinct_update_query.c.direction_id,
+            VehicleTrips.start_time == distinct_update_query.c.start_time,
+            VehicleTrips.vehicle_id == distinct_update_query.c.vehicle_id,
+        )
+    )
+    db_manager.execute(trip_update_query)
+
+    process_logger.log_complete()
+
+
+def update_static_version_key(db_manager: DatabaseManager) -> None:
+    """
+    Update static_version_key so each day only uses one key
+    """
+    version_key_sub = (
+        sa.select(
+            TempEventCompare.service_date,
+            sa.func.max(TempEventCompare.static_version_key).label(
+                "max_version_key"
+            ),
+        )
+        .group_by(
+            TempEventCompare.service_date,
+        )
+        .subquery("update_version_key")
+    )
+
+    update_query = (
+        sa.update(VehicleTrips.__table__)
+        .values(
+            static_version_key=version_key_sub.c.max_version_key,
+        )
+        .where(
+            VehicleTrips.pm_trip_id == version_key_sub.c.service_date,
         )
     )
 
-    if db_trip_hashes.shape[0] == 0:
-        db_trip_hashes = pandas.DataFrame(columns=["trip_hash"])
-    else:
-        db_trip_hashes["trip_hash"] = (
-            db_trip_hashes["trip_hash"]
-            .apply(binascii.hexlify)
-            .str.decode("utf-8")
-        )
-
-    insert_events["trip_hash"] = (
-        insert_events["trip_hash"].apply(binascii.hexlify).str.decode("utf-8")
-    )
-
-    # insert_events are records that don't have an existing trip_hash in the "vehicle_trips" table
-    insert_events = insert_events.merge(
-        db_trip_hashes, how="outer", on="trip_hash", indicator=True
-    ).query('_merge=="left_only"')
-
-    insert_events = insert_events.drop(columns=["_merge"])
-
-    insert_events["trip_hash"] = insert_events["trip_hash"].str.decode("hex")
-
-    if insert_events.shape[0] > 0:
-        db_manager.execute_with_data(
-            sa.insert(VehicleTrips.__table__),
-            insert_events,
-        )
+    process_logger = ProcessLogger("l1_trips.update_static_version_key")
+    process_logger.log_start()
+    db_manager.execute(update_query)
     process_logger.log_complete()
 
 
@@ -150,15 +214,24 @@ def update_trip_stop_counts(db_manager: DatabaseManager) -> None:
     this function call should also update branch_route_id and trunk_route_id columns
     for the trips table by activiating the rt_trips_update_branch_trunk TDS trigger
     """
+    distinct_trips = (
+        sa.select(TempEventCompare.service_date, TempEventCompare.pm_trip_id)
+        .distinct()
+        .subquery("distinct_trips")
+    )
+
     new_stop_counts_cte = (
         sa.select(
-            VehicleEvents.trip_hash,
-            sa.func.count(VehicleEvents.trip_stop_hash).label("stop_count"),
+            VehicleEvents.pm_trip_id,
+            sa.func.count(VehicleEvents.pm_trip_id).label("stop_count"),
         )
         .select_from(VehicleEvents)
         .join(
-            TempHashCompare,
-            TempHashCompare.hash == VehicleEvents.trip_hash,
+            distinct_trips,
+            sa.and_(
+                distinct_trips.c.service_date == VehicleEvents.service_date,
+                distinct_trips.c.pm_trip_id == VehicleEvents.pm_trip_id,
+            ),
         )
         .where(
             sa.or_(
@@ -167,17 +240,17 @@ def update_trip_stop_counts(db_manager: DatabaseManager) -> None:
             ),
         )
         .group_by(
-            VehicleEvents.trip_hash,
+            VehicleEvents.pm_trip_id,
         )
-        .cte("new_stop_counts")
+        .subquery("new_stop_counts")
     )
 
     update_query = (
         sa.update(VehicleTrips.__table__)
-        .where(
-            VehicleTrips.trip_hash == new_stop_counts_cte.c.trip_hash,
-        )
         .values(stop_count=new_stop_counts_cte.c.stop_count)
+        .where(
+            VehicleTrips.pm_trip_id == new_stop_counts_cte.c.pm_trip_id,
+        )
     )
 
     process_logger = ProcessLogger("l1_trips.update_trip_stop_counts")
@@ -190,16 +263,19 @@ def update_static_trip_id_guess_exact(db_manager: DatabaseManager) -> None:
     """
     Update static_trip_id_guess with exact matches between rt and static trips
     """
-    rt_static_match_cte = (
+    rt_static_match_sub = (
         sa.select(
-            VehicleTrips.trip_hash,
+            VehicleTrips.pm_trip_id,
             VehicleTrips.trip_id,
             sa.true().label("first_last_station_match"),
             # TODO: add stop_count from static pre-processing when available # pylint: disable=fixme
             # TODO: add start_time from sattic pre-processing when available # pylint: disable=fixme
         )
         .select_from(VehicleTrips)
-        .join(TempHashCompare, TempHashCompare.hash == VehicleTrips.trip_hash)
+        .join(
+            TempEventCompare,
+            TempEventCompare.pm_trip_id == VehicleTrips.pm_trip_id,
+        )
         .join(
             StaticTrips,
             sa.and_(
@@ -210,19 +286,19 @@ def update_static_trip_id_guess_exact(db_manager: DatabaseManager) -> None:
                 StaticTrips.route_id == VehicleTrips.route_id,
             ),
         )
-        .cte("exact_trip_id_matches")
+        .subquery("exact_trip_id_matches")
     )
 
     update_query = (
         sa.update(VehicleTrips.__table__)
-        .where(
-            VehicleTrips.trip_hash == rt_static_match_cte.c.trip_hash,
-        )
         .values(
-            static_trip_id_guess=rt_static_match_cte.c.trip_id,
-            first_last_station_match=rt_static_match_cte.c.first_last_station_match,
+            static_trip_id_guess=rt_static_match_sub.c.trip_id,
+            first_last_station_match=rt_static_match_sub.c.first_last_station_match,
             # TODO: add stop_count from static pre-processing when available # pylint: disable=fixme
             # TODO: add start_time from sattic pre-processing when available # pylint: disable=fixme
+        )
+        .where(
+            VehicleTrips.pm_trip_id == rt_static_match_sub.c.pm_trip_id,
         )
     )
 
@@ -236,14 +312,17 @@ def update_directions(db_manager: DatabaseManager) -> None:
     """
     Update direction and direction_destination from static tables
     """
-    directions_cte = (
+    directions_sub = (
         sa.select(
-            VehicleTrips.trip_hash,
+            VehicleTrips.pm_trip_id,
             StaticDirections.direction,
             StaticDirections.direction_destination,
         )
         .select_from(VehicleTrips)
-        .join(TempHashCompare, TempHashCompare.hash == VehicleTrips.trip_hash)
+        .join(
+            TempEventCompare,
+            TempEventCompare.pm_trip_id == VehicleTrips.pm_trip_id,
+        )
         .join(
             StaticDirections,
             sa.and_(
@@ -253,17 +332,17 @@ def update_directions(db_manager: DatabaseManager) -> None:
                 VehicleTrips.route_id == StaticDirections.route_id,
             ),
         )
-        .cte("update_directions")
+        .subquery("update_directions")
     )
 
     update_query = (
         sa.update(VehicleTrips.__table__)
-        .where(
-            VehicleTrips.trip_hash == directions_cte.c.trip_hash,
-        )
         .values(
-            direction=directions_cte.c.direction,
-            direction_destination=directions_cte.c.direction_destination,
+            direction=directions_sub.c.direction,
+            direction_destination=directions_sub.c.direction_destination,
+        )
+        .where(
+            VehicleTrips.pm_trip_id == directions_sub.c.pm_trip_id,
         )
     )
 
@@ -273,26 +352,12 @@ def update_directions(db_manager: DatabaseManager) -> None:
     process_logger.log_complete()
 
 
-def load_new_trips_records(
-    db_manager: DatabaseManager, events: pandas.DataFrame
-) -> None:
-    """
-    Load data into "vehicle_trips" table for any new RT events
-    """
-    load_temp_for_hash_compare(db_manager, events)
-    # update_prev_next_trip_stop(db_manager)
-    load_new_trip_data(db_manager, events)
-    update_trip_stop_counts(db_manager)
-    update_static_trip_id_guess_exact(db_manager)
-    update_directions(db_manager)
-
-
 # pylint: disable=R0914
 # pylint too many local variables (more than 15)
 def backup_rt_static_trip_match(
     db_manager: DatabaseManager,
     seed_service_date: int,
-    version_keys: List[int],
+    static_version_key: int,
 ) -> None:
     """
     perform "backup" match of RT trips to Static schedule trip
@@ -300,52 +365,54 @@ def backup_rt_static_trip_match(
     this matches an RT trip to a static trip with the same branch_route_id or trunk_route_id if branch is null
     and direction with the closest start_time
     """
-    static_trips_cte = get_static_trips_cte(version_keys, seed_service_date)
+    static_trips_sub = get_static_trips_cte(
+        static_version_key, seed_service_date
+    )
 
     # to build a 'summary' trips table only the first and last records for each
     # static trip are needed.
-    first_stop_static_cte = (
+    first_stop_static_sub = (
         sa.select(
-            static_trips_cte.c.static_version_key,
-            static_trips_cte.c.static_trip_id,
-            static_trips_cte.c.static_stop_timestamp.label("static_start_time"),
+            static_trips_sub.c.static_version_key,
+            static_trips_sub.c.static_trip_id,
+            static_trips_sub.c.static_stop_timestamp.label("static_start_time"),
         )
-        .select_from(static_trips_cte)
-        .where(static_trips_cte.c.static_trip_first_stop == sa.true())
-        .cte(name="first_stop_static_cte")
+        .select_from(static_trips_sub)
+        .where(static_trips_sub.c.static_trip_first_stop == sa.true())
+        .subquery(name="first_stop_static_sub")
     )
 
-    # join first_stop_static_cte with last stop records to create trip summary records
-    static_trips_summary_cte = (
+    # join first_stop_static_sub with last stop records to create trip summary records
+    static_trips_summary_sub = (
         sa.select(
-            static_trips_cte.c.static_version_key,
-            static_trips_cte.c.static_trip_id,
+            static_trips_sub.c.static_version_key,
+            static_trips_sub.c.static_trip_id,
             sa.func.coalesce(
-                static_trips_cte.c.branch_route_id,
-                static_trips_cte.c.trunk_route_id,
+                static_trips_sub.c.branch_route_id,
+                static_trips_sub.c.trunk_route_id,
             ).label("route_id"),
-            static_trips_cte.c.direction_id,
-            first_stop_static_cte.c.static_start_time,
-            static_trips_cte.c.static_trip_stop_rank.label("static_stop_count"),
+            static_trips_sub.c.direction_id,
+            first_stop_static_sub.c.static_start_time,
+            static_trips_sub.c.static_trip_stop_rank.label("static_stop_count"),
         )
-        .select_from(static_trips_cte)
+        .select_from(static_trips_sub)
         .join(
-            first_stop_static_cte,
+            first_stop_static_sub,
             sa.and_(
-                static_trips_cte.c.static_version_key
-                == first_stop_static_cte.c.static_version_key,
-                static_trips_cte.c.static_trip_id
-                == first_stop_static_cte.c.static_trip_id,
+                static_trips_sub.c.static_version_key
+                == first_stop_static_sub.c.static_version_key,
+                static_trips_sub.c.static_trip_id
+                == first_stop_static_sub.c.static_trip_id,
             ),
         )
-        .where(static_trips_cte.c.static_trip_last_stop == sa.true())
-        .cte(name="static_trips_summary_cte")
+        .where(static_trips_sub.c.static_trip_last_stop == sa.true())
+        .subquery(name="static_trips_summary_sub")
     )
 
     # pull RT trips records that are candidates for backup matching to static trips
-    rt_trips_summary_cte = (
+    rt_trips_summary_sub = (
         sa.select(
-            VehicleTrips.trip_hash,
+            VehicleTrips.pm_trip_id,
             VehicleTrips.direction_id,
             sa.func.coalesce(
                 VehicleTrips.branch_route_id, VehicleTrips.trunk_route_id
@@ -354,53 +421,56 @@ def backup_rt_static_trip_match(
             VehicleTrips.static_version_key,
         )
         .select_from(VehicleTrips)
-        .join(TempHashCompare, TempHashCompare.hash == VehicleTrips.trip_hash)
+        .join(
+            TempEventCompare,
+            TempEventCompare.pm_trip_id == VehicleTrips.pm_trip_id,
+        )
         .where(
             VehicleTrips.first_last_station_match == sa.false(),
             VehicleTrips.service_date == int(seed_service_date),
-            VehicleTrips.static_version_key.in_(version_keys),
+            VehicleTrips.static_version_key == int(static_version_key),
         )
-        .cte("rt_trips_for_backup_match")
+        .subquery("rt_trips_for_backup_match")
     )
 
     # backup matching logic, should match all remaining RT trips to static trips,
     # assuming that the route_id exists in the static schedule data
     backup_trips_match = (
         sa.select(
-            rt_trips_summary_cte.c.trip_hash,
-            static_trips_summary_cte.c.static_trip_id,
-            static_trips_summary_cte.c.static_start_time,
-            static_trips_summary_cte.c.static_stop_count,
+            rt_trips_summary_sub.c.pm_trip_id,
+            static_trips_summary_sub.c.static_trip_id,
+            static_trips_summary_sub.c.static_start_time,
+            static_trips_summary_sub.c.static_stop_count,
             sa.literal(False).label("first_last_station_match"),
         )
         .distinct(
-            rt_trips_summary_cte.c.trip_hash,
+            rt_trips_summary_sub.c.pm_trip_id,
         )
-        .select_from(rt_trips_summary_cte)
+        .select_from(rt_trips_summary_sub)
         .join(
-            static_trips_summary_cte,
+            static_trips_summary_sub,
             sa.and_(
-                rt_trips_summary_cte.c.static_version_key
-                == static_trips_summary_cte.c.static_version_key,
-                rt_trips_summary_cte.c.direction_id
-                == static_trips_summary_cte.c.direction_id,
-                rt_trips_summary_cte.c.route_id
-                == static_trips_summary_cte.c.route_id,
+                rt_trips_summary_sub.c.static_version_key
+                == static_trips_summary_sub.c.static_version_key,
+                rt_trips_summary_sub.c.direction_id
+                == static_trips_summary_sub.c.direction_id,
+                rt_trips_summary_sub.c.route_id
+                == static_trips_summary_sub.c.route_id,
             ),
         )
         .order_by(
-            rt_trips_summary_cte.c.trip_hash,
+            rt_trips_summary_sub.c.pm_trip_id,
             sa.func.abs(
-                rt_trips_summary_cte.c.start_time
-                - static_trips_summary_cte.c.static_start_time
+                rt_trips_summary_sub.c.start_time
+                - static_trips_summary_sub.c.static_start_time
             ),
         )
-    ).cte(name="backup_trips_match")
+    ).subquery(name="backup_trips_match")
 
     update_query = (
         sa.update(VehicleTrips.__table__)
         .where(
-            VehicleTrips.trip_hash == backup_trips_match.c.trip_hash,
+            VehicleTrips.pm_trip_id == backup_trips_match.c.pm_trip_id,
         )
         .values(
             static_trip_id_guess=backup_trips_match.c.static_trip_id,
@@ -413,28 +483,39 @@ def backup_rt_static_trip_match(
     db_manager.execute(update_query)
 
 
-def process_trips(
-    db_manager: DatabaseManager, events: pandas.DataFrame
-) -> None:
+def update_backup_static_trip_id(db_manager: DatabaseManager) -> None:
     """
-    insert new trips records from events dataframe into RDS
+    perform backup static_trip_id matching on events_trips table
 
     """
-    load_new_trips_records(db_manager, events)
-
     process_logger = ProcessLogger("l1_trips.update_backup_trip_matches")
     process_logger.log_start()
-    for service_date in events["service_date"].unique():
-        version_keys = [
-            int(s_d)
-            for s_d in events.loc[
-                events["service_date"] == service_date, "static_version_key"
-            ].unique()
-        ]
 
+    service_date_query = sa.select(
+        TempEventCompare.service_date,
+        TempEventCompare.static_version_key,
+    ).distinct()
+
+    for result in db_manager.select_as_list(service_date_query):
+        service_date = int(result["service_date"])
+        static_version_key = int(result["static_version_key"])
         backup_rt_static_trip_match(
-            db_manager,
-            seed_service_date=int(service_date),
-            version_keys=version_keys,
+            db_manager=db_manager,
+            seed_service_date=service_date,
+            static_version_key=static_version_key,
         )
+
     process_logger.log_complete()
+
+
+def process_trips(db_manager: DatabaseManager) -> None:
+    """
+    update vehicle_trips table based on new events in temp_event_compare
+
+    """
+    # update_prev_next_trip_stop(db_manager)
+    update_static_version_key(db_manager)
+    update_trip_stop_counts(db_manager)
+    update_static_trip_id_guess_exact(db_manager)
+    update_directions(db_manager)
+    update_backup_static_trip_id(db_manager)

--- a/python_src/src/lamp_py/performance_manager/l1_rt_trips.py
+++ b/python_src/src/lamp_py/performance_manager/l1_rt_trips.py
@@ -11,7 +11,7 @@ from lamp_py.postgres.postgres_schema import (
 )
 from lamp_py.runtime_utils.process_logger import ProcessLogger
 from .l1_cte_statements import (
-    get_static_trips_cte,
+    static_trips_subquery,
 )
 
 
@@ -365,7 +365,7 @@ def backup_rt_static_trip_match(
     this matches an RT trip to a static trip with the same branch_route_id or trunk_route_id if branch is null
     and direction with the closest start_time
     """
-    static_trips_sub = get_static_trips_cte(
+    static_trips_sub = static_trips_subquery(
         static_version_key, seed_service_date
     )
 

--- a/python_src/src/lamp_py/postgres/seed_metadata.py
+++ b/python_src/src/lamp_py/postgres/seed_metadata.py
@@ -15,7 +15,6 @@ from lamp_py.runtime_utils.alembic_migration import (
 
 from .postgres_schema import (
     MetadataLog,
-    VehicleEventMetrics,
     VehicleEvents,
     VehicleTrips,
 )
@@ -90,7 +89,6 @@ def run() -> None:
         alembic_upgrade_to_head("performance_manager")
     elif parsed_args.clear_rt:
         db_manager.truncate_table(VehicleTrips)
-        db_manager.truncate_table(VehicleEventMetrics)
         db_manager.truncate_table(VehicleEvents, restart_identity=True)
 
         db_manager.execute(

--- a/python_src/tests/performance_manager/test_performance_manager.py
+++ b/python_src/tests/performance_manager/test_performance_manager.py
@@ -331,26 +331,26 @@ def test_gtfs_rt_processing(
         assert position_size > positions.shape[0]
 
         positions = transform_vp_timestamps(positions)
-        assert positions.shape[1] == 15
+        assert positions.shape[1] == 14
         assert position_size > positions.shape[0]
 
         trip_updates = get_and_unwrap_tu_dataframe(files["tu_paths"])
         trip_update_size = trip_updates.shape[0]
-        assert trip_updates.shape[1] == 10
+        assert trip_updates.shape[1] == 8
 
         # check that it can be combined with the static schedule
         trip_updates = add_static_version_key_column(trip_updates, db_manager)
-        assert trip_updates.shape[1] == 11
+        assert trip_updates.shape[1] == 9
         assert trip_update_size == trip_updates.shape[0]
 
         # remove bus records from dataframe
         trip_updates = remove_bus_records(trip_updates, db_manager)
-        assert trip_updates.shape[1] == 11
+        assert trip_updates.shape[1] == 9
         assert trip_update_size > trip_updates.shape[0]
 
         # remove bus records from dataframe
         trip_updates = add_parent_station_column(trip_updates, db_manager)
-        assert trip_updates.shape[1] == 12
+        assert trip_updates.shape[1] == 10
         assert trip_update_size > trip_updates.shape[0]
 
         trip_updates = reduce_trip_updates(trip_updates)
@@ -359,20 +359,21 @@ def test_gtfs_rt_processing(
         events = combine_events(positions, trip_updates)
 
         ve_columns = [c.key for c in VehicleEvents.__table__.columns]
-        # pk id and updated on are handled by postgres. trip hash is added just
-        # before inserting new rows to the db.
+        # pm_trip_id and updated_on are handled by postgres
         # trip_id is pulled from parquet but not inserted into vehicle_events table
         expected_columns = set(ve_columns) - {
-            "pk_id",
             "updated_on",
-            "trip_hash",
+            "pm_trip_id",
+            "travel_time_seconds",
+            "dwell_time_seconds",
+            "headway_trunk_seconds",
+            "headway_branch_seconds",
         }
         expected_columns.add("trip_id")
         expected_columns.add("vehicle_label")
         expected_columns.add("vehicle_consist")
         expected_columns.add("direction_id")
         expected_columns.add("route_id")
-        expected_columns.add("service_date")
         expected_columns.add("start_time")
         expected_columns.add("vehicle_id")
         expected_columns.add("static_version_key")

--- a/python_src/tests/performance_manager/test_performance_manager.py
+++ b/python_src/tests/performance_manager/test_performance_manager.py
@@ -16,7 +16,8 @@ from lamp_py.performance_manager.l0_gtfs_rt_events import (
     combine_events,
     get_gtfs_rt_paths,
     process_gtfs_rt_files,
-    upload_to_database,
+    build_temp_events,
+    update_events_from_temp,
 )
 from lamp_py.performance_manager.l0_rt_trip_updates import (
     get_and_unwrap_tu_dataframe,
@@ -382,7 +383,8 @@ def test_gtfs_rt_processing(
         missing_columns = set(events.columns) - expected_columns
         assert len(missing_columns) == 0
 
-        upload_to_database(events, db_manager)
+        build_temp_events(events, db_manager)
+        update_events_from_temp(db_manager)
 
     check_logs(caplog)
 


### PR DESCRIPTION
This PR removes the `trip_hash` and `trip_stop_hash` columns from all tables on the RDS.

This has far reaching implications to the business logic of the entire event loading apparatus of the application. 

This PR also includes removing the `event_metrics` table and just merging it into the `vehicle_events` table to reduce join logic and duplicate data.

Asana Task: https://app.asana.com/0/1204921490312295/1204999066398940
