### PR TITLE
FIX: Parquet writes failing from  performance manager

### DIFF
--- a/python_src/src/lamp_py/tableau/jobs/rt_rail.py
+++ b/python_src/src/lamp_py/tableau/jobs/rt_rail.py
@@ -126,10 +126,10 @@ class HyperRtRail(HyperJob):
                 ("static_stop_count", pyarrow.int64()),
                 ("first_last_station_match", pyarrow.bool_()),
                 ("static_version_key", pyarrow.int64()),
-                ("travel_time_seconds", pyarrow.int16()),
-                ("dwell_time_seconds", pyarrow.int16()),
-                ("headway_trunk_seconds", pyarrow.int16()),
-                ("headway_branch_seconds", pyarrow.int16()),
+                ("travel_time_seconds", pyarrow.int32()),
+                ("dwell_time_seconds", pyarrow.int32()),
+                ("headway_trunk_seconds", pyarrow.int32()),
+                ("headway_branch_seconds", pyarrow.int32()),
                 ("updated_on", pyarrow.timestamp("us")),
             ]
         )

--- a/python_src/src/lamp_py/tableau/pipeline.py
+++ b/python_src/src/lamp_py/tableau/pipeline.py
@@ -12,7 +12,7 @@ from lamp_py.tableau.jobs.gtfs_rail import (
     HyperStaticFeedInfo,
     HyperStaticRoutes,
     HyperStaticStops,
-    HyperStaticStopTimes,
+    # HyperStaticStopTimes,
     HyperStaticTrips,
 )
 
@@ -27,7 +27,7 @@ def create_hyper_jobs() -> List[HyperJob]:
         HyperStaticFeedInfo(),
         HyperStaticRoutes(),
         HyperStaticStops(),
-        HyperStaticStopTimes(),
+        # HyperStaticStopTimes(),
         HyperStaticTrips(),
     ]
 


### PR DESCRIPTION
Fix type overload on `HyperRtRail` Job

Skip processing of `HyperStaticStopTimes` because it causes out of memory on ecs. 
