### PR TITLE
FIX: Ingestion RT table save for yield

### DIFF
--- a/python_src/src/lamp_py/ingestion/convert_gtfs_rt.py
+++ b/python_src/src/lamp_py/ingestion/convert_gtfs_rt.py
@@ -360,8 +360,13 @@ class GtfsRtConverter(Converter):
         try:
             s3_prefix = str(self.config_type)
 
+            sort_log = ProcessLogger(
+                "pyarrow_sort_by", table_rows=table.num_rows
+            )
+            sort_log.log_start()
             if self.detail.table_sort_order is not None:
                 table = table.sort_by(self.detail.table_sort_order)
+            sort_log.log_complete()
 
             write_parquet_file(
                 table=table,


### PR DESCRIPTION
Ingestion is running out of memory processing very large trip update tables. 

This fix changes the way RT table data is stored during ingestion loops.

Previously, `json.gz` table data was stored as a list of individual pyarrow tables, that was concatenated before writing to parquet. 

The new method concats each `json.gz` pyarrow table to a main pyarrow table when each table is extracted. 