### PR TITLE
chore: Bump Black version to 24.1.1 with file updates

### DIFF
--- a/python_src/poetry.lock
+++ b/python_src/poetry.lock
@@ -64,33 +64,33 @@ test = ["astroid (>=1,<2)", "astroid (>=2,<4)", "pytest"]
 
 [[package]]
 name = "black"
-version = "23.12.1"
+version = "24.1.1"
 description = "The uncompromising code formatter."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "black-23.12.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e0aaf6041986767a5e0ce663c7a2f0e9eaf21e6ff87a5f95cbf3675bfd4c41d2"},
-    {file = "black-23.12.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c88b3711d12905b74206227109272673edce0cb29f27e1385f33b0163c414bba"},
-    {file = "black-23.12.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a920b569dc6b3472513ba6ddea21f440d4b4c699494d2e972a1753cdc25df7b0"},
-    {file = "black-23.12.1-cp310-cp310-win_amd64.whl", hash = "sha256:3fa4be75ef2a6b96ea8d92b1587dd8cb3a35c7e3d51f0738ced0781c3aa3a5a3"},
-    {file = "black-23.12.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:8d4df77958a622f9b5a4c96edb4b8c0034f8434032ab11077ec6c56ae9f384ba"},
-    {file = "black-23.12.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:602cfb1196dc692424c70b6507593a2b29aac0547c1be9a1d1365f0d964c353b"},
-    {file = "black-23.12.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9c4352800f14be5b4864016882cdba10755bd50805c95f728011bcb47a4afd59"},
-    {file = "black-23.12.1-cp311-cp311-win_amd64.whl", hash = "sha256:0808494f2b2df923ffc5723ed3c7b096bd76341f6213989759287611e9837d50"},
-    {file = "black-23.12.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:25e57fd232a6d6ff3f4478a6fd0580838e47c93c83eaf1ccc92d4faf27112c4e"},
-    {file = "black-23.12.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2d9e13db441c509a3763a7a3d9a49ccc1b4e974a47be4e08ade2a228876500ec"},
-    {file = "black-23.12.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6d1bd9c210f8b109b1762ec9fd36592fdd528485aadb3f5849b2740ef17e674e"},
-    {file = "black-23.12.1-cp312-cp312-win_amd64.whl", hash = "sha256:ae76c22bde5cbb6bfd211ec343ded2163bba7883c7bc77f6b756a1049436fbb9"},
-    {file = "black-23.12.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:1fa88a0f74e50e4487477bc0bb900c6781dbddfdfa32691e780bf854c3b4a47f"},
-    {file = "black-23.12.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:a4d6a9668e45ad99d2f8ec70d5c8c04ef4f32f648ef39048d010b0689832ec6d"},
-    {file = "black-23.12.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b18fb2ae6c4bb63eebe5be6bd869ba2f14fd0259bda7d18a46b764d8fb86298a"},
-    {file = "black-23.12.1-cp38-cp38-win_amd64.whl", hash = "sha256:c04b6d9d20e9c13f43eee8ea87d44156b8505ca8a3c878773f68b4e4812a421e"},
-    {file = "black-23.12.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:3e1b38b3135fd4c025c28c55ddfc236b05af657828a8a6abe5deec419a0b7055"},
-    {file = "black-23.12.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:4f0031eaa7b921db76decd73636ef3a12c942ed367d8c3841a0739412b260a54"},
-    {file = "black-23.12.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:97e56155c6b737854e60a9ab1c598ff2533d57e7506d97af5481141671abf3ea"},
-    {file = "black-23.12.1-cp39-cp39-win_amd64.whl", hash = "sha256:dd15245c8b68fe2b6bd0f32c1556509d11bb33aec9b5d0866dd8e2ed3dba09c2"},
-    {file = "black-23.12.1-py3-none-any.whl", hash = "sha256:78baad24af0f033958cad29731e27363183e140962595def56423e626f4bee3e"},
-    {file = "black-23.12.1.tar.gz", hash = "sha256:4ce3ef14ebe8d9509188014d96af1c456a910d5b5cbf434a09fef7e024b3d0d5"},
+    {file = "black-24.1.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2588021038bd5ada078de606f2a804cadd0a3cc6a79cb3e9bb3a8bf581325a4c"},
+    {file = "black-24.1.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1a95915c98d6e32ca43809d46d932e2abc5f1f7d582ffbe65a5b4d1588af7445"},
+    {file = "black-24.1.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2fa6a0e965779c8f2afb286f9ef798df770ba2b6cee063c650b96adec22c056a"},
+    {file = "black-24.1.1-cp310-cp310-win_amd64.whl", hash = "sha256:5242ecd9e990aeb995b6d03dc3b2d112d4a78f2083e5a8e86d566340ae80fec4"},
+    {file = "black-24.1.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:fc1ec9aa6f4d98d022101e015261c056ddebe3da6a8ccfc2c792cbe0349d48b7"},
+    {file = "black-24.1.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0269dfdea12442022e88043d2910429bed717b2d04523867a85dacce535916b8"},
+    {file = "black-24.1.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b3d64db762eae4a5ce04b6e3dd745dcca0fb9560eb931a5be97472e38652a161"},
+    {file = "black-24.1.1-cp311-cp311-win_amd64.whl", hash = "sha256:5d7b06ea8816cbd4becfe5f70accae953c53c0e53aa98730ceccb0395520ee5d"},
+    {file = "black-24.1.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:e2c8dfa14677f90d976f68e0c923947ae68fa3961d61ee30976c388adc0b02c8"},
+    {file = "black-24.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a21725862d0e855ae05da1dd25e3825ed712eaaccef6b03017fe0853a01aa45e"},
+    {file = "black-24.1.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:07204d078e25327aad9ed2c64790d681238686bce254c910de640c7cc4fc3aa6"},
+    {file = "black-24.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:a83fe522d9698d8f9a101b860b1ee154c1d25f8a82ceb807d319f085b2627c5b"},
+    {file = "black-24.1.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:08b34e85170d368c37ca7bf81cf67ac863c9d1963b2c1780c39102187ec8dd62"},
+    {file = "black-24.1.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:7258c27115c1e3b5de9ac6c4f9957e3ee2c02c0b39222a24dc7aa03ba0e986f5"},
+    {file = "black-24.1.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:40657e1b78212d582a0edecafef133cf1dd02e6677f539b669db4746150d38f6"},
+    {file = "black-24.1.1-cp38-cp38-win_amd64.whl", hash = "sha256:e298d588744efda02379521a19639ebcd314fba7a49be22136204d7ed1782717"},
+    {file = "black-24.1.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:34afe9da5056aa123b8bfda1664bfe6fb4e9c6f311d8e4a6eb089da9a9173bf9"},
+    {file = "black-24.1.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:854c06fb86fd854140f37fb24dbf10621f5dab9e3b0c29a690ba595e3d543024"},
+    {file = "black-24.1.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3897ae5a21ca132efa219c029cce5e6bfc9c3d34ed7e892113d199c0b1b444a2"},
+    {file = "black-24.1.1-cp39-cp39-win_amd64.whl", hash = "sha256:ecba2a15dfb2d97105be74bbfe5128bc5e9fa8477d8c46766505c1dda5883aac"},
+    {file = "black-24.1.1-py3-none-any.whl", hash = "sha256:5cdc2e2195212208fbcae579b931407c1fa9997584f0a415421748aeafff1168"},
+    {file = "black-24.1.1.tar.gz", hash = "sha256:48b5760dcbfe5cf97fd4fba23946681f3a81514c6ab8a45b50da67ac8fbc6c7b"},
 ]
 
 [package.dependencies]
