### PR TITLE
FIX: Tableau Server Import Exception 

### DIFF
--- a/python_src/src/lamp_py/tableau/pipeline.py
+++ b/python_src/src/lamp_py/tableau/pipeline.py
@@ -1,7 +1,9 @@
 import os
+from typing import List
 
 from lamp_py.runtime_utils.env_validation import validate_environment
 
+from lamp_py.tableau.hyper import HyperJob
 from lamp_py.tableau.jobs.rt_rail import HyperRtRail
 from lamp_py.tableau.jobs.gtfs_rail import (
     HyperServiceIdByRoute,
@@ -14,17 +16,20 @@ from lamp_py.tableau.jobs.gtfs_rail import (
     HyperStaticTrips,
 )
 
-HYPER_JOBS = (
-    HyperRtRail(),
-    HyperServiceIdByRoute(),
-    HyperStaticCalendar(),
-    HyperStaticCalendarDates(),
-    HyperStaticFeedInfo(),
-    HyperStaticRoutes(),
-    HyperStaticStops(),
-    HyperStaticStopTimes(),
-    HyperStaticTrips(),
-)
+
+def create_hyper_jobs() -> List[HyperJob]:
+    """Create Hyper Jobs to Run"""
+    return [
+        HyperRtRail(),
+        HyperServiceIdByRoute(),
+        HyperStaticCalendar(),
+        HyperStaticCalendarDates(),
+        HyperStaticFeedInfo(),
+        HyperStaticRoutes(),
+        HyperStaticStops(),
+        HyperStaticStopTimes(),
+        HyperStaticTrips(),
+    ]
 
 
 def start_hyper_updates() -> None:
@@ -39,12 +44,11 @@ def start_hyper_updates() -> None:
             "PUBLIC_ARCHIVE_BUCKET",
         ],
     )
-
-    for job in HYPER_JOBS:
+    for job in create_hyper_jobs():
         job.run_hyper()
 
 
 def start_parquet_updates() -> None:
     """Run all Parquet Update jobs"""
-    for job in HYPER_JOBS:
+    for job in create_hyper_jobs():
         job.run_parquet()

--- a/python_src/src/lamp_py/tableau/server.py
+++ b/python_src/src/lamp_py/tableau/server.py
@@ -42,8 +42,8 @@ def tableau_authentication(
 
 
 def project_list(
-    server: TSC.server.server.Server = tableau_server(),
-    auth: TSC.models.tableau_auth.TableauAuth = tableau_authentication(),
+    server: Optional[TSC.server.server.Server] = None,
+    auth: Optional[TSC.models.tableau_auth.TableauAuth] = None,
 ) -> List[TSC.models.project_item.ProjectItem]:
     """
     Get List of all projects from Tablea server
@@ -53,13 +53,18 @@ def project_list(
 
     :return List[ProjectItem]
     """
+    if server is None:
+        server = tableau_server()
+    if auth is None:
+        auth = tableau_authentication()
+
     with server.auth.sign_in(auth):
         return list(TSC.Pager(server.projects))
 
 
 def datasource_list(
-    server: TSC.server.server.Server = tableau_server(),
-    auth: TSC.models.tableau_auth.TableauAuth = tableau_authentication(),
+    server: Optional[TSC.server.server.Server] = None,
+    auth: Optional[TSC.models.tableau_auth.TableauAuth] = None,
 ) -> List[TSC.models.datasource_item.DatasourceItem]:
     """
     Get List of all datasources from Tablea server
@@ -69,14 +74,19 @@ def datasource_list(
 
     :return List[DatasourceItem]
     """
+    if server is None:
+        server = tableau_server()
+    if auth is None:
+        auth = tableau_authentication()
+
     with server.auth.sign_in(auth):
         return list(TSC.Pager(server.datasources))
 
 
 def project_from_name(
     project_name: str,
-    server: TSC.server.server.Server = tableau_server(),
-    auth: TSC.models.tableau_auth.TableauAuth = tableau_authentication(),
+    server: Optional[TSC.server.server.Server] = None,
+    auth: Optional[TSC.models.tableau_auth.TableauAuth] = None,
 ) -> Optional[TSC.models.project_item.ProjectItem]:
     """
     Get Tableau ProjectItem from name
@@ -90,12 +100,17 @@ def project_from_name(
 
 def datasource_from_name(
     datasource_name: str,
-    server: TSC.server.server.Server = tableau_server(),
-    auth: TSC.models.tableau_auth.TableauAuth = tableau_authentication(),
+    server: Optional[TSC.server.server.Server] = None,
+    auth: Optional[TSC.models.tableau_auth.TableauAuth] = None,
 ) -> Optional[TSC.models.datasource_item.DatasourceItem]:
     """
     Get Tableau DatasourceItem from name
     """
+    if server is None:
+        server = tableau_server()
+    if auth is None:
+        auth = tableau_authentication()
+
     for datasource in datasource_list(server, auth):
         if datasource.name == datasource_name:
             return datasource
@@ -106,12 +121,17 @@ def datasource_from_name(
 def overwrite_datasource(
     project_name: str,
     hyper_path: str,
-    server: TSC.server.server.Server = tableau_server(),
-    auth: TSC.models.tableau_auth.TableauAuth = tableau_authentication(),
+    server: Optional[TSC.server.server.Server] = None,
+    auth: Optional[TSC.models.tableau_auth.TableauAuth] = None,
 ) -> TSC.models.datasource_item.DatasourceItem:
     """
     Publish locally saved hyperfile to Tableau
     """
+    if server is None:
+        server = tableau_server()
+    if auth is None:
+        auth = tableau_authentication()
+
     publish_mode = TSC.Server.PublishMode.Overwrite
 
     project = project_from_name(project_name)


### PR DESCRIPTION
`tableau_server` function call being in function signature was causing Exception at import time. Move function calls out of parameter declaration. 

Also move HyperJob creation into function to avoid creation of jobs at import. 
