### PR TITLE
Fix rds writer process and with more typing

### DIFF
--- a/python_src/src/lamp_py/aws/ecs.py
+++ b/python_src/src/lamp_py/aws/ecs.py
@@ -1,7 +1,8 @@
 import time
 import os
 import sys
-from multiprocessing import Process, Queue
+from multiprocessing import Process
+from queue import Queue
 from typing import Any, Optional
 
 from lamp_py.runtime_utils.process_logger import ProcessLogger
@@ -18,7 +19,7 @@ def handle_ecs_sigterm(_: int, __: Any) -> None:
 
 
 def check_for_sigterm(
-    metadata_queue: Optional[Queue] = None,
+    metadata_queue: Optional[Queue[Optional[str]]] = None,
     rds_process: Optional[Process] = None,
 ) -> None:
     """

--- a/python_src/src/lamp_py/aws/s3.py
+++ b/python_src/src/lamp_py/aws/s3.py
@@ -312,7 +312,7 @@ def write_parquet_file(
     file_type: str,
     s3_dir: str,
     partition_cols: List[str],
-    visitor_func: Optional[Callable[..., None]] = None,
+    visitor_func: Optional[Callable[[str], None]] = None,
     basename_template: Optional[str] = None,
 ) -> None:
     """

--- a/python_src/src/lamp_py/ingestion/convert_gtfs_rt.py
+++ b/python_src/src/lamp_py/ingestion/convert_gtfs_rt.py
@@ -4,7 +4,7 @@ import os
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from multiprocessing import Queue
+from queue import Queue
 from threading import current_thread
 from typing import Dict, Iterable, List, Optional, Tuple
 
@@ -54,7 +54,9 @@ class GtfsRtConverter(Converter):
     https_mbta_integration.mybluemix.net_vehicleCount.gz
     """
 
-    def __init__(self, config_type: ConfigType, metadata_queue: Queue) -> None:
+    def __init__(
+        self, config_type: ConfigType, metadata_queue: Queue[Optional[str]]
+    ) -> None:
         Converter.__init__(self, config_type, metadata_queue)
 
         # Depending on filename, assign self.details to correct implementation

--- a/python_src/src/lamp_py/ingestion/converter.py
+++ b/python_src/src/lamp_py/ingestion/converter.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from abc import ABC
 from abc import abstractmethod
-from typing import List, Any
-from multiprocessing import Queue
+from queue import Queue
+from typing import List, Optional
 
 from enum import auto
 from enum import Enum
@@ -99,16 +99,18 @@ class Converter(ABC):
     into pyarrow tables.
     """
 
-    def __init__(self, config_type: ConfigType, metadata_queue: Queue) -> None:
+    def __init__(
+        self, config_type: ConfigType, metadata_queue: Queue[Optional[str]]
+    ) -> None:
         self.config_type = config_type
         self.files: List[str] = []
-        self.metadata_queue = metadata_queue
+        self.metadata_queue: Queue[Optional[str]] = metadata_queue
 
     def add_files(self, files: List[str]) -> None:
         """add files to this converter"""
         self.files += files
 
-    def send_metadata(self, written_file: Any) -> None:
+    def send_metadata(self, written_file: str) -> None:
         """send metadata path to rds writer process"""
         self.metadata_queue.put(written_file)
 

--- a/python_src/src/lamp_py/ingestion/ingest.py
+++ b/python_src/src/lamp_py/ingestion/ingest.py
@@ -1,6 +1,7 @@
 import os
-from multiprocessing import Pool, Queue
-from typing import Dict, List
+from multiprocessing import Pool
+from queue import Queue
+from typing import Dict, List, Optional
 
 from lamp_py.aws.s3 import move_s3_objects
 
@@ -25,7 +26,9 @@ class NoImplConverter(Converter):
         )
 
 
-def get_converter(config_type: ConfigType, metadata_queue: Queue) -> Converter:
+def get_converter(
+    config_type: ConfigType, metadata_queue: Queue[Optional[str]]
+) -> Converter:
     """
     get the correct converter for this config type. it may raise an exception if
     the gtfs_rt file type does not have an implemented detail
@@ -42,7 +45,9 @@ def run_converter(converter: Converter) -> None:
     converter.convert()
 
 
-def ingest_files(files: List[str], metadata_queue: Queue) -> None:
+def ingest_files(
+    files: List[str], metadata_queue: Queue[Optional[str]]
+) -> None:
     """
     sort the incoming file list by type and create a converter for each type.
     each converter will ingest and convert its files in its own thread.

--- a/python_src/src/lamp_py/ingestion/pipeline.py
+++ b/python_src/src/lamp_py/ingestion/pipeline.py
@@ -3,7 +3,8 @@
 import logging
 import os
 import signal
-from multiprocessing import Queue
+from queue import Queue
+from typing import Optional
 
 import time
 
@@ -21,7 +22,7 @@ DESCRIPTION = """Entry Point For GTFS Ingestion Scripts"""
 HERE = os.path.dirname(os.path.abspath(__file__))
 
 
-def ingest(metadata_queue: Queue) -> None:
+def ingest(metadata_queue: Queue[Optional[str]]) -> None:
     """
     get all of the filepaths currently in the incoming bucket, sort them into
     batches of similar gtfs files, convert each batch into tables, write the

--- a/python_src/tests/ingestion/test_gtfs_converter.py
+++ b/python_src/tests/ingestion/test_gtfs_converter.py
@@ -1,5 +1,5 @@
 import os
-from multiprocessing import Queue
+from queue import Queue
 from typing import Callable, Iterator, Optional, List, Dict
 
 import pytest

--- a/python_src/tests/ingestion/test_gtfs_rt_converter.py
+++ b/python_src/tests/ingestion/test_gtfs_rt_converter.py
@@ -1,6 +1,6 @@
 import os
 from datetime import datetime, timezone
-from multiprocessing import Queue
+from queue import Queue
 from unittest.mock import patch
 
 from pyarrow import fs

--- a/python_src/tests/ingestion/test_ingest.py
+++ b/python_src/tests/ingestion/test_ingest.py
@@ -3,7 +3,7 @@
 # fixtures work. https://stackoverflow.com/q/59664605
 
 import os
-from multiprocessing import Queue
+from queue import Queue
 import pytest
 
 from lamp_py.ingestion.converter import ConfigType


### PR DESCRIPTION
The RDS writer process waits for items to be put on a metadata queue, pops them off, and then writes that file to the metadata. In the past, the queue was typed with any, as it was being populated with an obscure pyarrow object we couldn't deduce properly.

With the recent changes to how we write parquet files, these changed to strings. This caused the process to fail since it was attempting to pull a `path` attribute out a string, causing an uncaught exception.

I've updated the process to expect a string from the queue and put in typing hints that should prevent an error like this in the future.

Asana Task: https://app.asana.com/0/1205827492903547/1206288301107382/f
