### PR TITLE
FIX: Tableau Parquet file missing records for end of service_date

### DIFF
--- a/python_src/src/lamp_py/tableau/jobs/rt_rail.py
+++ b/python_src/src/lamp_py/tableau/jobs/rt_rail.py
@@ -172,6 +172,8 @@ class HyperRtRail(HyperJob):
         max_stats = self.max_stats_of_parquet()
 
         max_start_date: datetime.date = max_stats["service_date"]
+        # subtract additional day incase of early spurious service_date record
+        max_start_date -= datetime.timedelta(days=1)
 
         update_query = self.table_query % (
             f" AND vt.service_date >= {max_start_date.strftime('%Y%m%d')} ",


### PR DESCRIPTION
Ops Analytics reported an issue with the Tableau staging dataset, where data would be cut off at 1AM, but records existed until 2AM:
![image (1)](https://github.com/mbta/lamp/assets/51686280/b87d3715-cba8-46c8-8270-9f02882b94df)

I believe this is caused by spurious early records from the next day's `service_date` cutting of parquet file updates for the previous `service_date`. 

This fix updates an additional day (looking back) of `service_date` records to avoid this issue. 
