### PR TITLE
Add function for generating flat pyarrow table

### DIFF
--- a/python_src/src/lamp_py/performance_manager/flat_file.py
+++ b/python_src/src/lamp_py/performance_manager/flat_file.py
@@ -1,0 +1,130 @@
+import sqlalchemy as sa
+import pyarrow
+
+from lamp_py.postgres.postgres_schema import (
+    VehicleEvents,
+    VehicleTrips,
+    StaticStopTimes,
+)
+from lamp_py.postgres.postgres_utils import DatabaseManager
+
+
+def generate_daily_table(
+    db_manager: DatabaseManager, service_date: int
+) -> pyarrow.Table:
+    """
+    Generate a dataframe of all events and metrics for a single service date
+    """
+    query = (
+        sa.select(
+            VehicleEvents.stop_sequence,
+            VehicleEvents.stop_id,
+            VehicleEvents.parent_station,
+            VehicleEvents.vp_move_timestamp.label("move_timestamp"),
+            sa.func.coalesce(
+                VehicleEvents.vp_stop_timestamp,
+                VehicleEvents.tu_stop_timestamp,
+            ).label("stop_timestamp"),
+            VehicleEvents.travel_time_seconds,
+            VehicleEvents.dwell_time_seconds,
+            VehicleEvents.headway_trunk_seconds,
+            VehicleEvents.headway_branch_seconds,
+            VehicleTrips.service_date,
+            VehicleTrips.route_id,
+            VehicleTrips.direction_id,
+            VehicleTrips.start_time,
+            VehicleTrips.vehicle_id,
+            VehicleTrips.branch_route_id,
+            VehicleTrips.trunk_route_id,
+            VehicleTrips.stop_count,
+            VehicleTrips.trip_id,
+            VehicleTrips.vehicle_label,
+            VehicleTrips.vehicle_consist,
+            VehicleTrips.direction,
+            VehicleTrips.direction_destination,
+            VehicleTrips.static_start_time,
+            StaticStopTimes.arrival_time.label("scheduled_arrival_time"),
+            StaticStopTimes.departure_time.label("scheduled_departure_time"),
+            StaticStopTimes.schedule_travel_time_seconds.label(
+                "scheduled_travel_time"
+            ),
+            StaticStopTimes.schedule_headway_branch_seconds.label(
+                "scheduled_headway_branch"
+            ),
+            StaticStopTimes.schedule_headway_trunk_seconds.label(
+                "scheduled_headway_trunk"
+            ),
+        )
+        .join(VehicleTrips, VehicleEvents.pm_trip_id == VehicleTrips.pm_trip_id)
+        .join(
+            StaticStopTimes,
+            sa.and_(
+                StaticStopTimes.static_version_key
+                == VehicleTrips.static_version_key,
+                StaticStopTimes.trip_id == VehicleTrips.static_trip_id_guess,
+                StaticStopTimes.stop_id == VehicleEvents.stop_id,
+            ),
+            isouter=True,
+        )
+        .where(
+            sa.and_(
+                VehicleEvents.service_date == service_date,
+                sa.or_(
+                    VehicleEvents.vp_move_timestamp.is_not(None),
+                    VehicleEvents.vp_stop_timestamp.is_not(None),
+                ),
+            )
+        )
+    )
+
+    # get the days events as a dataframe from postgres
+    days_events = db_manager.select_as_dataframe(query)
+
+    # transform the seru
+    days_events["year"] = days_events.apply(
+        lambda record: int(str(record["service_date"])[0:4]), axis=1
+    )
+    days_events["month"] = days_events.apply(
+        lambda record: int(str(record["service_date"])[4:6]), axis=1
+    )
+    days_events["day"] = days_events.apply(
+        lambda record: int(str(record["service_date"])[6:8]), axis=1
+    )
+    days_events.drop(columns="service_date")
+
+    flat_schema = pyarrow.schema(
+        [
+            ("stop_sequence", pyarrow.int16()),
+            ("stop_id", pyarrow.string()),
+            ("parent_station", pyarrow.string()),
+            ("move_timestamp", pyarrow.int64()),
+            ("stop_timestamp", pyarrow.int64()),
+            ("travel_time_seconds", pyarrow.int64()),
+            ("dwell_time_seconds", pyarrow.int64()),
+            ("headway_trunk_seconds", pyarrow.int64()),
+            ("headway_branch_seconds", pyarrow.int64()),
+            ("route_id", pyarrow.string()),
+            ("direction_id", pyarrow.int8()),
+            ("start_time", pyarrow.int64()),
+            ("vehicle_id", pyarrow.string()),
+            ("branch_route_id", pyarrow.string()),
+            ("trunk_route_id", pyarrow.string()),
+            ("stop_count", pyarrow.int16()),
+            ("trip_id", pyarrow.string()),
+            ("vehicle_label", pyarrow.string()),
+            ("vehicle_consist", pyarrow.string()),
+            ("direction", pyarrow.string()),
+            ("direction_destination", pyarrow.string()),
+            ("static_start_time", pyarrow.int64()),
+            ("scheduled_arrival_time", pyarrow.int64()),
+            ("scheduled_departure_time", pyarrow.int64()),
+            ("scheduled_travel_time", pyarrow.int64()),
+            ("scheduled_headway_branch", pyarrow.int64()),
+            ("scheduled_headway_trunk", pyarrow.int64()),
+            ("year", pyarrow.int16()),
+            ("month", pyarrow.int8()),
+            ("day", pyarrow.int8()),
+        ]
+    )
+
+    return pyarrow.Table.from_pandas(days_events, schema=flat_schema)

