### PR TITLE
FIX: Update ALL_RT_fields to fix UTC timezone adjustement on seconds fields

### DIFF
--- a/python_src/src/lamp_py/tableau/jobs/rt_rail.py
+++ b/python_src/src/lamp_py/tableau/jobs/rt_rail.py
@@ -38,8 +38,9 @@ class HyperRtRail(HyperJob):
             "   , TIMEZONE('America/New_York', TO_TIMESTAMP(ve.vp_move_timestamp)) as previous_stop_departure_datetime"
             "   , TIMEZONE('America/New_York', TO_TIMESTAMP(COALESCE(ve.vp_stop_timestamp,  ve.tu_stop_timestamp))) as stop_arrival_datetime"
             "   , TIMEZONE('America/New_York', TO_TIMESTAMP(COALESCE(ve.vp_stop_timestamp,  ve.tu_stop_timestamp) + ve.dwell_time_seconds)) as stop_departure_datetime"
-            "   , (ve.vp_move_timestamp - extract(epoch FROM date(vt.service_date::text)))::int as previous_stop_departure_sec"
-            "   , (ve.vp_move_timestamp - extract(epoch FROM date(vt.service_date::text)) + ve.travel_time_seconds)::int as stop_arrival_sec"
+            "   , (ve.vp_move_timestamp - extract(epoch FROM date(vt.service_date::text) AT TIME ZONE 'UTC'))::int as previous_stop_departure_sec"
+            "   , (ve.vp_move_timestamp - extract(epoch FROM date(vt.service_date::text) AT TIME ZONE 'UTC') + ve.travel_time_seconds)::int as stop_arrival_sec"
+            "   , (ve.vp_move_timestamp - extract(epoch FROM date(vt.service_date::text) AT TIME ZONE 'UTC') + ve.travel_time_seconds + ve.dwell_time_seconds)::int as stop_departure_sec"
             "   , vt.direction_id::int"
             "   , vt.route_id"
             "   , vt.branch_route_id"
@@ -104,6 +105,7 @@ class HyperRtRail(HyperJob):
                 ("stop_departure_datetime", pyarrow.timestamp("us")),
                 ("previous_stop_departure_sec", pyarrow.int64()),
                 ("stop_arrival_sec", pyarrow.int64()),
+                ("stop_departure_sec", pyarrow.int64()),
                 ("direction_id", pyarrow.int8()),
                 ("route_id", pyarrow.string()),
                 ("branch_route_id", pyarrow.string()),


### PR DESCRIPTION
Fix for following feedback from Heather Davis on LAMP_ALL_RT_fields Hyper file extract: 

> In the all RT fields view, the stop arrival sec and previous stop departure sec fields are not calculated properly -- they seem to be in GMT rather than EST/EDT. Pre-11/5/23, they are 14,400 seconds or 4 hours too large, and post-11/5/23 they are 18,000 seconds or 5 hours too large. The datetime fields are in the correct time zone and do account for DST.

> The stop departure datetime field does not have an associated field in seconds after midnight (i.e. stop departure sec). Can you please add this field?
