### PR TITLE
FIX: Update how Secrets are used in Base Deploy

### DIFF
--- a/.github/workflows/deploy-base.yaml
+++ b/.github/workflows/deploy-base.yaml
@@ -34,7 +34,7 @@ on:
       SLACK_WEBHOOK:
         description: Slack URL to post to
         required: true
-      ROLE_TO_ASSUME:
+      AWS_ROLE_ARN:
         description: AWS_ROLE_ARN
         required: true
 
@@ -52,15 +52,15 @@ jobs:
         id: setup-aws
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ inputs.role-to-assume }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Build and Push Docker Image
         id: build-push
         uses: mbta/actions/build-push-ecr@v2
         with:
-          role-to-assume: ${{ inputs.role-to-assume }}
-          docker-repo: ${{ inputs.docker-repo }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          docker-repo: ${{ secrets.DOCKER_REPO }}
           dockerfile-path: ./python_src/
 
       - name: Deploy Ingestion Application
@@ -68,7 +68,7 @@ jobs:
         if: ${{ inputs.deploy-ingestion }}
         uses: mbta/actions/deploy-ecs@v2
         with:
-          role-to-assume: ${{ inputs.role-to-assume }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           ecs-cluster: lamp
           ecs-service: lamp-ingestion-${{ inputs.env-name }}
           docker-tag: ${{ steps.build-push.outputs.docker-tag }}
@@ -78,7 +78,7 @@ jobs:
         if: ${{ inputs.deploy-rail-pm }}
         uses: mbta/actions/deploy-ecs@v2
         with:
-          role-to-assume: ${{ inputs.role-to-assume }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           ecs-cluster: lamp
           ecs-service: lamp-rail-performance-manager-${{ inputs.env-name }}
           docker-tag: ${{ steps.build-push.outputs.docker-tag }}
@@ -88,7 +88,7 @@ jobs:
         if: ${{ inputs.deploy-rail-pm && inputs.env-name == 'prod' }}
         uses: mbta/actions/deploy-scheduled-ecs@v2
         with:
-          role-to-assume: ${{ inputs.role-to-assume }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           ecs-cluster: lamp
           ecs-service: lamp-tableau-publisher-${{ inputs.env-name }}
           ecs-task-definition: lamp-tableau-publisher-${{ inputs.env-name }}
@@ -97,5 +97,5 @@ jobs:
       - uses: mbta/actions/notify-slack-deploy@v2
         if: ${{ !cancelled() }}
         with:
-          webhook-url: ${{ inputs.slack-webhook-url }}
+          webhook-url: ${{ secrets.SLACK_WEBHOOK }}
           job-status: ${{ job.status }}


### PR DESCRIPTION
The secrets should be as they are in the the repo's secrets. Additionally, they need to be accessed via the `secrets` variable, not the `inputs` variable.