### PR TITLE
feat: Pre-Sort Pyarrow Tables to write smaller Parquet files

### DIFF
--- a/python_src/src/lamp_py/ingestion/config_rt_alerts.py
+++ b/python_src/src/lamp_py/ingestion/config_rt_alerts.py
@@ -1,3 +1,4 @@
+from typing import List, Tuple
 import pyarrow
 
 from .gtfs_rt_detail import GTFSRTDetail
@@ -209,3 +210,12 @@ class RtAlertsDetail(GTFSRTDetail):
                 ("translation", "recurrence_text_translation"),
             ),
         }
+
+    @property
+    def table_sort_order(self) -> List[Tuple[str, str]]:
+        return [
+            ("severity", "ascending"),
+            ("effect", "ascending"),
+            ("cause", "ascending"),
+            ("feed_timestamp", "ascending"),
+        ]

--- a/python_src/src/lamp_py/ingestion/config_rt_bus_trip.py
+++ b/python_src/src/lamp_py/ingestion/config_rt_bus_trip.py
@@ -1,3 +1,4 @@
+from typing import List, Tuple
 import pyarrow
 
 from .gtfs_rt_detail import GTFSRTDetail
@@ -13,18 +14,18 @@ class RtBusTripDetail(GTFSRTDetail):
     def export_schema(self) -> pyarrow.schema:
         return pyarrow.schema(
             [
-                ## header -> timestamp
+                # header -> timestamp
                 ("year", pyarrow.int16()),
                 ("month", pyarrow.int8()),
                 ("day", pyarrow.int8()),
                 ("hour", pyarrow.int8()),
                 ("feed_timestamp", pyarrow.int64()),  # actual: timestamp
-                ## entity
+                # entity
                 ("entity_id", pyarrow.string()),  # actual label: id
                 # "is_deleted" all null during schema review
                 # "alert" all null during schema review
                 # "vehicle" all null during schema review
-                ## entity -> trip_update
+                # entity -> trip_update
                 # "timestamp" all null during schema review
                 # "cause_description" all null during schema review
                 # "cause_id" all null during schema review
@@ -81,7 +82,7 @@ class RtBusTripDetail(GTFSRTDetail):
                         )
                     ),
                 ),
-                ## entity -> trip_update -> trip
+                # entity -> trip_update -> trip
                 ("direction_id", pyarrow.int64()),
                 ("route_id", pyarrow.string()),
                 ("route_pattern_id", pyarrow.string()),
@@ -89,7 +90,7 @@ class RtBusTripDetail(GTFSRTDetail):
                 ("start_date", pyarrow.string()),
                 ("start_time", pyarrow.string()),
                 ("trip_id", pyarrow.string()),
-                ## entity -> trip_update -> vehicle
+                # entity -> trip_update -> vehicle
                 # "license_plate" all null during schema review
                 ("vehicle_id", pyarrow.string()),  # actual label: id
                 ("vehicle_label", pyarrow.string()),  # actual label: label
@@ -111,13 +112,18 @@ class RtBusTripDetail(GTFSRTDetail):
                 ("trip_id",),
             ),
             "entity,trip_update,vehicle": (
-                (
-                    "id",
-                    "vehicle_id",
-                ),
-                (
-                    "label",
-                    "vehicle_label",
-                ),
+                ("id", "vehicle_id"),
+                ("label", "vehicle_label"),
             ),
         }
+
+    @property
+    def table_sort_order(self) -> List[Tuple[str, str]]:
+        return [
+            ("start_date", "ascending"),
+            ("route_pattern_id", "ascending"),
+            ("route_id", "ascending"),
+            ("direction_id", "ascending"),
+            ("vehicle_id", "ascending"),
+            ("feed_timestamp", "ascending"),
+        ]

--- a/python_src/src/lamp_py/ingestion/config_rt_bus_vehicle.py
+++ b/python_src/src/lamp_py/ingestion/config_rt_bus_vehicle.py
@@ -1,3 +1,4 @@
+from typing import List, Tuple
 import pyarrow
 
 from .gtfs_rt_detail import GTFSRTDetail
