### PR TITLE
FIX: Incorrect WHERE clause on static_version_key sync

### DIFF
--- a/python_src/src/lamp_py/performance_manager/l1_rt_trips.py
+++ b/python_src/src/lamp_py/performance_manager/l1_rt_trips.py
@@ -210,7 +210,7 @@ def update_static_version_key(db_manager: DatabaseManager) -> None:
             static_version_key=version_key_sub.c.max_version_key,
         )
         .where(
-            VehicleTrips.pm_trip_id == version_key_sub.c.service_date,
+            VehicleTrips.service_date == version_key_sub.c.service_date,
         )
     )
 


### PR DESCRIPTION
Found this incorrect WHERE clause while debugging a separate issue raised by ops analytics. 