### PR TITLE
CHORE: Clean Up Parquet File Writing

### DIFF
--- a/python_src/pyproject.toml
+++ b/python_src/pyproject.toml
@@ -44,7 +44,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.black]
 line-length = 80
-target-version = ['py39']
+target-version = ['py310']
 
 [tool.mypy]
 disallow_untyped_defs = true

--- a/python_src/src/lamp_py/tableau/hyper.py
+++ b/python_src/src/lamp_py/tableau/hyper.py
@@ -199,7 +199,7 @@ class HyperJob(ABC):  # pylint: disable=R0902
         )
         process_log.log_start()
 
-        for retry_count in range(max_retries):
+        for retry_count in range(max_retries + 1):
             try:
                 process_log.add_metadata(retry_count=retry_count)
                 # get datasource from Tableau to check "updated_at" datetime
@@ -256,7 +256,7 @@ class HyperJob(ABC):  # pylint: disable=R0902
                 break
 
             except Exception as exception:
-                if retry_count == max_retries - 1:
+                if retry_count == max_retries:
                     process_log.log_failure(exception=exception)
 
     def run_parquet(self, db_manager: DatabaseManager) -> None:

--- a/python_src/src/lamp_py/tableau/jobs/gtfs_rail.py
+++ b/python_src/src/lamp_py/tableau/jobs/gtfs_rail.py
@@ -40,10 +40,13 @@ class HyperGTFS(HyperJob):
         if os.path.exists(self.local_parquet_path):
             os.remove(self.local_parquet_path)
 
+        db_batch_size = 1024 * 1024 / 2
+
         db_manager.write_to_parquet(
             select_query=sa.text(self.create_query),
             write_path=self.local_parquet_path,
             schema=self.parquet_schema,
+            batch_size=db_batch_size,
         )
 
     def update_parquet(self, db_manager: DatabaseManager) -> bool:

--- a/python_src/src/lamp_py/tableau/pipeline.py
+++ b/python_src/src/lamp_py/tableau/pipeline.py
@@ -1,4 +1,5 @@
 import os
+import gc
 from typing import List
 
 from lamp_py.runtime_utils.env_validation import validate_environment
@@ -56,3 +57,7 @@ def start_parquet_updates(db_manager: DatabaseManager) -> None:
     """Run all Parquet Update jobs"""
     for job in create_hyper_jobs():
         job.run_parquet(db_manager)
+
+    # ECS Memory Utilization appeared to stay elevated after initial calling
+    # of `run_parquet` to create all parquet files, this may resolve that...
+    gc.collect()

--- a/python_src/src/lamp_py/tableau/server.py
+++ b/python_src/src/lamp_py/tableau/server.py
@@ -23,7 +23,7 @@ def tableau_server(
 def tableau_authentication(
     tableau_user: Optional[str] = os.getenv("TABLEAU_USER"),
     tableau_password: Optional[str] = os.getenv("TABLEAU_PASSWORD"),
-    tableau_site: str = "",  # empty string corresponds to Default site
+    tableau_site: str = "",  # empty string corresponds to 'Default' site
 ) -> TSC.models.tableau_auth.TableauAuth:
     """
     Get Tableau Authentication object


### PR DESCRIPTION
This change has some minor updates to our parquet file writing process that should be helpful prior to our push to the prod environment.

- decrease `batch_size` for initial parquet file creation to reduce memory usage
- clean up `LAMP_ALL_RT_fields` schema 
- add `gc.collect()` call to end of parquet file creation process