### PR TITLE
Run vacuum analyze on static tables

### DIFF
--- a/python_src/src/lamp_py/performance_manager/l0_gtfs_rt_events.py
+++ b/python_src/src/lamp_py/performance_manager/l0_gtfs_rt_events.py
@@ -533,4 +533,7 @@ def process_gtfs_rt_files(db_manager: DatabaseManager) -> None:
             )
             subprocess_logger.log_failure(error)
 
+    db_manager.vacuum_analyze(VehicleEvents)
+    db_manager.vacuum_analyze(VehicleTrips)
+
     process_logger.log_complete()

--- a/python_src/src/lamp_py/performance_manager/l0_gtfs_static_load.py
+++ b/python_src/src/lamp_py/performance_manager/l0_gtfs_static_load.py
@@ -364,7 +364,8 @@ def insert_data_tables(
     db_manager: DatabaseManager,
 ) -> None:
     """
-    insert static gtfs data tables into rds tables
+    insert static gtfs data tables into rds tables and run a vacuum analyze
+    afterwards to re-index
     """
     for table in static_tables.values():
         process_logger = ProcessLogger(
@@ -372,6 +373,7 @@ def insert_data_tables(
         )
         process_logger.log_start()
         db_manager.insert_dataframe(table.data_table, table.insert_table)
+        db_manager.vacuum_analyze(table.insert_table)
         process_logger.log_complete()
 
 

--- a/python_src/src/lamp_py/postgres/postgres_utils.py
+++ b/python_src/src/lamp_py/postgres/postgres_utils.py
@@ -295,6 +295,14 @@ class DatabaseManager:
             cursor.execute(sa.text("END TRANSACTION;"))
             cursor.execute(sa.text(f"VACUUM (ANALYZE) {truncat_as};"))
 
+    def vacuum_analyze(self, table: Any) -> None:
+        """RUN VACUUM (ANALYZE) on table"""
+        table_as = self._get_schema_table(table)
+
+        with self.session.begin() as cursor:
+            cursor.execute(sa.text("END TRANSACTION;"))
+            cursor.execute(sa.text(f"VACUUM (ANALYZE) {table_as};"))
+
     def add_metadata_paths(self, paths: List[str]) -> None:
         """
         add metadata filepaths to metadata table for testing


### PR DESCRIPTION
Some of our subquery execution times have blown up and the assumption is that they will be more performative if we run `VACUUM (ANALYZE)` on static tables after a static schedule is processed.

* add a new function to run vacuum analyze on a table to the DatabaseManager class.
* use that function on static tables after new data is loaded.
* use that function on vehicle events and vehicle trips tables after processing a batch of gtfs_rt data.
