### PR TITLE
FIX: Use Trip Updates to help compute start time

### DIFF
--- a/python_src/src/lamp_py/ingestion/convert_gtfs_rt.py
+++ b/python_src/src/lamp_py/ingestion/convert_gtfs_rt.py
@@ -85,7 +85,7 @@ class GtfsRtConverter(Converter):
         self.archive_files: List[str] = []
 
     def convert(self) -> None:
-        max_tables_to_convert = 12
+        max_tables_to_convert = 6
         process_logger = ProcessLogger(
             "parquet_table_creator",
             table_type="gtfs-rt",

--- a/python_src/src/lamp_py/ingestion/pipeline.py
+++ b/python_src/src/lamp_py/ingestion/pipeline.py
@@ -60,7 +60,7 @@ def main() -> None:
         check_for_sigterm(metadata_queue, rds_process)
         ingest(metadata_queue=metadata_queue)
         check_for_sigterm(metadata_queue, rds_process)
-        time.sleep(60 * 5)
+        time.sleep(5)
 
 
 def start() -> None:

--- a/python_src/src/lamp_py/performance_manager/gtfs_utils.py
+++ b/python_src/src/lamp_py/performance_manager/gtfs_utils.py
@@ -31,8 +31,14 @@ def start_time_to_seconds(
     """
     if time is None:
         return time
-    (hour, minute, second) = time.split(":")
-    return int(hour) * 3600 + int(minute) * 60 + int(second)
+
+    try:
+        (hour, minute, second) = time.split(":")
+        return int(hour) * 3600 + int(minute) * 60 + int(second)
+    except ValueError:
+        # some older files have the start time already formatted as seconds
+        # after midnight. in those cases, convert to an int and pass through.
+        return int(time)
 
 
 def start_timestamp_to_seconds(start_timestamp: int) -> int:

--- a/python_src/src/lamp_py/performance_manager/l0_rt_trip_updates.py
+++ b/python_src/src/lamp_py/performance_manager/l0_rt_trip_updates.py
@@ -183,7 +183,7 @@ def process_tu_files(
     Generate a dataframe of Vehicle Events from gtfs_rt trip updates parquet files.
     """
     process_logger = ProcessLogger(
-        "process_trip_updates", file_count=len(paths)
+        "process_trip_updates", file_count=len(paths), paths=paths
     )
     process_logger.log_start()
 

--- a/python_src/src/lamp_py/performance_manager/l0_rt_vehicle_positions.py
+++ b/python_src/src/lamp_py/performance_manager/l0_rt_vehicle_positions.py
@@ -218,7 +218,7 @@ def process_vp_files(
     Generate a dataframe of Vehicle Events from gtfs_rt vehicle position parquet files.
     """
     process_logger = ProcessLogger(
-        "process_vehicle_positions", file_count=len(paths)
+        "process_vehicle_positions", file_count=len(paths), paths=paths
     )
     process_logger.log_start()
 

--- a/python_src/src/lamp_py/performance_manager/l1_rt_trips.py
+++ b/python_src/src/lamp_py/performance_manager/l1_rt_trips.py
@@ -290,6 +290,7 @@ def update_start_times(db_manager: DatabaseManager) -> None:
             sa.func.coalesce(
                 sa.func.min(VehicleEvents.vp_move_timestamp),
                 sa.func.min(VehicleEvents.vp_stop_timestamp),
+                sa.func.min(VehicleEvents.tu_stop_timestamp),
             ).label("b_start_time"),
         )
         .select_from(VehicleEvents)


### PR DESCRIPTION
When processing trips, we need to compute a start time for added trips. We've coded doing that based on the minimal vp move and vp stop timestamps for a given trip. However, this flow triggers a failure if there are only Trip Update records for this event. In those cases, use the minimal tu stop timestamp as well.