### PR TITLE
Chore: Update GitHub actions to use assumed role

### DIFF
--- a/.github/actions/deploy/action.yaml
+++ b/.github/actions/deploy/action.yaml
@@ -1,5 +1,8 @@
 name: Deploy To Environment
 description: Build docker image and deploy it for each data pipeline.
+permissions:
+  id-token: write
+  contents: read
 inputs:
   aws-role-arn:
     description: AWS_ROLE_ARN

--- a/.github/actions/deploy/action.yaml
+++ b/.github/actions/deploy/action.yaml
@@ -4,9 +4,6 @@ permissions:
   id-token: write
   contents: read
 inputs:
-  aws-role-arn:
-    description: AWS_ROLE_ARN
-    required: true
   docker-repo:
     description: ECR Docker repo to push to
     required: true
@@ -15,6 +12,9 @@ inputs:
     required: true
   slack-webhook-url:
     description: Slack URL to post to
+    required: true
+  role-to-assume:
+    description: AWS_ROLE_ARN
     required: true
 
 runs:

--- a/.github/actions/deploy/action.yaml
+++ b/.github/actions/deploy/action.yaml
@@ -20,23 +20,25 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ inputs.role-to-assume }}
+        aws-region: us-east-1
     - uses: mbta/actions/build-push-ecr@v2
       id: build-push
       with:
-        role-to-assume: ${{ inputs.aws-role-arn }}
         docker-repo: ${{ inputs.docker-repo }}
         dockerfile-path: ./python_src/
     - uses: mbta/actions/deploy-ecs@v2
       id: deploy-ingestion
       with:
-        role-to-assume: ${{ inputs.aws-role-arn }}
         ecs-cluster: lamp
         ecs-service: lamp-ingestion-${{ inputs.env-name }}
         docker-tag: ${{ steps.build-push.outputs.docker-tag }}
     - uses: mbta/actions/deploy-ecs@v2
       id: deploy-performance-manager
       with:
-        role-to-assume: ${{ inputs.aws-role-arn }}
         ecs-cluster: lamp
         ecs-service: lamp-performance-manager-${{ inputs.env-name }}
         docker-tag: ${{ steps.build-push.outputs.docker-tag }}

--- a/.github/actions/deploy/action.yaml
+++ b/.github/actions/deploy/action.yaml
@@ -1,11 +1,8 @@
 name: Deploy To Environment
 description: Build docker image and deploy it for each data pipeline.
 inputs:
-  aws-access-key-id:
-    description: AWS_ACCESS_KEY_ID
-    required: true
-  aws-secret-access-key:
-    description: AWS_SECRET_ACCCESS_KEY
+  aws-role-arn:
+    description: AWS_ROLE_ARN
     required: true
   docker-repo:
     description: ECR Docker repo to push to
@@ -20,26 +17,23 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: mbta/actions/build-push-ecr@v1
+    - uses: mbta/actions/build-push-ecr@v2
       id: build-push
       with:
-        aws-access-key-id: ${{ inputs.aws-access-key-id }}
-        aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
+        role-to-assume: ${{ inputs.aws-role-arn }}
         docker-repo: ${{ inputs.docker-repo }}
         dockerfile-path: ./python_src/
-    - uses: mbta/actions/deploy-ecs@v1
+    - uses: mbta/actions/deploy-ecs@v2
       id: deploy-ingestion
       with:
-        aws-access-key-id: ${{ inputs.aws-access-key-id }}
-        aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
+        role-to-assume: ${{ inputs.aws-role-arn }}
         ecs-cluster: lamp
         ecs-service: lamp-ingestion-${{ inputs.env-name }}
         docker-tag: ${{ steps.build-push.outputs.docker-tag }}
-    - uses: mbta/actions/deploy-ecs@v1
+    - uses: mbta/actions/deploy-ecs@v2
       id: deploy-performance-manager
       with:
-        aws-access-key-id: ${{ inputs.aws-access-key-id }}
-        aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
+        role-to-assume: ${{ inputs.aws-role-arn }}
         ecs-cluster: lamp
         ecs-service: lamp-performance-manager-${{ inputs.env-name }}
         docker-tag: ${{ steps.build-push.outputs.docker-tag }}

--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -11,7 +11,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v3
-      - uses: mbta/actions/deploy-ecs@v2
+      - uses: ./.github/actions/deploy
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           docker-repo: ${{ secrets.LAMP_DOCKER_URI }}

--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -6,12 +6,14 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v3
-      - uses: ./.github/actions/deploy
+      - uses: mbta/actions/deploy-ecs@v2
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           docker-repo: ${{ secrets.LAMP_DOCKER_URI }}
           env-name: dev 
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -11,7 +11,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v3
-      - uses: mbta/actions/deploy-ecs@v2
+      - uses: ./.github/actions/deploy
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           docker-repo: ${{ secrets.LAMP_DOCKER_URI }}

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -6,12 +6,14 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v3
-      - uses: ./.github/actions/deploy
+      - uses: mbta/actions/deploy-ecs@v2
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           docker-repo: ${{ secrets.LAMP_DOCKER_URI }}
           env-name: prod
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -11,12 +11,14 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v3
-      - uses: ./.github/actions/deploy
+      - uses: mbta/actions/deploy-ecs@v2
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           docker-repo: ${{ secrets.LAMP_DOCKER_URI }}
           env-name: staging
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -16,7 +16,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v3
-      - uses: mbta/actions/deploy-ecs@v2
+      - uses: ./.github/actions/deploy
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           docker-repo: ${{ secrets.LAMP_DOCKER_URI }}


### PR DESCRIPTION
Asana Task: <[asana_ticket_url](https://app.asana.com/0/1113179098808463/1205367032564122/f)>

This PR updates the deploy workflow to use v2 of the shared `build-push-ecr` and `deploy-ecs` actions. These updated actions assume an IAM role instead of relying on long-lasting AWS keys for an IAM user

Successful dev deployment [here](https://github.com/mbta/lamp/actions/runs/6553421551)