### PR TITLE
feat: add `sync_stop_sequence` field to performance manager

### DIFF
--- a/python_src/src/lamp_py/migrations/versions/performance_manager_prod/001_5d9a7ee21ae5_initial_prod_schema.py
+++ b/python_src/src/lamp_py/migrations/versions/performance_manager_prod/001_5d9a7ee21ae5_initial_prod_schema.py
@@ -293,6 +293,7 @@ def upgrade() -> None:
         sa.Column("pm_trip_id", sa.Integer(), nullable=False),
         sa.Column("stop_sequence", sa.SmallInteger(), nullable=True),
         sa.Column("canonical_stop_sequence", sa.SmallInteger(), nullable=True),
+        sa.Column("sync_stop_sequence", sa.SmallInteger(), nullable=True),
         sa.Column("stop_id", sa.String(length=60), nullable=False),
         sa.Column("parent_station", sa.String(length=60), nullable=False),
         sa.Column(

--- a/python_src/src/lamp_py/migrations/versions/performance_manager_prod/sql_strings/strings_001.py
+++ b/python_src/src/lamp_py/migrations/versions/performance_manager_prod/sql_strings/strings_001.py
@@ -387,6 +387,8 @@ view_opmi_all_rt_fields_joined = """
             , ve.stop_sequence
             , ve.canonical_stop_sequence
             , prev_ve.canonical_stop_sequence as previous_canonical_stop_sequence
+            , ve.sync_stop_sequence
+            , prev_ve.sync_stop_sequence as previous_sync_stop_sequence
             , ve.stop_id
             , prev_ve.stop_id as previous_stop_id
             , ve.parent_station

--- a/python_src/src/lamp_py/migrations/versions/performance_manager_staging/001_5d9a7ee21ae5_initial_prod_schema.py
+++ b/python_src/src/lamp_py/migrations/versions/performance_manager_staging/001_5d9a7ee21ae5_initial_prod_schema.py
@@ -293,6 +293,7 @@ def upgrade() -> None:
         sa.Column("pm_trip_id", sa.Integer(), nullable=False),
         sa.Column("stop_sequence", sa.SmallInteger(), nullable=True),
         sa.Column("canonical_stop_sequence", sa.SmallInteger(), nullable=True),
+        sa.Column("sync_stop_sequence", sa.SmallInteger(), nullable=True),
         sa.Column("stop_id", sa.String(length=60), nullable=False),
         sa.Column("parent_station", sa.String(length=60), nullable=False),
         sa.Column(

--- a/python_src/src/lamp_py/migrations/versions/performance_manager_staging/sql_strings/strings_001.py
+++ b/python_src/src/lamp_py/migrations/versions/performance_manager_staging/sql_strings/strings_001.py
@@ -387,6 +387,8 @@ view_opmi_all_rt_fields_joined = """
             , ve.stop_sequence
             , ve.canonical_stop_sequence
             , prev_ve.canonical_stop_sequence as previous_canonical_stop_sequence
+            , ve.sync_stop_sequence
+            , prev_ve.sync_stop_sequence as previous_sync_stop_sequence
             , ve.stop_id
             , prev_ve.stop_id as previous_stop_id
             , ve.parent_station

--- a/python_src/src/lamp_py/performance_manager/README.md
+++ b/python_src/src/lamp_py/performance_manager/README.md
@@ -13,6 +13,7 @@ Performance Manager is an application to measure rail performance on the MBTA tr
 | stop_id | string | false | |
 | stop_sequence | small integer | false | |
 | canonical_stop_sequence | small integer | false | stop_sequence based on "typical" route trips as defined in the [static_route_patterns](#static_route_patterns) table|
+| sync_stop_sequence | small integer | false | stop_sequence that is consistent across all branches of a trunk for a particular `parent_station`|
 | parent_station | string | false | |
 | previous_trip_stop_pm_event_id | integer | true | pm_event_id of previous stop of pm_trip_id grouping |
 | next_trip_stop_pm_event_id | integer | true| pm_event_id of next stop of pm_trip_id grouping |

--- a/python_src/src/lamp_py/postgres/postgres_schema.py
+++ b/python_src/src/lamp_py/postgres/postgres_schema.py
@@ -26,6 +26,7 @@ class VehicleEvents(SqlBase):  # pylint: disable=too-few-public-methods
     # stop identifiers
     stop_sequence = sa.Column(sa.SmallInteger, nullable=True)
     canonical_stop_sequence = sa.Column(sa.SmallInteger, nullable=True)
+    sync_stop_sequence = sa.Column(sa.SmallInteger, nullable=True)
     stop_id = sa.Column(sa.String(60), nullable=False)
     parent_station = sa.Column(sa.String(60), nullable=False)
 

--- a/python_src/tests/performance_manager/test_performance_manager.py
+++ b/python_src/tests/performance_manager/test_performance_manager.py
@@ -417,6 +417,7 @@ def test_gtfs_rt_processing(
             "headway_trunk_seconds",
             "headway_branch_seconds",
             "canonical_stop_sequence",
+            "sync_stop_sequence",
         }
         expected_columns.add("trip_id")
         expected_columns.add("vehicle_label")


### PR DESCRIPTION
Add `sync_stop_sequence` field to performance manager based on OPMI request.

`sync_stop_sequence` is a generated stop_sequence value that is meant to be consistent across parent stations for different branch-routes on the same trunk-route.

Asana Task: https://app.asana.com/0/1205634094440864/1205670479715896
