### PR TITLE
FIX: Update service_id_by_date_and_route VIEW

### DIFF
--- a/python_src/src/lamp_py/migrations/versions/performance_manager_prod/003_ae6c6e4b2df5_extend_service_id_view.py
+++ b/python_src/src/lamp_py/migrations/versions/performance_manager_prod/003_ae6c6e4b2df5_extend_service_id_view.py
@@ -28,6 +28,13 @@ def upgrade() -> None:
     op.execute("DROP VIEW IF EXISTS service_id_by_date_and_route;")
     op.execute(view_service_id_by_date_and_route)
 
+    op.create_index(
+        "ix_static_trips_composite_4",
+        "static_trips",
+        ["static_version_key", "service_id"],
+        unique=False,
+    )
+
     update_stop_sequences = (
         "UPDATE vehicle_events "
         "SET canonical_stop_sequence = static_canon.stop_sequence "
@@ -67,4 +74,4 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    pass
+    op.drop_index("ix_static_trips_composite_4", table_name="static_trips")

--- a/python_src/src/lamp_py/migrations/versions/performance_manager_prod/003_ae6c6e4b2df5_extend_service_id_view.py
+++ b/python_src/src/lamp_py/migrations/versions/performance_manager_prod/003_ae6c6e4b2df5_extend_service_id_view.py
@@ -1,0 +1,32 @@
+"""extend service_id_by_date_and_route
+
+Revision ID: ae6c6e4b2df5
+Revises: 1b53fd278b10
+Create Date: 2023-12-17 06:56:17.330783
+
+Details
+* upgrade -> extend service_id_by_date_and_route VIEW to generate values past current date
+
+* downgrade -> Nothing
+"""
+from alembic import op
+
+from lamp_py.migrations.versions.performance_manager_prod.sql_strings.strings_003 import (
+    view_service_id_by_date_and_route,
+)
+
+
+# revision identifiers, used by Alembic.
+revision = "ae6c6e4b2df5"
+down_revision = "1b53fd278b10"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("DROP VIEW IF EXISTS service_id_by_date_and_route;")
+    op.execute(view_service_id_by_date_and_route)
+
+
+def downgrade() -> None:
+    pass

--- a/python_src/src/lamp_py/migrations/versions/performance_manager_prod/003_ae6c6e4b2df5_extend_service_id_view.py
+++ b/python_src/src/lamp_py/migrations/versions/performance_manager_prod/003_ae6c6e4b2df5_extend_service_id_view.py
@@ -6,6 +6,7 @@ Create Date: 2023-12-17 06:56:17.330783
 
 Details
 * upgrade -> extend service_id_by_date_and_route VIEW to generate values past current date
+* upgrade -> update canonical_stop_sequence to use row_number function instead of direct from static schedule
 
 * downgrade -> Nothing
 """
@@ -26,6 +27,43 @@ depends_on = None
 def upgrade() -> None:
     op.execute("DROP VIEW IF EXISTS service_id_by_date_and_route;")
     op.execute(view_service_id_by_date_and_route)
+
+    update_stop_sequences = (
+        "UPDATE vehicle_events "
+        "SET canonical_stop_sequence = static_canon.stop_sequence "
+        "FROM vehicle_events AS ve "
+        "JOIN vehicle_trips AS vt "
+        "ON ve.pm_trip_id = vt.pm_trip_id "
+        "JOIN "
+        "("
+        "    select "
+        "      srp.direction_id "
+        "    , coalesce(st.branch_route_id, st.trunk_route_id) AS route_id "
+        "    , ROW_NUMBER () OVER (PARTITION BY srp.static_version_key, srp.direction_id, coalesce(st.branch_route_id, st.trunk_route_id) ORDER BY sst.stop_sequence) AS stop_sequence"
+        "    , ss.parent_station "
+        "    , srp.static_version_key "
+        "    from static_route_patterns srp "
+        "    JOIN static_trips st "
+        "    ON srp.representative_trip_id = st.trip_id "
+        "    AND srp.static_version_key = st.static_version_key "
+        "    JOIN static_stop_times sst "
+        "    ON srp.representative_trip_id = sst.trip_id "
+        "    AND srp.static_version_key = sst.static_version_key "
+        "    JOIN static_stops ss "
+        "    ON sst.stop_id = ss.stop_id "
+        "    AND sst.static_version_key = ss.static_version_key "
+        "    WHERE "
+        "    srp.route_pattern_typicality = 1"
+        ") AS static_canon "
+        "ON ve.parent_station = static_canon.parent_station "
+        "AND vt.static_version_key = static_canon.static_version_key "
+        "AND vt.direction_id = static_canon.direction_id "
+        "AND coalesce(vt.branch_route_id, vt.trunk_route_id) = static_canon.route_id "
+        "WHERE vehicle_events.pm_trip_id = ve.pm_trip_id "
+        "AND vehicle_events.parent_station = static_canon.parent_station "
+        ";"
+    )
+    op.execute(update_stop_sequences)
 
 
 def downgrade() -> None:

--- a/python_src/src/lamp_py/migrations/versions/performance_manager_prod/sql_strings/strings_003.py
+++ b/python_src/src/lamp_py/migrations/versions/performance_manager_prod/sql_strings/strings_003.py
@@ -1,87 +1,109 @@
 view_service_id_by_date_and_route = """
         CREATE OR REPLACE VIEW service_id_by_date_and_route AS 
-        SELECT static_trips.route_id,
-            all_service_ids.service_id,
-            all_service_ids.service_date,
-            all_service_ids.static_version_key
+        SELECT 
+                static_trips.route_id,
+                all_service_ids.service_id,
+                all_service_ids.service_date,
+                all_service_ids.static_version_key
         FROM
-        (SELECT service_ids.service_id AS service_id,
-                service_ids.service_date AS service_date,
-                service_ids.static_version_key AS static_version_key
-        FROM
-            (SELECT static_cal.service_id AS service_id,
-                    replace(new_sd::date::text, '-', '')::integer AS service_date,
-                    static_cal.static_version_key AS static_version_key
-            FROM
-                (SELECT static_calendar.service_id AS service_id,
-                        start_date::text::date AS start_date,
-                        end_date::text::date AS end_date,
-                        static_calendar.static_version_key AS static_version_key,
-                        static_calendar.monday AS monday,
-                        static_calendar.tuesday AS tuesday,
-                        static_calendar.wednesday AS wednesday,
-                        static_calendar.thursday AS thursday,
-                        static_calendar.friday AS friday,
-                        static_calendar.saturday AS saturday,
-                        static_calendar.sunday AS sunday
-                FROM static_calendar
-                WHERE static_calendar.static_version_key >=
-                    (SELECT min(static_calendar_dates.static_version_key) AS min_1
-                    FROM static_calendar_dates)) AS static_cal,
-                generate_series(static_cal.start_date, static_cal.end_date, '1 day') AS new_sd
-            WHERE (extract(dow
-                            from new_sd) = 0
-                    AND static_cal.sunday)
-                OR (extract(dow
-                            from new_sd) = 1
-                    AND static_cal.monday)
-                OR (extract(dow
-                            from new_sd) = 2
-                    AND static_cal.tuesday)
-                OR (extract(dow
-                            from new_sd) = 3
-                    AND static_cal.wednesday)
-                OR (extract(dow
-                            from new_sd) = 4
-                    AND static_cal.thursday)
-                OR (extract(dow
-                            from new_sd) = 5
-                    AND static_cal.friday)
-                OR (extract(dow
-                            from new_sd) = 6
-                    AND static_cal.saturday)) AS service_ids
-        UNION SELECT service_ids_special.service_id AS service_id,
+        (
+                SELECT 
+                        service_ids.service_id AS service_id,
+                        service_ids.service_date AS service_date,
+                        service_ids.static_version_key AS static_version_key
+                FROM
+                (
+                        SELECT 
+                                static_cal.service_id AS service_id,
+                                TO_CHAR(new_sd, 'YYYYMMDD')::integer AS service_date,
+                                static_cal.static_version_key AS static_version_key
+                        FROM
+                        (
+                                SELECT 
+                                        static_calendar.service_id AS service_id,
+                                        start_date::text::date AS start_date,
+                                        end_date::text::date AS end_date,
+                                        static_calendar.static_version_key AS static_version_key,
+                                        static_calendar.monday AS monday,
+                                        static_calendar.tuesday AS tuesday,
+                                        static_calendar.wednesday AS wednesday,
+                                        static_calendar.thursday AS thursday,
+                                        static_calendar.friday AS friday,
+                                        static_calendar.saturday AS saturday,
+                                        static_calendar.sunday AS sunday
+                                FROM static_calendar
+                                WHERE 
+                                        static_calendar.static_version_key >= (SELECT min(static_calendar_dates.static_version_key) FROM static_calendar_dates)
+                        ) AS static_cal,
+                        generate_series(static_cal.start_date, static_cal.end_date, '1 day') AS new_sd
+                        WHERE 
+                                (extract(dow from new_sd) = 0 AND static_cal.sunday)
+                                OR (extract(dow from new_sd) = 1 AND static_cal.monday)
+                                OR (extract(dow from new_sd) = 2 AND static_cal.tuesday)
+                                OR (extract(dow from new_sd) = 3 AND static_cal.wednesday)
+                                OR (extract(dow from new_sd) = 4 AND static_cal.thursday)
+                                OR (extract(dow from new_sd) = 5 AND static_cal.friday)
+                                OR (extract(dow from new_sd) = 6 AND static_cal.saturday)
+                ) AS service_ids
+                UNION 
+                SELECT 
+                        service_ids_special.service_id AS service_id,
                         service_ids_special.service_date AS service_date,
                         service_ids_special.static_version_key AS static_version_key
-        FROM
-            (SELECT static_calendar_dates.service_id AS service_id,
-                    static_calendar_dates.date AS service_date,
-                    static_calendar_dates.static_version_key AS static_version_key
-            FROM static_calendar_dates
-            WHERE static_calendar_dates.exception_type = 1) AS service_ids_special) AS all_service_ids
+                FROM
+                (
+                        SELECT 
+                                static_calendar_dates.service_id AS service_id,
+                                static_calendar_dates.date AS service_date,
+                                static_calendar_dates.static_version_key AS static_version_key
+                        FROM static_calendar_dates
+                        WHERE 
+                                static_calendar_dates.exception_type = 1
+                ) AS service_ids_special
+        ) AS all_service_ids
         FULL OUTER JOIN
-        (SELECT static_calendar_dates.service_id AS service_id,
-                static_calendar_dates.date AS service_date,
-                static_calendar_dates.static_version_key AS static_version_key,
-                true AS to_exclude
-        FROM static_calendar_dates
-        WHERE static_calendar_dates.exception_type = 2) AS service_ids_exclude ON all_service_ids.service_id = service_ids_exclude.service_id
-        AND service_ids_exclude.service_date = all_service_ids.service_date
-        AND all_service_ids.static_version_key = service_ids_exclude.static_version_key
+        (
+                SELECT 
+                        static_calendar_dates.service_id AS service_id,
+                        static_calendar_dates.date AS service_date,
+                        static_calendar_dates.static_version_key AS static_version_key,
+                        true AS to_exclude
+                FROM static_calendar_dates
+                WHERE 
+                        static_calendar_dates.exception_type = 2
+        ) AS service_ids_exclude 
+        ON 
+                all_service_ids.service_id = service_ids_exclude.service_id
+                AND service_ids_exclude.service_date = all_service_ids.service_date
+                AND all_service_ids.static_version_key = service_ids_exclude.static_version_key
         JOIN
-        (SELECT replace(mod_sd::date::text, '-', '')::integer AS service_date,
-                static_version_key
-        FROM
-            (SELECT feed_start_date::text::date AS start_date,
-                    lead(feed_start_date, 1, feed_end_date) OVER (ORDER BY feed_start_date)::text::date - 1 AS end_date,
-                    static_version_key
-            FROM public.static_feed_info) AS mod_fed_dates,
-                generate_series(mod_fed_dates.start_date, mod_fed_dates.end_date, '1 day') AS mod_sd) AS sd_match ON all_service_ids.static_version_key = sd_match.static_version_key
-        AND all_service_ids.service_date = sd_match.service_date
-        JOIN static_trips ON all_service_ids.service_id = static_trips.service_id
-        WHERE service_ids_exclude.to_exclude IS NULL
-        AND static_trips.route_id IN ('Red', 'Mattapan', 'Orange', 'Green-B', 'Green-C', 'Green-D', 'Green-E', 'Blue')
-        GROUP BY static_trips.route_id,
+        (
+                SELECT 
+                        TO_CHAR(mod_sd, 'YYYYMMDD')::integer AS service_date,
+                        static_version_key
+                FROM
+                (
+                        SELECT 
+                                feed_start_date::text::date AS start_date,
+                                lead(feed_start_date, 1, feed_end_date) OVER (ORDER BY feed_start_date)::text::date - 1 AS end_date,
+                                static_version_key
+                        FROM public.static_feed_info
+                ) AS mod_fed_dates,
+                generate_series(mod_fed_dates.start_date, mod_fed_dates.end_date, '1 day') AS mod_sd
+        ) AS sd_match 
+        ON 
+                all_service_ids.static_version_key = sd_match.static_version_key
+                AND all_service_ids.service_date = sd_match.service_date
+        JOIN 
+                static_trips 
+        ON 
+                all_service_ids.service_id = static_trips.service_id
+                AND all_service_ids.static_version_key = static_trips.static_version_key
+        WHERE 
+                service_ids_exclude.to_exclude IS NULL
+                AND static_trips.route_id IN ('Red', 'Mattapan', 'Orange', 'Green-B', 'Green-C', 'Green-D', 'Green-E', 'Blue')
+        GROUP BY 
+                static_trips.route_id,
                 all_service_ids.service_id,
                 all_service_ids.service_date,
                 all_service_ids.static_version_key

--- a/python_src/src/lamp_py/migrations/versions/performance_manager_prod/sql_strings/strings_003.py
+++ b/python_src/src/lamp_py/migrations/versions/performance_manager_prod/sql_strings/strings_003.py
@@ -1,0 +1,89 @@
+view_service_id_by_date_and_route = """
+        CREATE OR REPLACE VIEW service_id_by_date_and_route AS 
+        SELECT static_trips.route_id,
+            all_service_ids.service_id,
+            all_service_ids.service_date,
+            all_service_ids.static_version_key
+        FROM
+        (SELECT service_ids.service_id AS service_id,
+                service_ids.service_date AS service_date,
+                service_ids.static_version_key AS static_version_key
+        FROM
+            (SELECT static_cal.service_id AS service_id,
+                    replace(new_sd::date::text, '-', '')::integer AS service_date,
+                    static_cal.static_version_key AS static_version_key
+            FROM
+                (SELECT static_calendar.service_id AS service_id,
+                        start_date::text::date AS start_date,
+                        end_date::text::date AS end_date,
+                        static_calendar.static_version_key AS static_version_key,
+                        static_calendar.monday AS monday,
+                        static_calendar.tuesday AS tuesday,
+                        static_calendar.wednesday AS wednesday,
+                        static_calendar.thursday AS thursday,
+                        static_calendar.friday AS friday,
+                        static_calendar.saturday AS saturday,
+                        static_calendar.sunday AS sunday
+                FROM static_calendar
+                WHERE static_calendar.static_version_key >=
+                    (SELECT min(static_calendar_dates.static_version_key) AS min_1
+                    FROM static_calendar_dates)) AS static_cal,
+                generate_series(static_cal.start_date, static_cal.end_date, '1 day') AS new_sd
+            WHERE (extract(dow
+                            from new_sd) = 0
+                    AND static_cal.sunday)
+                OR (extract(dow
+                            from new_sd) = 1
+                    AND static_cal.monday)
+                OR (extract(dow
+                            from new_sd) = 2
+                    AND static_cal.tuesday)
+                OR (extract(dow
+                            from new_sd) = 3
+                    AND static_cal.wednesday)
+                OR (extract(dow
+                            from new_sd) = 4
+                    AND static_cal.thursday)
+                OR (extract(dow
+                            from new_sd) = 5
+                    AND static_cal.friday)
+                OR (extract(dow
+                            from new_sd) = 6
+                    AND static_cal.saturday)) AS service_ids
+        UNION SELECT service_ids_special.service_id AS service_id,
+                        service_ids_special.service_date AS service_date,
+                        service_ids_special.static_version_key AS static_version_key
+        FROM
+            (SELECT static_calendar_dates.service_id AS service_id,
+                    static_calendar_dates.date AS service_date,
+                    static_calendar_dates.static_version_key AS static_version_key
+            FROM static_calendar_dates
+            WHERE static_calendar_dates.exception_type = 1) AS service_ids_special) AS all_service_ids
+        FULL OUTER JOIN
+        (SELECT static_calendar_dates.service_id AS service_id,
+                static_calendar_dates.date AS service_date,
+                static_calendar_dates.static_version_key AS static_version_key,
+                true AS to_exclude
+        FROM static_calendar_dates
+        WHERE static_calendar_dates.exception_type = 2) AS service_ids_exclude ON all_service_ids.service_id = service_ids_exclude.service_id
+        AND service_ids_exclude.service_date = all_service_ids.service_date
+        AND all_service_ids.static_version_key = service_ids_exclude.static_version_key
+        JOIN
+        (SELECT replace(mod_sd::date::text, '-', '')::integer AS service_date,
+                static_version_key
+        FROM
+            (SELECT feed_start_date::text::date AS start_date,
+                    lead(feed_start_date, 1, feed_end_date) OVER (ORDER BY feed_start_date)::text::date - 1 AS end_date,
+                    static_version_key
+            FROM public.static_feed_info) AS mod_fed_dates,
+                generate_series(mod_fed_dates.start_date, mod_fed_dates.end_date, '1 day') AS mod_sd) AS sd_match ON all_service_ids.static_version_key = sd_match.static_version_key
+        AND all_service_ids.service_date = sd_match.service_date
+        JOIN static_trips ON all_service_ids.service_id = static_trips.service_id
+        WHERE service_ids_exclude.to_exclude IS NULL
+        AND static_trips.route_id IN ('Red', 'Mattapan', 'Orange', 'Green-B', 'Green-C', 'Green-D', 'Green-E', 'Blue')
+        GROUP BY static_trips.route_id,
+                all_service_ids.service_id,
+                all_service_ids.service_date,
+                all_service_ids.static_version_key
+        ;
+    """

--- a/python_src/src/lamp_py/migrations/versions/performance_manager_staging/003_ae6c6e4b2df5_extend_service_id_view.py
+++ b/python_src/src/lamp_py/migrations/versions/performance_manager_staging/003_ae6c6e4b2df5_extend_service_id_view.py
@@ -1,0 +1,32 @@
+"""extend service_id_by_date_and_route
+
+Revision ID: ae6c6e4b2df5
+Revises: 1b53fd278b10
+Create Date: 2023-12-17 06:56:17.330783
+
+Details
+* upgrade -> extend service_id_by_date_and_route VIEW to generate values past current date
+
+* downgrade -> Nothing
+"""
+from alembic import op
+
+from lamp_py.migrations.versions.performance_manager_staging.sql_strings.strings_003 import (
+    view_service_id_by_date_and_route,
+)
+
+
+# revision identifiers, used by Alembic.
+revision = "ae6c6e4b2df5"
+down_revision = "1b53fd278b10"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("DROP VIEW IF EXISTS service_id_by_date_and_route;")
+    op.execute(view_service_id_by_date_and_route)
+
+
+def downgrade() -> None:
+    pass

--- a/python_src/src/lamp_py/migrations/versions/performance_manager_staging/003_ae6c6e4b2df5_extend_service_id_view.py
+++ b/python_src/src/lamp_py/migrations/versions/performance_manager_staging/003_ae6c6e4b2df5_extend_service_id_view.py
@@ -28,6 +28,13 @@ def upgrade() -> None:
     op.execute("DROP VIEW IF EXISTS service_id_by_date_and_route;")
     op.execute(view_service_id_by_date_and_route)
 
+    op.create_index(
+        "ix_static_trips_composite_4",
+        "static_trips",
+        ["static_version_key", "service_id"],
+        unique=False,
+    )
+
     update_stop_sequences = (
         "UPDATE vehicle_events "
         "SET canonical_stop_sequence = static_canon.stop_sequence "
@@ -67,4 +74,4 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    pass
+    op.drop_index("ix_static_trips_composite_4", table_name="static_trips")

--- a/python_src/src/lamp_py/migrations/versions/performance_manager_staging/003_ae6c6e4b2df5_extend_service_id_view.py
+++ b/python_src/src/lamp_py/migrations/versions/performance_manager_staging/003_ae6c6e4b2df5_extend_service_id_view.py
@@ -6,6 +6,7 @@ Create Date: 2023-12-17 06:56:17.330783
 
 Details
 * upgrade -> extend service_id_by_date_and_route VIEW to generate values past current date
+* upgrade -> update canonical_stop_sequence to use row_number function instead of direct from static schedule
 
 * downgrade -> Nothing
 """
@@ -26,6 +27,43 @@ depends_on = None
 def upgrade() -> None:
     op.execute("DROP VIEW IF EXISTS service_id_by_date_and_route;")
     op.execute(view_service_id_by_date_and_route)
+
+    update_stop_sequences = (
+        "UPDATE vehicle_events "
+        "SET canonical_stop_sequence = static_canon.stop_sequence "
+        "FROM vehicle_events AS ve "
+        "JOIN vehicle_trips AS vt "
+        "ON ve.pm_trip_id = vt.pm_trip_id "
+        "JOIN "
+        "("
+        "    select "
+        "      srp.direction_id "
+        "    , coalesce(st.branch_route_id, st.trunk_route_id) AS route_id "
+        "    , ROW_NUMBER () OVER (PARTITION BY srp.static_version_key, srp.direction_id, coalesce(st.branch_route_id, st.trunk_route_id) ORDER BY sst.stop_sequence) AS stop_sequence"
+        "    , ss.parent_station "
+        "    , srp.static_version_key "
+        "    from static_route_patterns srp "
+        "    JOIN static_trips st "
+        "    ON srp.representative_trip_id = st.trip_id "
+        "    AND srp.static_version_key = st.static_version_key "
+        "    JOIN static_stop_times sst "
+        "    ON srp.representative_trip_id = sst.trip_id "
+        "    AND srp.static_version_key = sst.static_version_key "
+        "    JOIN static_stops ss "
+        "    ON sst.stop_id = ss.stop_id "
+        "    AND sst.static_version_key = ss.static_version_key "
+        "    WHERE "
+        "    srp.route_pattern_typicality = 1"
+        ") AS static_canon "
+        "ON ve.parent_station = static_canon.parent_station "
+        "AND vt.static_version_key = static_canon.static_version_key "
+        "AND vt.direction_id = static_canon.direction_id "
+        "AND coalesce(vt.branch_route_id, vt.trunk_route_id) = static_canon.route_id "
+        "WHERE vehicle_events.pm_trip_id = ve.pm_trip_id "
+        "AND vehicle_events.parent_station = static_canon.parent_station "
+        ";"
+    )
+    op.execute(update_stop_sequences)
 
 
 def downgrade() -> None:

--- a/python_src/src/lamp_py/migrations/versions/performance_manager_staging/sql_strings/strings_003.py
+++ b/python_src/src/lamp_py/migrations/versions/performance_manager_staging/sql_strings/strings_003.py
@@ -1,87 +1,109 @@
 view_service_id_by_date_and_route = """
         CREATE OR REPLACE VIEW service_id_by_date_and_route AS 
-        SELECT static_trips.route_id,
-            all_service_ids.service_id,
-            all_service_ids.service_date,
-            all_service_ids.static_version_key
+        SELECT 
+                static_trips.route_id,
+                all_service_ids.service_id,
+                all_service_ids.service_date,
+                all_service_ids.static_version_key
         FROM
-        (SELECT service_ids.service_id AS service_id,
-                service_ids.service_date AS service_date,
-                service_ids.static_version_key AS static_version_key
-        FROM
-            (SELECT static_cal.service_id AS service_id,
-                    replace(new_sd::date::text, '-', '')::integer AS service_date,
-                    static_cal.static_version_key AS static_version_key
-            FROM
-                (SELECT static_calendar.service_id AS service_id,
-                        start_date::text::date AS start_date,
-                        end_date::text::date AS end_date,
-                        static_calendar.static_version_key AS static_version_key,
-                        static_calendar.monday AS monday,
-                        static_calendar.tuesday AS tuesday,
-                        static_calendar.wednesday AS wednesday,
-                        static_calendar.thursday AS thursday,
-                        static_calendar.friday AS friday,
-                        static_calendar.saturday AS saturday,
-                        static_calendar.sunday AS sunday
-                FROM static_calendar
-                WHERE static_calendar.static_version_key >=
-                    (SELECT min(static_calendar_dates.static_version_key) AS min_1
-                    FROM static_calendar_dates)) AS static_cal,
-                generate_series(static_cal.start_date, static_cal.end_date, '1 day') AS new_sd
-            WHERE (extract(dow
-                            from new_sd) = 0
-                    AND static_cal.sunday)
-                OR (extract(dow
-                            from new_sd) = 1
-                    AND static_cal.monday)
-                OR (extract(dow
-                            from new_sd) = 2
-                    AND static_cal.tuesday)
-                OR (extract(dow
-                            from new_sd) = 3
-                    AND static_cal.wednesday)
-                OR (extract(dow
-                            from new_sd) = 4
-                    AND static_cal.thursday)
-                OR (extract(dow
-                            from new_sd) = 5
-                    AND static_cal.friday)
-                OR (extract(dow
-                            from new_sd) = 6
-                    AND static_cal.saturday)) AS service_ids
-        UNION SELECT service_ids_special.service_id AS service_id,
+        (
+                SELECT 
+                        service_ids.service_id AS service_id,
+                        service_ids.service_date AS service_date,
+                        service_ids.static_version_key AS static_version_key
+                FROM
+                (
+                        SELECT 
+                                static_cal.service_id AS service_id,
+                                TO_CHAR(new_sd, 'YYYYMMDD')::integer AS service_date,
+                                static_cal.static_version_key AS static_version_key
+                        FROM
+                        (
+                                SELECT 
+                                        static_calendar.service_id AS service_id,
+                                        start_date::text::date AS start_date,
+                                        end_date::text::date AS end_date,
+                                        static_calendar.static_version_key AS static_version_key,
+                                        static_calendar.monday AS monday,
+                                        static_calendar.tuesday AS tuesday,
+                                        static_calendar.wednesday AS wednesday,
+                                        static_calendar.thursday AS thursday,
+                                        static_calendar.friday AS friday,
+                                        static_calendar.saturday AS saturday,
+                                        static_calendar.sunday AS sunday
+                                FROM static_calendar
+                                WHERE 
+                                        static_calendar.static_version_key >= (SELECT min(static_calendar_dates.static_version_key) FROM static_calendar_dates)
+                        ) AS static_cal,
+                        generate_series(static_cal.start_date, static_cal.end_date, '1 day') AS new_sd
+                        WHERE 
+                                (extract(dow from new_sd) = 0 AND static_cal.sunday)
+                                OR (extract(dow from new_sd) = 1 AND static_cal.monday)
+                                OR (extract(dow from new_sd) = 2 AND static_cal.tuesday)
+                                OR (extract(dow from new_sd) = 3 AND static_cal.wednesday)
+                                OR (extract(dow from new_sd) = 4 AND static_cal.thursday)
+                                OR (extract(dow from new_sd) = 5 AND static_cal.friday)
+                                OR (extract(dow from new_sd) = 6 AND static_cal.saturday)
+                ) AS service_ids
+                UNION 
+                SELECT 
+                        service_ids_special.service_id AS service_id,
                         service_ids_special.service_date AS service_date,
                         service_ids_special.static_version_key AS static_version_key
-        FROM
-            (SELECT static_calendar_dates.service_id AS service_id,
-                    static_calendar_dates.date AS service_date,
-                    static_calendar_dates.static_version_key AS static_version_key
-            FROM static_calendar_dates
-            WHERE static_calendar_dates.exception_type = 1) AS service_ids_special) AS all_service_ids
+                FROM
+                (
+                        SELECT 
+                                static_calendar_dates.service_id AS service_id,
+                                static_calendar_dates.date AS service_date,
+                                static_calendar_dates.static_version_key AS static_version_key
+                        FROM static_calendar_dates
+                        WHERE 
+                                static_calendar_dates.exception_type = 1
+                ) AS service_ids_special
+        ) AS all_service_ids
         FULL OUTER JOIN
-        (SELECT static_calendar_dates.service_id AS service_id,
-                static_calendar_dates.date AS service_date,
-                static_calendar_dates.static_version_key AS static_version_key,
-                true AS to_exclude
-        FROM static_calendar_dates
-        WHERE static_calendar_dates.exception_type = 2) AS service_ids_exclude ON all_service_ids.service_id = service_ids_exclude.service_id
-        AND service_ids_exclude.service_date = all_service_ids.service_date
-        AND all_service_ids.static_version_key = service_ids_exclude.static_version_key
+        (
+                SELECT 
+                        static_calendar_dates.service_id AS service_id,
+                        static_calendar_dates.date AS service_date,
+                        static_calendar_dates.static_version_key AS static_version_key,
+                        true AS to_exclude
+                FROM static_calendar_dates
+                WHERE 
+                        static_calendar_dates.exception_type = 2
+        ) AS service_ids_exclude 
+        ON 
+                all_service_ids.service_id = service_ids_exclude.service_id
+                AND service_ids_exclude.service_date = all_service_ids.service_date
+                AND all_service_ids.static_version_key = service_ids_exclude.static_version_key
         JOIN
-        (SELECT replace(mod_sd::date::text, '-', '')::integer AS service_date,
-                static_version_key
-        FROM
-            (SELECT feed_start_date::text::date AS start_date,
-                    lead(feed_start_date, 1, feed_end_date) OVER (ORDER BY feed_start_date)::text::date - 1 AS end_date,
-                    static_version_key
-            FROM public.static_feed_info) AS mod_fed_dates,
-                generate_series(mod_fed_dates.start_date, mod_fed_dates.end_date, '1 day') AS mod_sd) AS sd_match ON all_service_ids.static_version_key = sd_match.static_version_key
-        AND all_service_ids.service_date = sd_match.service_date
-        JOIN static_trips ON all_service_ids.service_id = static_trips.service_id
-        WHERE service_ids_exclude.to_exclude IS NULL
-        AND static_trips.route_id IN ('Red', 'Mattapan', 'Orange', 'Green-B', 'Green-C', 'Green-D', 'Green-E', 'Blue')
-        GROUP BY static_trips.route_id,
+        (
+                SELECT 
+                        TO_CHAR(mod_sd, 'YYYYMMDD')::integer AS service_date,
+                        static_version_key
+                FROM
+                (
+                        SELECT 
+                                feed_start_date::text::date AS start_date,
+                                lead(feed_start_date, 1, feed_end_date) OVER (ORDER BY feed_start_date)::text::date - 1 AS end_date,
+                                static_version_key
+                        FROM public.static_feed_info
+                ) AS mod_fed_dates,
+                generate_series(mod_fed_dates.start_date, mod_fed_dates.end_date, '1 day') AS mod_sd
+        ) AS sd_match 
+        ON 
+                all_service_ids.static_version_key = sd_match.static_version_key
+                AND all_service_ids.service_date = sd_match.service_date
+        JOIN 
+                static_trips 
+        ON 
+                all_service_ids.service_id = static_trips.service_id
+                AND all_service_ids.static_version_key = static_trips.static_version_key
+        WHERE 
+                service_ids_exclude.to_exclude IS NULL
+                AND static_trips.route_id IN ('Red', 'Mattapan', 'Orange', 'Green-B', 'Green-C', 'Green-D', 'Green-E', 'Blue')
+        GROUP BY 
+                static_trips.route_id,
                 all_service_ids.service_id,
                 all_service_ids.service_date,
                 all_service_ids.static_version_key

--- a/python_src/src/lamp_py/migrations/versions/performance_manager_staging/sql_strings/strings_003.py
+++ b/python_src/src/lamp_py/migrations/versions/performance_manager_staging/sql_strings/strings_003.py
@@ -1,0 +1,89 @@
+view_service_id_by_date_and_route = """
+        CREATE OR REPLACE VIEW service_id_by_date_and_route AS 
+        SELECT static_trips.route_id,
+            all_service_ids.service_id,
+            all_service_ids.service_date,
+            all_service_ids.static_version_key
+        FROM
+        (SELECT service_ids.service_id AS service_id,
+                service_ids.service_date AS service_date,
+                service_ids.static_version_key AS static_version_key
+        FROM
+            (SELECT static_cal.service_id AS service_id,
+                    replace(new_sd::date::text, '-', '')::integer AS service_date,
+                    static_cal.static_version_key AS static_version_key
+            FROM
+                (SELECT static_calendar.service_id AS service_id,
+                        start_date::text::date AS start_date,
+                        end_date::text::date AS end_date,
+                        static_calendar.static_version_key AS static_version_key,
+                        static_calendar.monday AS monday,
+                        static_calendar.tuesday AS tuesday,
+                        static_calendar.wednesday AS wednesday,
+                        static_calendar.thursday AS thursday,
+                        static_calendar.friday AS friday,
+                        static_calendar.saturday AS saturday,
+                        static_calendar.sunday AS sunday
+                FROM static_calendar
+                WHERE static_calendar.static_version_key >=
+                    (SELECT min(static_calendar_dates.static_version_key) AS min_1
+                    FROM static_calendar_dates)) AS static_cal,
+                generate_series(static_cal.start_date, static_cal.end_date, '1 day') AS new_sd
+            WHERE (extract(dow
+                            from new_sd) = 0
+                    AND static_cal.sunday)
+                OR (extract(dow
+                            from new_sd) = 1
+                    AND static_cal.monday)
+                OR (extract(dow
+                            from new_sd) = 2
+                    AND static_cal.tuesday)
+                OR (extract(dow
+                            from new_sd) = 3
+                    AND static_cal.wednesday)
+                OR (extract(dow
+                            from new_sd) = 4
+                    AND static_cal.thursday)
+                OR (extract(dow
+                            from new_sd) = 5
+                    AND static_cal.friday)
+                OR (extract(dow
+                            from new_sd) = 6
+                    AND static_cal.saturday)) AS service_ids
+        UNION SELECT service_ids_special.service_id AS service_id,
+                        service_ids_special.service_date AS service_date,
+                        service_ids_special.static_version_key AS static_version_key
+        FROM
+            (SELECT static_calendar_dates.service_id AS service_id,
+                    static_calendar_dates.date AS service_date,
+                    static_calendar_dates.static_version_key AS static_version_key
+            FROM static_calendar_dates
+            WHERE static_calendar_dates.exception_type = 1) AS service_ids_special) AS all_service_ids
+        FULL OUTER JOIN
+        (SELECT static_calendar_dates.service_id AS service_id,
+                static_calendar_dates.date AS service_date,
+                static_calendar_dates.static_version_key AS static_version_key,
+                true AS to_exclude
+        FROM static_calendar_dates
+        WHERE static_calendar_dates.exception_type = 2) AS service_ids_exclude ON all_service_ids.service_id = service_ids_exclude.service_id
+        AND service_ids_exclude.service_date = all_service_ids.service_date
+        AND all_service_ids.static_version_key = service_ids_exclude.static_version_key
+        JOIN
+        (SELECT replace(mod_sd::date::text, '-', '')::integer AS service_date,
+                static_version_key
+        FROM
+            (SELECT feed_start_date::text::date AS start_date,
+                    lead(feed_start_date, 1, feed_end_date) OVER (ORDER BY feed_start_date)::text::date - 1 AS end_date,
+                    static_version_key
+            FROM public.static_feed_info) AS mod_fed_dates,
+                generate_series(mod_fed_dates.start_date, mod_fed_dates.end_date, '1 day') AS mod_sd) AS sd_match ON all_service_ids.static_version_key = sd_match.static_version_key
+        AND all_service_ids.service_date = sd_match.service_date
+        JOIN static_trips ON all_service_ids.service_id = static_trips.service_id
+        WHERE service_ids_exclude.to_exclude IS NULL
+        AND static_trips.route_id IN ('Red', 'Mattapan', 'Orange', 'Green-B', 'Green-C', 'Green-D', 'Green-E', 'Blue')
+        GROUP BY static_trips.route_id,
+                all_service_ids.service_id,
+                all_service_ids.service_date,
+                all_service_ids.static_version_key
+        ;
+    """

--- a/python_src/src/lamp_py/postgres/postgres_schema.py
+++ b/python_src/src/lamp_py/postgres/postgres_schema.py
@@ -249,6 +249,12 @@ sa.Index(
     StaticTrips.trunk_route_id,
 )
 
+sa.Index(
+    "ix_static_trips_composite_4",
+    StaticTrips.static_version_key,
+    StaticTrips.service_id,
+)
+
 
 class StaticRoutes(SqlBase):  # pylint: disable=too-few-public-methods
     """Table for GTFS routes"""


### PR DESCRIPTION
Ops Analytics has requested a change to the `service_id_by_date_and_route` export VIEW. 

This change extends the generation of service id's (by date and route) to the `feed_end_date` of the latest available static schedule. 

Updated calculation of canonical_stop_sequence to use row_number function along with associated migration of existing data. 

Downgrade action has been excluded from this migration because the VIEW should never be reverted. 
