### PR TITLE
FEAT: Add parallel task checking to Tableau Publisher

### DIFF
--- a/python_src/src/lamp_py/aws/ecs.py
+++ b/python_src/src/lamp_py/aws/ecs.py
@@ -5,6 +5,8 @@ from multiprocessing import Process
 from queue import Queue
 from typing import Any, Optional
 
+import boto3
+
 from lamp_py.runtime_utils.process_logger import ProcessLogger
 
 
@@ -41,3 +43,48 @@ def check_for_sigterm(
         time.sleep(5)
 
         sys.exit()
+
+
+def running_in_aws() -> bool:
+    """
+    return True if running on aws, else False
+    """
+    return bool(os.getenv("AWS_DEFAULT_REGION"))
+
+
+def check_for_parallel_tasks() -> None:
+    """
+    Check that that this task is not already running on ECS
+    """
+    if not running_in_aws():
+        return
+
+    process_logger = ProcessLogger("check_for_tasks")
+    process_logger.log_start()
+
+    client = boto3.client("ecs")
+    ecs_cluster = os.environ["ECS_CLUSTER"]
+    ecs_task_group = os.environ["ECS_TASK_GROUP"]
+
+    # get all of the tasks running on the cluster
+    task_arns = client.list_tasks(cluster=ecs_cluster)["taskArns"]
+
+    # if tasks are running on the cluster, get their descriptions and check to
+    # count matches the ecs task group.
+    match_count = 0
+    if task_arns:
+        running_tasks = client.describe_tasks(
+            cluster=ecs_cluster, tasks=task_arns
+        )["tasks"]
+
+        for task in running_tasks:
+            if ecs_task_group == task["group"]:
+                match_count += 1
+
+    # if the group matches, raise an exception that will terminate the process
+    if match_count > 1:
+        exception = SystemError(f"Multiple {ecs_cluster} ECS Tasks Running")
+        process_logger.log_failure(exception)
+        raise exception
+
+    process_logger.log_complete()

--- a/python_src/src/lamp_py/tableau/pipeline.py
+++ b/python_src/src/lamp_py/tableau/pipeline.py
@@ -17,6 +17,7 @@ from lamp_py.tableau.jobs.gtfs_rail import (
     HyperStaticStopTimes,
     HyperStaticTrips,
 )
+from lamp_py.aws.ecs import check_for_parallel_tasks
 
 
 def create_hyper_jobs() -> List[HyperJob]:
@@ -38,17 +39,24 @@ def start_hyper_updates() -> None:
     """Run all HyperFile Update Jobs"""
     # configure the environment
     os.environ["SERVICE_NAME"] = "tableau_hyper_update"
+
     validate_environment(
         required_variables=[
             "TABLEAU_USER",
             "TABLEAU_PASSWORD",
             "TABLEAU_SERVER",
             "PUBLIC_ARCHIVE_BUCKET",
+            "ECS_CLUSTER",
+            "ECS_TASK_GROUP",
         ],
         private_variables=[
             "TABLEAU_PASSWORD",
         ],
     )
+
+    # make sure only one publisher runs at a time
+    check_for_parallel_tasks()
+
     for job in create_hyper_jobs():
         job.run_hyper()
 


### PR DESCRIPTION
This change adds a check to the Tableau Publisher pipeline to make sure that only one is running at a time. 

Implementation was lifted from dmap-import. 

Requires ENV VARS to be added to ECS first with devops PR: https://github.com/mbta/devops/pull/1540

Asana Task: https://app.asana.com/0/1205827492903547/1206184120740467