### PR TITLE
feat: Suppress first stop record in `opmi_all_rt_fields_joined`

### DIFF
--- a/python_src/src/lamp_py/migrations/versions/performance_manager_prod/sql_strings/strings_001.py
+++ b/python_src/src/lamp_py/migrations/versions/performance_manager_prod/sql_strings/strings_001.py
@@ -385,6 +385,7 @@ view_opmi_all_rt_fields_joined = """
             vt.service_date
             , ve.pm_trip_id
             , ve.stop_sequence
+            , ve.canonical_stop_sequence
             , ve.stop_id
             , prev_ve.stop_id as previous_stop_id
             , ve.parent_station
@@ -423,9 +424,13 @@ view_opmi_all_rt_fields_joined = """
         LEFT JOIN
             vehicle_events prev_ve
         ON
-            ve.pm_event_id = prev_ve.previous_trip_stop_pm_event_id
+            ve.pm_event_id = prev_ve.next_trip_stop_pm_event_id
         WHERE
-            ve.vp_stop_timestamp IS NOT null
-            OR ve.vp_move_timestamp IS NOT null
+            ve.previous_trip_stop_pm_event_id is not NULL 
+            AND ( 
+                ve.vp_stop_timestamp IS NOT null
+                OR ve.vp_move_timestamp IS NOT null 
+            )
+            
         ;
     """

--- a/python_src/src/lamp_py/migrations/versions/performance_manager_staging/sql_strings/strings_001.py
+++ b/python_src/src/lamp_py/migrations/versions/performance_manager_staging/sql_strings/strings_001.py
@@ -385,6 +385,7 @@ view_opmi_all_rt_fields_joined = """
             vt.service_date
             , ve.pm_trip_id
             , ve.stop_sequence
+            , ve.canonical_stop_sequence
             , ve.stop_id
             , prev_ve.stop_id as previous_stop_id
             , ve.parent_station
@@ -423,9 +424,13 @@ view_opmi_all_rt_fields_joined = """
         LEFT JOIN
             vehicle_events prev_ve
         ON
-            ve.pm_event_id = prev_ve.previous_trip_stop_pm_event_id
+            ve.pm_event_id = prev_ve.next_trip_stop_pm_event_id
         WHERE
-            ve.vp_stop_timestamp IS NOT null
-            OR ve.vp_move_timestamp IS NOT null
+            ve.previous_trip_stop_pm_event_id is not NULL 
+            AND ( 
+                ve.vp_stop_timestamp IS NOT null
+                OR ve.vp_move_timestamp IS NOT null 
+            )
+            
         ;
     """


### PR DESCRIPTION
Ops Analytics requested that the first stop of every trip from the `ompi_all_rt_fields_joined` VIEW be dropped as the information is not relevant to their metrics. This change has been incorporated by added the WHERE clause:

`
     ve.previous_trip_stop_pm_event_id is not NULL
`

to the VIEW

While looking into this ticket I also noticed an error with joining the `vehicle_events` table to itself to generate previous stop information for each record. The JOIN condition was providing next stop information, editing the ON statement has fixed this bug. 

`canonical_stop_sequence` was also added to the view as it was a previous request from Ops Analytics, that was implemented but the VIEW was not updated. 


Asana Task: https://app.asana.com/0/1204931901750670/1205316545733163