@@ -1109,8 +1109,6 @@ files = [
     {file = "psycopg2-2.9.9-cp310-cp310-win_amd64.whl", hash = "sha256:426f9f29bde126913a20a96ff8ce7d73fd8a216cfb323b1f04da402d452853c3"},
     {file = "psycopg2-2.9.9-cp311-cp311-win32.whl", hash = "sha256:ade01303ccf7ae12c356a5e10911c9e1c51136003a9a1d92f7aa9d010fb98372"},
     {file = "psycopg2-2.9.9-cp311-cp311-win_amd64.whl", hash = "sha256:121081ea2e76729acfb0673ff33755e8703d45e926e416cb59bae3a86c6a4981"},
-    {file = "psycopg2-2.9.9-cp312-cp312-win32.whl", hash = "sha256:d735786acc7dd25815e89cc4ad529a43af779db2e25aa7c626de864127e5a024"},
-    {file = "psycopg2-2.9.9-cp312-cp312-win_amd64.whl", hash = "sha256:a7653d00b732afb6fc597e29c50ad28087dcb4fbfb28e86092277a559ae4e693"},
     {file = "psycopg2-2.9.9-cp37-cp37m-win32.whl", hash = "sha256:5e0d98cade4f0e0304d7d6f25bbfbc5bd186e07b38eac65379309c4ca3193efa"},
     {file = "psycopg2-2.9.9-cp37-cp37m-win_amd64.whl", hash = "sha256:7e2dacf8b009a1c1e843b5213a87f7c544b2b042476ed7755be813eaf4e8347a"},
     {file = "psycopg2-2.9.9-cp38-cp38-win32.whl", hash = "sha256:ff432630e510709564c01dafdbe996cb552e0b9f3f065eb89bdce5bd31fabf4c"},
@@ -1734,4 +1732,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "890d1e94151e0fe4aed3a23106f5c8ddd0061a02d757af29ed0e14573f95c7bd"
+content-hash = "45051d22f84fc8551fb4a08b8eeb075155e20e6b7360d4991aa79bda4b9db63d"

--- a/python_src/pyproject.toml
+++ b/python_src/pyproject.toml
@@ -37,7 +37,7 @@ tableauhyperapi = "^0.0.18618"
 tableauserverclient = "0.30"
 
 [tool.poetry.group.dev.dependencies]
-black = "^23.1.0"
+black = "^24.1.1"
 mypy = "^1.1.1"
 pylint = "^3.0.3"
 pytest = "^8.0.0"

--- a/python_src/src/lamp_py/migrations/versions/performance_manager_dev/001_5d9a7ee21ae5_initial_prod_schema.py
+++ b/python_src/src/lamp_py/migrations/versions/performance_manager_dev/001_5d9a7ee21ae5_initial_prod_schema.py
@@ -5,6 +5,7 @@ Revises:
 Create Date: 2023-07-25 13:52:06.082838
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/python_src/src/lamp_py/migrations/versions/performance_manager_dev/002_1b53fd278b10_fix_trip_id_length.py
+++ b/python_src/src/lamp_py/migrations/versions/performance_manager_dev/002_1b53fd278b10_fix_trip_id_length.py
@@ -8,6 +8,7 @@ Details
 * upgrade -> change "trip_id" field from length 128 to 512
 * downgrade -> change "trip_id" field from length 512 to 128
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/python_src/src/lamp_py/migrations/versions/performance_manager_dev/003_ae6c6e4b2df5_extend_service_id_view.py
+++ b/python_src/src/lamp_py/migrations/versions/performance_manager_dev/003_ae6c6e4b2df5_extend_service_id_view.py
@@ -10,6 +10,7 @@ Details
 
 * downgrade -> Nothing
 """
+
 from alembic import op
 
 from lamp_py.migrations.versions.performance_manager_staging.sql_strings.strings_003 import (

--- a/python_src/src/lamp_py/migrations/versions/performance_manager_dev/004_45dedc21086e_canon_stop_seq.py
+++ b/python_src/src/lamp_py/migrations/versions/performance_manager_dev/004_45dedc21086e_canon_stop_seq.py
@@ -13,6 +13,7 @@ this condition was introduced by 3 schedules in Dec 2023:
 
 * downgrade -> Nothing
 """
+
 from alembic import op
 
 

--- a/python_src/src/lamp_py/migrations/versions/performance_manager_prod/001_5d9a7ee21ae5_initial_prod_schema.py
+++ b/python_src/src/lamp_py/migrations/versions/performance_manager_prod/001_5d9a7ee21ae5_initial_prod_schema.py
@@ -5,6 +5,7 @@ Revises:
 Create Date: 2023-07-25 13:52:06.082838
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/python_src/src/lamp_py/migrations/versions/performance_manager_staging/001_5d9a7ee21ae5_initial_prod_schema.py
+++ b/python_src/src/lamp_py/migrations/versions/performance_manager_staging/001_5d9a7ee21ae5_initial_prod_schema.py
@@ -5,6 +5,7 @@ Revises:
 Create Date: 2023-07-25 13:52:06.082838
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/python_src/src/lamp_py/migrations/versions/performance_manager_staging/002_1b53fd278b10_fix_trip_id_length.py
+++ b/python_src/src/lamp_py/migrations/versions/performance_manager_staging/002_1b53fd278b10_fix_trip_id_length.py
@@ -8,6 +8,7 @@ Details
 * upgrade -> change "trip_id" field from length 128 to 512
 * downgrade -> change "trip_id" field from length 512 to 128
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/python_src/src/lamp_py/migrations/versions/performance_manager_staging/003_ae6c6e4b2df5_extend_service_id_view.py
+++ b/python_src/src/lamp_py/migrations/versions/performance_manager_staging/003_ae6c6e4b2df5_extend_service_id_view.py
@@ -10,6 +10,7 @@ Details
 
 * downgrade -> Nothing
 """
+
 from alembic import op
 
 from lamp_py.migrations.versions.performance_manager_staging.sql_strings.strings_003 import (

--- a/python_src/src/lamp_py/migrations/versions/performance_manager_staging/004_45dedc21086e_canon_stop_seq.py
+++ b/python_src/src/lamp_py/migrations/versions/performance_manager_staging/004_45dedc21086e_canon_stop_seq.py
@@ -13,6 +13,7 @@ this condition was introduced by 3 schedules in Dec 2023:
 
 * downgrade -> Nothing
 """
+
 from alembic import op
 
 

--- a/python_src/src/lamp_py/performance_manager/gtfs_utils.py
+++ b/python_src/src/lamp_py/performance_manager/gtfs_utils.py
@@ -198,9 +198,9 @@ def add_static_version_key_column(
         )
 
         service_date_mask = events_dataframe["service_date"] == service_date
-        events_dataframe.loc[
-            service_date_mask, "static_version_key"
-        ] = static_version_key
+        events_dataframe.loc[service_date_mask, "static_version_key"] = (
+            static_version_key
+        )
 
     process_logger.log_complete()
 

--- a/python_src/src/lamp_py/tableau/__init__.py
+++ b/python_src/src/lamp_py/tableau/__init__.py
@@ -1,4 +1,5 @@
 """Utilities for Interacting with Tableau and Hyper files"""
+
 import logging
 from types import ModuleType
 from typing import Optional


### PR DESCRIPTION
Bumping Black version to 24.1.1 required a few formatting updates. Mostly white-space changes. 

Asana Task: https://app.asana.com/0/1205827492903547/1204354793482788
