### PR TITLE
FIX: Always Create new service_id_by_date_and_route parquet

### DIFF
--- a/python_src/src/lamp_py/tableau/jobs/gtfs_rail.py
+++ b/python_src/src/lamp_py/tableau/jobs/gtfs_rail.py
@@ -22,6 +22,7 @@ class HyperGTFS(HyperJob):
         self,
         gtfs_table_name: str,
         table_query: str,
+        always_create_parquet: bool = False,
     ) -> None:
         HyperJob.__init__(
             self,
@@ -31,6 +32,7 @@ class HyperGTFS(HyperJob):
         self.gtfs_table_name = gtfs_table_name
         self.create_query = table_query % ""
         self.update_query = table_query
+        self.always_create_parquet = always_create_parquet
 
     @property
     def parquet_schema(self) -> pyarrow.schema:
@@ -68,6 +70,10 @@ class HyperGTFS(HyperJob):
         # no update needed
         if max_db_key <= max_parquet_key:
             return False
+
+        if self.always_create_parquet:
+            self.create_parquet(db_manager)
+            return True
 
         # add WHERE clause to UPDATE query
         update_query = self.update_query % (
@@ -120,6 +126,7 @@ class HyperServiceIdByRoute(HyperGTFS):
                 "%s"
                 "ORDER BY static_version_key, service_id, service_date"
             ),
+            always_create_parquet=True,
         )
 
     @property


### PR DESCRIPTION
The service_id_by_date_and_route VIEW dataset cannot be updated in the same manner as the other GTFS Static datasets being sent to tableau.

This change allows the service_id_by_date_and_route VIEW dataset to be re-created instead of updated whenever new static schedule data is available. 

Asana Task: https://app.asana.com/0/1205827492903547/1206273298673484
