### PR TITLE
Schedule flat file write 2

### DIFF
--- a/python_src/src/lamp_py/ingestion/convert_gtfs.py
+++ b/python_src/src/lamp_py/ingestion/convert_gtfs.py
@@ -116,8 +116,8 @@ class GtfsConverter(Converter):
 
         write_parquet_file(
             table=table,
-            config_type=s3_prefix,
-            s3_path=os.path.join(
+            file_type=s3_prefix,
+            s3_dir=os.path.join(
                 os.environ["SPRINGBOARD_BUCKET"],
                 DEFAULT_S3_PREFIX,
                 s3_prefix,

--- a/python_src/src/lamp_py/ingestion/convert_gtfs_rt.py
+++ b/python_src/src/lamp_py/ingestion/convert_gtfs_rt.py
@@ -356,8 +356,8 @@ class GtfsRtConverter(Converter):
             s3_prefix = str(self.config_type)
             write_parquet_file(
                 table=table,
-                config_type=s3_prefix,
-                s3_path=os.path.join(
+                file_type=s3_prefix,
+                s3_dir=os.path.join(
                     os.environ["SPRINGBOARD_BUCKET"],
                     DEFAULT_S3_PREFIX,
                     s3_prefix,

--- a/python_src/src/lamp_py/performance_manager/flat_file.py
+++ b/python_src/src/lamp_py/performance_manager/flat_file.py
@@ -1,0 +1,162 @@
+import sqlalchemy as sa
+import pyarrow
+
+from lamp_py.performance_manager.gtfs_utils import (
+    static_version_key_from_service_date,
+)
+from lamp_py.postgres.postgres_schema import (
+    VehicleEvents,
+    VehicleTrips,
+    StaticStopTimes,
+    StaticStops,
+)
+from lamp_py.postgres.postgres_utils import DatabaseManager
+
+
+def generate_daily_table(
+    db_manager: DatabaseManager, service_date: int
+) -> pyarrow.Table:
+    """
+    Generate a dataframe of all events and metrics for a single service date
+    """
+    static_version_key = static_version_key_from_service_date(
+        service_date=service_date, db_manager=db_manager
+    )
+
+    static_subquery = (
+        sa.select(
+            StaticStopTimes.arrival_time.label("scheduled_arrival_time"),
+            StaticStopTimes.departure_time.label("scheduled_departure_time"),
+            StaticStopTimes.schedule_travel_time_seconds.label(
+                "scheduled_travel_time"
+            ),
+            StaticStopTimes.schedule_headway_branch_seconds.label(
+                "scheduled_headway_branch"
+            ),
+            StaticStopTimes.schedule_headway_trunk_seconds.label(
+                "scheduled_headway_trunk"
+            ),
+            StaticStopTimes.trip_id,
+            sa.func.coalesce(
+                StaticStops.parent_station,
+                StaticStops.stop_id,
+            ).label("parent_station"),
+        )
+        .select_from(StaticStopTimes)
+        .join(
+            StaticStops,
+            sa.and_(
+                StaticStopTimes.static_version_key
+                == StaticStops.static_version_key,
+                StaticStopTimes.stop_id == StaticStops.stop_id,
+            ),
+        )
+        .where(
+            StaticStopTimes.static_version_key == static_version_key,
+            StaticStops.static_version_key == static_version_key,
+        )
+        .subquery(name="static_subquery")
+    )
+
+    query = (
+        sa.select(
+            VehicleEvents.stop_sequence,
+            VehicleEvents.stop_id,
+            VehicleEvents.parent_station,
+            VehicleEvents.vp_move_timestamp.label("move_timestamp"),
+            sa.func.coalesce(
+                VehicleEvents.vp_stop_timestamp,
+                VehicleEvents.tu_stop_timestamp,
+            ).label("stop_timestamp"),
+            VehicleEvents.travel_time_seconds,
+            VehicleEvents.dwell_time_seconds,
+            VehicleEvents.headway_trunk_seconds,
+            VehicleEvents.headway_branch_seconds,
+            VehicleEvents.service_date,
+            VehicleTrips.route_id,
+            VehicleTrips.direction_id,
+            VehicleTrips.start_time,
+            VehicleTrips.vehicle_id,
+            VehicleTrips.branch_route_id,
+            VehicleTrips.trunk_route_id,
+            VehicleTrips.stop_count,
+            VehicleTrips.trip_id,
+            VehicleTrips.vehicle_label,
+            VehicleTrips.vehicle_consist,
+            VehicleTrips.direction,
+            VehicleTrips.direction_destination,
+            static_subquery.c.scheduled_arrival_time,
+            static_subquery.c.scheduled_departure_time,
+            static_subquery.c.scheduled_travel_time,
+            static_subquery.c.scheduled_headway_branch,
+            static_subquery.c.scheduled_headway_trunk,
+        )
+        .join(VehicleTrips, VehicleEvents.pm_trip_id == VehicleTrips.pm_trip_id)
+        .join(
+            static_subquery,
+            sa.and_(
+                static_subquery.c.trip_id == VehicleTrips.static_trip_id_guess,
+                static_subquery.c.parent_station
+                == VehicleEvents.parent_station,
+            ),
+            isouter=True,
+        )
+        .where(
+            VehicleEvents.service_date == service_date,
+            sa.or_(
+                VehicleEvents.vp_move_timestamp.is_not(None),
+                VehicleEvents.vp_stop_timestamp.is_not(None),
+            ),
+        )
+    )
+
+    # get the days events as a dataframe from postgres
+    days_events = db_manager.select_as_dataframe(query)
+
+    # transform the seru
+    days_events["year"] = (
+        days_events["service_date"].astype(str).str[:4].astype(int)
+    )
+    days_events["month"] = (
+        days_events["service_date"].astype(str).str[4:6].astype(int)
+    )
+    days_events["day"] = (
+        days_events["service_date"].astype(str).str[6:8].astype(int)
+    )
+
+    flat_schema = pyarrow.schema(
+        [
+            ("stop_sequence", pyarrow.int16()),
+            ("stop_id", pyarrow.string()),
+            ("parent_station", pyarrow.string()),
+            ("move_timestamp", pyarrow.int64()),
+            ("stop_timestamp", pyarrow.int64()),
+            ("travel_time_seconds", pyarrow.int64()),
+            ("dwell_time_seconds", pyarrow.int64()),
+            ("headway_trunk_seconds", pyarrow.int64()),
+            ("headway_branch_seconds", pyarrow.int64()),
+            ("service_date", pyarrow.int64()),
+            ("route_id", pyarrow.string()),
+            ("direction_id", pyarrow.int8()),
+            ("start_time", pyarrow.int64()),
+            ("vehicle_id", pyarrow.string()),
+            ("branch_route_id", pyarrow.string()),
+            ("trunk_route_id", pyarrow.string()),
+            ("stop_count", pyarrow.int16()),
+            ("trip_id", pyarrow.string()),
+            ("vehicle_label", pyarrow.string()),
+            ("vehicle_consist", pyarrow.string()),
+            ("direction", pyarrow.string()),
+            ("direction_destination", pyarrow.string()),
+            ("scheduled_arrival_time", pyarrow.int64()),
+            ("scheduled_departure_time", pyarrow.int64()),
+            ("scheduled_travel_time", pyarrow.int64()),
+            ("scheduled_headway_branch", pyarrow.int64()),
+            ("scheduled_headway_trunk", pyarrow.int64()),
+            ("year", pyarrow.int16()),
+            ("month", pyarrow.int8()),
+            ("day", pyarrow.int8()),
+        ]
+    )
+
+    return pyarrow.Table.from_pandas(days_events, schema=flat_schema)

--- a/python_src/src/lamp_py/performance_manager/pipeline.py
+++ b/python_src/src/lamp_py/performance_manager/pipeline.py
@@ -14,8 +14,9 @@ from lamp_py.postgres.postgres_utils import DatabaseManager
 from lamp_py.runtime_utils.process_logger import ProcessLogger
 from lamp_py.runtime_utils.alembic_migration import alembic_upgrade_to_head
 
-from .l0_gtfs_static_load import process_static_tables
+from .flat_file import write_flat_files
 from .l0_gtfs_rt_events import process_gtfs_rt_files
+from .l0_gtfs_static_load import process_static_tables
 
 logging.getLogger().setLevel("INFO")
 
@@ -94,6 +95,7 @@ def main(args: argparse.Namespace) -> None:
         try:
             process_static_tables(db_manager)
             process_gtfs_rt_files(db_manager)
+            write_flat_files(db_manager)
 
             process_logger.log_complete()
         except Exception as exception:

--- a/python_src/tests/ingestion/test_gtfs_converter.py
+++ b/python_src/tests/ingestion/test_gtfs_converter.py
@@ -326,17 +326,17 @@ def fixture_s3_patch(monkeypatch: MonkeyPatch) -> Iterator[None]:
 
     def mock_write_parquet_file(
         table: Table,
-        config_type: str,
-        s3_path: str,
+        file_type: str,
+        s3_dir: str,
         partition_cols: List[str],
-        visitor_func: Optional[Callable[..., None]],
+        visitor_func: Optional[Callable[..., None]] = None,
     ) -> None:
         """
         instead of writing the parquet file to s3, inspect the contents of the
         table. call the visitor function on a dummy s3 path.
         """
         # pull the name out of the s3 path and check that we are expecting this table
-        table_name = config_type.lower()
+        table_name = file_type.lower()
         tables_written.append(table_name)
 
         table_attributes = all_table_attributes()[table_name]
@@ -352,7 +352,7 @@ def fixture_s3_patch(monkeypatch: MonkeyPatch) -> Iterator[None]:
 
         # call the visitor function, which should add the string to the queue to check later
         if visitor_func is not None:
-            visitor_func(os.path.join(s3_path, "written.parquet"))
+            visitor_func(os.path.join(s3_dir, "written.parquet"))
 
     monkeypatch.setattr(
         "lamp_py.ingestion.convert_gtfs.write_parquet_file",

--- a/python_src/tests/performance_manager/test_performance_manager.py
+++ b/python_src/tests/performance_manager/test_performance_manager.py
@@ -11,6 +11,7 @@ from _pytest.monkeypatch import MonkeyPatch
 import pyarrow
 from pyarrow import fs, parquet, csv
 
+from lamp_py.performance_manager.flat_file import generate_daily_table
 from lamp_py.performance_manager.l0_gtfs_static_load import (
     process_static_tables,
 )
@@ -164,6 +165,58 @@ def fixture_s3_patch(monkeypatch: MonkeyPatch) -> Iterator[None]:
         "lamp_py.aws.s3._get_pyarrow_table", mock__get_pyarrow_table
     )
     yield
+
+
+def flat_table_check(db_manager: DatabaseManager, service_date: int) -> None:
+    """checks to run on a flat table to ensure it has what would be expected"""
+    flat_table = generate_daily_table(db_manager, service_date)
+
+    # check that the shape is good
+    rows, columns = flat_table.shape
+    assert columns == 30
+
+    expected_row_count = db_manager.select_as_list(
+        sa.select(sa.func.count()).where(
+            sa.and_(
+                VehicleEvents.service_date == service_date,
+                sa.or_(
+                    VehicleEvents.vp_move_timestamp.is_not(None),
+                    VehicleEvents.vp_stop_timestamp.is_not(None),
+                ),
+            )
+        )
+    )[0]["count_1"]
+    assert rows == expected_row_count
+
+    # check that partitioned columns behave appropriately
+    assert "year" in flat_table.column_names
+    assert len(flat_table["year"].unique()) == 1
+
+    assert "month" in flat_table.column_names
+    assert len(flat_table["month"].unique()) == 1
+
+    assert "day" in flat_table.column_names
+    assert len(flat_table["day"].unique()) == 1
+
+    # check that these keys have values throughout the file
+    must_have_keys = [
+        "stop_id",
+        "parent_station",
+        "route_id",
+        "direction_id",
+        "start_time",
+        "vehicle_id",
+        "trip_id",
+        "vehicle_label",
+        "year",
+        "month",
+        "day",
+    ]
+
+    for key in must_have_keys:
+        assert True not in flat_table[key].is_null(
+            nan_is_null=True
+        ), f"{key} has null values"
 
 
 def check_logs(caplog: pytest.LogCaptureFixture) -> None:
@@ -390,6 +443,8 @@ def test_gtfs_rt_processing(
 
         build_temp_events(events, db_manager)
         update_events_from_temp(db_manager)
+
+    flat_table_check(db_manager=db_manager, service_date=20230508)
 
     check_logs(caplog)
 


### PR DESCRIPTION
Create method to write a flat file from the database for a given service date. It joins the Vehicle Events, Vehicle Positions, and Static Stops tables into a format third parties can use to read performance data.

Add flat file writing to performance manager event loop after new data is generated from gtfs realtime files. Write flat files for service dates from newly processed data.

Asana Task: https://app.asana.com/0/1204931901750655/1204907226653447/f
Asana Task: https://app.asana.com/0/1204931901750655/1204907226653449/f