--- a/python_src/tests/performance_manager/test_performance_manager.py
+++ b/python_src/tests/performance_manager/test_performance_manager.py
@@ -11,6 +11,7 @@ from _pytest.monkeypatch import MonkeyPatch
 import pyarrow
 from pyarrow import fs, parquet, csv
 
+from lamp_py.performance_manager.flat_file import generate_daily_table
 from lamp_py.performance_manager.l0_gtfs_static_load import (
     process_static_tables,
 )
@@ -164,6 +165,58 @@ def fixture_s3_patch(monkeypatch: MonkeyPatch) -> Iterator[None]:
         "lamp_py.aws.s3._get_pyarrow_table", mock__get_pyarrow_table
     )
     yield
+
+
+def flat_table_check(db_manager: DatabaseManager, service_date: int) -> None:
+    """checks to run on a flat table to ensure it has what would be expected"""
+    flat_table = generate_daily_table(db_manager, service_date)
+
+    # check that the shape is good
+    rows, columns = flat_table.shape
+    assert columns == 30
+
+    expected_row_count = db_manager.select_as_list(
+        sa.select(sa.func.count()).where(
+            sa.and_(
+                VehicleEvents.service_date == service_date,
+                sa.or_(
+                    VehicleEvents.vp_move_timestamp.is_not(None),
+                    VehicleEvents.vp_stop_timestamp.is_not(None),
+                ),
+            )
+        )
+    )[0]["count_1"]
+    assert rows == expected_row_count
+
+    # check that partitioned columns behave appropriately
+    assert "year" in flat_table.column_names
+    assert len(flat_table["year"].unique()) == 1
+
+    assert "month" in flat_table.column_names
+    assert len(flat_table["month"].unique()) == 1
+
+    assert "day" in flat_table.column_names
+    assert len(flat_table["day"].unique()) == 1
+
+    # check that these keys have values throughout the file
+    must_have_keys = [
+        "stop_id",
+        "parent_station",
+        "route_id",
+        "direction_id",
+        "start_time",
+        "vehicle_id",
+        "trip_id",
+        "vehicle_label",
+        "year",
+        "month",
+        "day",
+    ]
+
+    for key in must_have_keys:
+        assert True not in flat_table[key].is_null(
+            nan_is_null=True
+        ), f"{key} has null values"
 
 
 def check_logs(caplog: pytest.LogCaptureFixture) -> None:
@@ -390,6 +443,8 @@ def test_gtfs_rt_processing(
 
         build_temp_events(events, db_manager)
         update_events_from_temp(db_manager)
+
+    flat_table_check(db_manager=db_manager, service_date=20230508)
 
     check_logs(caplog)
 


### PR DESCRIPTION
For some external users, we're going to provide flat parquet files via a data portal that can be used to run analysis on the data we've synthesized in the rail performance manager. Create a function that generates the pyarrow table with the appropriate data types for a given service date. This function will be run on a daily cadence, with the resulting table being written to a parquet file in an accessible s3 bucket.

Asana Task: https://app.asana.com/0/1204931901750655/1204907226653447/f
