### PR TITLE
feat: add `previous_canonical_stop_sequence` to OPMI view

### DIFF
--- a/python_src/src/lamp_py/migrations/versions/performance_manager_prod/sql_strings/strings_001.py
+++ b/python_src/src/lamp_py/migrations/versions/performance_manager_prod/sql_strings/strings_001.py
@@ -386,6 +386,7 @@ view_opmi_all_rt_fields_joined = """
             , ve.pm_trip_id
             , ve.stop_sequence
             , ve.canonical_stop_sequence
+            , prev_ve.canonical_stop_sequence as previous_canonical_stop_sequence
             , ve.stop_id
             , prev_ve.stop_id as previous_stop_id
             , ve.parent_station

--- a/python_src/src/lamp_py/migrations/versions/performance_manager_staging/sql_strings/strings_001.py
+++ b/python_src/src/lamp_py/migrations/versions/performance_manager_staging/sql_strings/strings_001.py
@@ -386,6 +386,7 @@ view_opmi_all_rt_fields_joined = """
             , ve.pm_trip_id
             , ve.stop_sequence
             , ve.canonical_stop_sequence
+            , prev_ve.canonical_stop_sequence as previous_canonical_stop_sequence
             , ve.stop_id
             , prev_ve.stop_id as previous_stop_id
             , ve.parent_station


### PR DESCRIPTION
`previous_canonical_stop_sequence` field added to OPMI RDS view based on request during touch point meeting on 13 September 2023. 

Asana Task: https://app.asana.com/0/1204931901750675/1205499565957359
