### PR TITLE
reversion: Remove Delete Verification from Ingestion

### DIFF
--- a/python_src/src/lamp_py/ingestion/convert_gtfs.py
+++ b/python_src/src/lamp_py/ingestion/convert_gtfs.py
@@ -1,7 +1,7 @@
 import os
 import zipfile
 from datetime import datetime
-from typing import IO, List, Union
+from typing import IO, Union
 
 from pyarrow import csv
 
@@ -21,7 +21,7 @@ class GtfsConverter(Converter):
     Converter for GTFS Schedule Data
     """
 
-    def convert(self) -> List[str]:
+    def convert(self) -> None:
         archive_files = []
         error_files = []
 
@@ -50,8 +50,6 @@ class GtfsConverter(Converter):
                 archive_files,
                 os.path.join(os.environ["ARCHIVE_BUCKET"], DEFAULT_S3_PREFIX),
             )
-
-        return error_files + archive_files
 
     def process_schedule(self, filename: str) -> None:
         """

--- a/python_src/src/lamp_py/ingestion/convert_gtfs_rt.py
+++ b/python_src/src/lamp_py/ingestion/convert_gtfs_rt.py
@@ -83,9 +83,8 @@ class GtfsRtConverter(Converter):
 
         self.error_files: List[str] = []
         self.archive_files: List[str] = []
-        self.moved_files: List[str] = []
 
-    def convert(self) -> List[str]:
+    def convert(self) -> None:
         max_tables_to_convert = 12
         process_logger = ProcessLogger(
             "parquet_table_creator",
@@ -115,8 +114,6 @@ class GtfsRtConverter(Converter):
             process_logger.log_failure(exception)
         else:
             process_logger.log_complete()
-        finally:
-            return self.moved_files
 
     def thread_init(self) -> None:
         """
@@ -367,14 +364,12 @@ class GtfsRtConverter(Converter):
         move archive and error files to their respective s3 buckets.
         """
         if len(self.error_files) > 0:
-            self.moved_files += self.error_files
             self.error_files = move_s3_objects(
                 self.error_files,
                 os.path.join(os.environ["ERROR_BUCKET"], DEFAULT_S3_PREFIX),
             )
 
         if len(self.archive_files) > 0:
-            self.moved_files += self.archive_files
             self.archive_files = move_s3_objects(
                 self.archive_files,
                 os.path.join(os.environ["ARCHIVE_BUCKET"], DEFAULT_S3_PREFIX),

--- a/python_src/src/lamp_py/ingestion/converter.py
+++ b/python_src/src/lamp_py/ingestion/converter.py
@@ -102,7 +102,7 @@ class Converter(ABC):
         self.metadata_queue.put(written_file)
 
     @abstractmethod
-    def convert(self) -> List[str]:
+    def convert(self) -> None:
         """
         convert files to pyarrow tables, write them to s3 as parquete, and move
         files from incoming to archive (or error)

--- a/python_src/tests/ingestion/test_gtfs_converter.py
+++ b/python_src/tests/ingestion/test_gtfs_converter.py
@@ -398,10 +398,7 @@ def test_schedule_conversion(
     # processed correctly.
     gtfs_schedule_file_list = [os.path.join(incoming_dir, "MBTA_GTFS.zip")]
     converter.add_files(gtfs_schedule_file_list)
-    processed_files = converter.convert()
-
-    # check that the ingested file was returned back properly
-    assert processed_files == gtfs_schedule_file_list
+    converter.convert()
 
     # check through all of the paths that were "written" to s3 have the
     # appropriate format and that we "wrote" all of the tables.


### PR DESCRIPTION
Functionality to verify S3 delete/move operations was previously added to ingestion because of duplicate processing errors we were seeing with GTFS files. 

These errors have since been traced back to how Delta populates our `incoming` S3 buckets with two processes running in parallel creating a race condition with file writing to S3. 

Removing the delete/move verification from ingestion because we've never gotten a log indicating that the delete/move didn't work and it adds unnecessary overhead. 

Asana Task: https://app.asana.com/0/1204921490312295/1205063998912225