@@ -112,3 +113,13 @@ class RtBusVehicleDetail(GTFSRTDetail):
                 ("last_name",),
             ),
         }
+
+    @property
+    def table_sort_order(self) -> List[Tuple[str, str]]:
+        return [
+            ("start_date", "ascending"),
+            ("route_id", "ascending"),
+            ("block_id", "ascending"),
+            ("vehicle_id", "ascending"),
+            ("feed_timestamp", "ascending"),
+        ]

--- a/python_src/src/lamp_py/ingestion/config_rt_trip.py
+++ b/python_src/src/lamp_py/ingestion/config_rt_trip.py
@@ -1,3 +1,4 @@
+from typing import List, Tuple
 import pyarrow
 
 from .gtfs_rt_detail import GTFSRTDetail
@@ -108,3 +109,18 @@ class RtTripDetail(GTFSRTDetail):
                 ),
             ),
         }
+
+    # pylint: disable=R0801
+    # Similar lines in 2 files
+    @property
+    def table_sort_order(self) -> List[Tuple[str, str]]:
+        return [
+            ("start_date", "ascending"),
+            ("route_pattern_id", "ascending"),
+            ("route_id", "ascending"),
+            ("direction_id", "ascending"),
+            ("vehicle_id", "ascending"),
+            ("feed_timestamp", "ascending"),
+        ]
+
+    # pylint: enable=R0801

--- a/python_src/src/lamp_py/ingestion/config_rt_vehicle.py
+++ b/python_src/src/lamp_py/ingestion/config_rt_vehicle.py
@@ -1,3 +1,4 @@
+from typing import List, Tuple
 import pyarrow
 
 from .gtfs_rt_detail import GTFSRTDetail
@@ -100,3 +101,13 @@ class RtVehicleDetail(GTFSRTDetail):
                 ),
             ),
         }
+
+    @property
+    def table_sort_order(self) -> List[Tuple[str, str]]:
+        return [
+            ("start_date", "ascending"),
+            ("route_id", "ascending"),
+            ("vehicle_id", "ascending"),
+            ("direction_id", "ascending"),
+            ("feed_timestamp", "ascending"),
+        ]

--- a/python_src/src/lamp_py/ingestion/convert_gtfs_rt.py
+++ b/python_src/src/lamp_py/ingestion/convert_gtfs_rt.py
@@ -354,6 +354,10 @@ class GtfsRtConverter(Converter):
 
         try:
             s3_prefix = str(self.config_type)
+
+            if self.detail.table_sort_order is not None:
+                table = table.sort_by(self.detail.table_sort_order)
+
             write_parquet_file(
                 table=table,
                 file_type=s3_prefix,

--- a/python_src/src/lamp_py/ingestion/gtfs_rt_detail.py
+++ b/python_src/src/lamp_py/ingestion/gtfs_rt_detail.py
@@ -1,6 +1,6 @@
 from abc import ABC
 from abc import abstractmethod
-from typing import Dict
+from typing import Dict, Optional, List, Tuple
 
 import pyarrow
 
@@ -29,3 +29,9 @@ class GTFSRTDetail(ABC):
     def empty_table(self) -> Dict[str, list]:
         """Create an empty table using this details parrow schema."""
         return {key.name: [] for key in self.export_schema}
+
+    @property
+    @abstractmethod
+    def table_sort_order(self) -> Optional[List[Tuple[str, str]]]:
+        """Provide list of fields to sort pyarrow table before writing to parquet"""
+        return None


### PR DESCRIPTION
Pre-Sorting table data, before writing to Parquet, allows Parquet compression algos to take advantage of low cardinality data. 

The following drop in file sizes has been observed:
Vehicle Positions (1 hour dataset)
63 MB → 4.9 MB

Trip Updates ( 1 hour dataset)
132MB → 26.5 MB

Asana Task: https://app.asana.com/0/1204931901750675/1205499565957353
