### PR TITLE
FIX: Downgrade TSC Library

### DIFF
--- a/python_src/poetry.lock
+++ b/python_src/poetry.lock
@@ -1742,24 +1742,24 @@ cffi = ">=1.12.2,<1.14.3 || >1.14.3,<2"
 
 [[package]]
 name = "tableauserverclient"
-version = "0.28"
+version = "0.25"
 description = "A Python module for working with the Tableau Server REST API."
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "tableauserverclient-0.28-py3-none-any.whl", hash = "sha256:dedee5c74de7b02617f6fb76c16252dbf2fcaf594929e22e6615cbf013515845"},
-    {file = "tableauserverclient-0.28.tar.gz", hash = "sha256:8d26e50d592eb81059ec698f2946238bcc2d4683d2ee0f2be987bd1299e3bca0"},
+    {file = "tableauserverclient-0.25-py3-none-any.whl", hash = "sha256:341cea1706c8fc4ce35d28e21f420e3874ec13812497e1629d37adb4dce4c74a"},
+    {file = "tableauserverclient-0.25.tar.gz", hash = "sha256:d354d16245c459a805ad207bcef3fa063e18bc8168695920ac89bf8125a420b6"},
 ]
 
 [package.dependencies]
 defusedxml = ">=0.7.1"
-packaging = ">=23.1"
-requests = ">=2.31"
-urllib3 = "2.0.6"
+packaging = ">=22.0"
+requests = ">=2.28"
+urllib3 = ">=1.26.8,<1.27.0"
 
 [package.extras]
-test = ["argparse", "black (==23.7)", "mock", "mypy (==1.4)", "pytest (>=7.0)", "pytest-cov", "pytest-subtests", "requests-mock (>=1.0,<2.0)"]
+test = ["argparse", "black", "mock", "mypy", "pytest (>=7.0)", "pytest-subtests", "requests-mock (>=1.0,<2.0)"]
 
 [[package]]
 name = "tomli"
@@ -1848,21 +1848,20 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.0.6"
+version = "1.26.18"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "main"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 files = [
-    {file = "urllib3-2.0.6-py3-none-any.whl", hash = "sha256:7a7c7003b000adf9e7ca2a377c9688bbc54ed41b985789ed576570342a375cd2"},
-    {file = "urllib3-2.0.6.tar.gz", hash = "sha256:b19e1a85d206b56d7df1d5e683df4a7725252a964e3993648dd0fb5a1c157564"},
+    {file = "urllib3-1.26.18-py2.py3-none-any.whl", hash = "sha256:34b97092d7e0a3a8cf7cd10e386f401b3737364026c45e622aa02903dffe0f07"},
+    {file = "urllib3-1.26.18.tar.gz", hash = "sha256:f8ecc1bba5667413457c529ab955bf8c67b45db799d159066261719e328580a0"},
 ]
 
 [package.extras]
-brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)"]
-secure = ["certifi", "cryptography (>=1.9)", "idna (>=2.0.0)", "pyopenssl (>=17.1.0)", "urllib3-secure-extra"]
-socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
-zstd = ["zstandard (>=0.18.0)"]
+brotli = ["brotli (==1.0.9)", "brotli (>=1.0.9)", "brotlicffi (>=0.8.0)", "brotlipy (>=0.6.0)"]
+secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "ipaddress", "pyOpenSSL (>=0.14)", "urllib3-secure-extra"]
+socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "wcwidth"
@@ -1964,4 +1963,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "77b38ff691fc74bee0fb6bfa0a4ba6c460b6a5ffa587f7fe202902c88596b9c3"
+content-hash = "7da6f131a324148550418d4e95344fa1923708b6c4eed45d85a2a91acefd7f61"

--- a/python_src/pyproject.toml
+++ b/python_src/pyproject.toml
@@ -28,7 +28,7 @@ schedule = "^1.1.0"
 alembic = "^1.10.2"
 types-pytz = "^2023.3.0.1"
 tableauhyperapi = "^0.0.17971"
-tableauserverclient = "^0.28"
+tableauserverclient = "0.25"
 
 [tool.poetry.dev-dependencies]
 black = "^23.1.0"

--- a/python_src/src/lamp_py/tableau/server.py
+++ b/python_src/src/lamp_py/tableau/server.py
@@ -135,7 +135,7 @@ def overwrite_datasource(
     publish_mode = TSC.Server.PublishMode.Overwrite
 
     project = project_from_name(project_name)
-    if project is None:
+    if project is None or project.id is None:
         raise KeyError(f"{project_name} project not found on Tableau server.")
 
     datasource = TSC.DatasourceItem(project_id=project.id)


### PR DESCRIPTION
Updates to the Tableau `tableauserverclient` library borked our Hyper File uploading per this: https://github.com/tableau/server-client-python/issues/1299

Downgrading library to fix, will test with updated version if fix  is released. 