### PR TITLE
FIX: LAMP_ALL_RT_fields incorrect SQL comparison

### DIFF
--- a/python_src/src/lamp_py/tableau/jobs/rt_rail.py
+++ b/python_src/src/lamp_py/tableau/jobs/rt_rail.py
@@ -1,4 +1,5 @@
 import os
+import datetime
 
 import pyarrow
 import pyarrow.parquet as pq
@@ -157,10 +158,10 @@ class HyperRtRail(HyperJob):
 
         max_stats = self.max_stats_of_parquet()
 
-        max_start_date = max_stats["service_date"]
+        max_start_date: datetime.date = max_stats["service_date"]
 
         update_query = self.table_query % (
-            f" AND vt.service_date >= {max_start_date} ",
+            f" AND vt.service_date >= {max_start_date.strftime('%Y%m%d')} ",
         )
 
         db_parquet_path = "/tmp/db_local.parquet"


### PR DESCRIPTION
```
 max_stats["service_date"]
```
statement was returning `datetime.date` object that was being piped direction into SQL statement for comparison to `vehicle_trips.service_date` which is an `Integer` field in the format of `YYYYMMDD`.

This change converts the `datetime.date` object into string representation of `YYYYMMDD` for the SQL statement comparison. 
