### PR TITLE
FIX: More bugs in Manual Deploy Workflow

### DIFF
--- a/.github/workflows/change_task_count.yaml
+++ b/.github/workflows/change_task_count.yaml
@@ -9,6 +9,7 @@ on:
         options:
           - dev
           - staging
+          - prod
       new_count:
         description: 1 to turn on 0 to turn off
         required: true

--- a/.github/workflows/deploy-base.yaml
+++ b/.github/workflows/deploy-base.yaml
@@ -8,7 +8,7 @@
 on:
   workflow_call:
     inputs:
-      env-name:
+      environment:
         description: One of 'prod', 'staging', or 'dev'
         required: true
         type: string
@@ -47,14 +47,12 @@ jobs:
     steps:
       - name: Checkout Branch
         uses: actions/checkout@v3
-
       - name: Configure AWS credentials
         id: setup-aws
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: us-east-1
-
       - name: Build and Push Docker Image
         id: build-push
         uses: mbta/actions/build-push-ecr@v2
@@ -62,7 +60,6 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           docker-repo: ${{ secrets.DOCKER_REPO }}
           dockerfile-path: ./python_src/
-
       - name: Deploy Ingestion Application
         id: deploy-ingestion
         if: ${{ inputs.deploy-ingestion }}
@@ -70,9 +67,8 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           ecs-cluster: lamp
-          ecs-service: lamp-ingestion-${{ inputs.env-name }}
+          ecs-service: lamp-ingestion-${{ inputs.environment }}
           docker-tag: ${{ steps.build-push.outputs.docker-tag }}
-
       - name: Deploy Rail Performance Manager Application
         id: deploy-rail-performance-manager
         if: ${{ inputs.deploy-rail-pm }}
@@ -80,20 +76,18 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           ecs-cluster: lamp
-          ecs-service: lamp-rail-performance-manager-${{ inputs.env-name }}
+          ecs-service: lamp-rail-performance-manager-${{ inputs.environment }}
           docker-tag: ${{ steps.build-push.outputs.docker-tag }}
-
       - name: Deploy Tableau Publisher Application
         id: deploy-tableau-publisher
-        if: ${{ inputs.deploy-rail-pm && inputs.env-name == 'prod' }}
+        if: ${{ inputs.deploy-rail-pm && inputs.environment == 'prod' }}
         uses: mbta/actions/deploy-scheduled-ecs@v2
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           ecs-cluster: lamp
-          ecs-service: lamp-tableau-publisher-${{ inputs.env-name }}
-          ecs-task-definition: lamp-tableau-publisher-${{ inputs.env-name }}
+          ecs-service: lamp-tableau-publisher-${{ inputs.environment }}
+          ecs-task-definition: lamp-tableau-publisher-${{ inputs.environment }}
           docker-tag: ${{ steps.build-push.outputs.docker-tag }}
-
       - uses: mbta/actions/notify-slack-deploy@v2
         if: ${{ !cancelled() }}
         with:

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -13,7 +13,7 @@ jobs:
       group: prod
     uses: ./.github/workflows/deploy-base.yaml
     with:
-      env-name: prod
+      environment: prod
       deploy-ingestion: true
       deploy-rail-pm: true
       deploy-tableau-publisher: true

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -16,7 +16,7 @@ jobs:
       group: staging
     uses: ./.github/workflows/deploy-base.yaml
     with:
-      env-name: staging
+      environment: staging
       deploy-ingestion: true
       deploy-rail-pm: true
     secrets: inherit

--- a/.github/workflows/manual-deploy.yaml
+++ b/.github/workflows/manual-deploy.yaml
@@ -25,13 +25,14 @@ on:
 
 jobs:
   deploy:
-    name: Deploy to Production
     concurrency:
       group: github.event.inputs.environment
     uses: ./.github/workflows/deploy-base.yaml
     with:
-      env-name: github.event.inputs.environment
-      deploy-ingestion: github.envent.inputs.deploy-ingestion
-      deploy-rail-pm: github.envent.inputs.deploy-rail-pm
-      deploy-tableau-publisher: github.envent.inputs.deploy-tableau-publisher
+      # pass the inputs from the workflow dispatch through to the deploy base. the booleans are
+      # converted to strings, so flip them back using fromJson function
+      environment: ${{ github.event.inputs.environment }}
+      deploy-ingestion: ${{ fromJson(github.event.inputs.deploy-ingestion) }}
+      deploy-rail-pm: ${{ fromJson(github.event.inputs.deploy-rail-pm) }}
+      deploy-tableau-publisher: ${{ fromJson(github.event.inputs.deploy-tableau-publisher) }}
     secrets: inherit


### PR DESCRIPTION
* Inputs need to be passed in from the workflow dispatch to the base workflow as booleans, so use a fromJson function to flip them.
* Rename the env-name input to environment so that it matches with the workflow dispatch name.
* Pass the environment string, not the name of the variable.

* Add prod to list of environments we can change the task count for.