### PR TITLE
FEAT: Update LAMP Dockerfile to use AWS Gobal Cert Bundle

### DIFF
--- a/python_src/Dockerfile
+++ b/python_src/Dockerfile
@@ -10,8 +10,7 @@ RUN apt-get update
 RUN apt-get install -y libpq-dev gcc curl
 
 # Fetch Amazon RDS certificate chain
-RUN curl https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem -o /usr/local/share/amazon-certs.pem
-RUN echo "d464378fbb8b981d2b28a1deafffd0113554e6adfb34535134f411bf3c689e73 /usr/local/share/amazon-certs.pem" | sha256sum -c -
+RUN curl https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem -o /usr/local/share/amazon-certs.pem
 RUN chmod a=r /usr/local/share/amazon-certs.pem
 
 # Install poetry


### PR DESCRIPTION
Update LAMP Dockerfile to use AWS Global Cert Bundle in preparation for expiration of `rds-ca-2019-root` cert. 

Asana Task: https://app.asana.com/0/1205827492903547/1206336785283369
