### PR TITLE
FIX - Clean Remote Parquet Paths at Application Start

### DIFF
--- a/python_src/src/lamp_py/aws/s3.py
+++ b/python_src/src/lamp_py/aws/s3.py
@@ -105,6 +105,40 @@ def download_file(object_path: str, file_name: str) -> bool:
         return False
 
 
+def delete_object(del_obj: str) -> bool:
+    """
+    delete s3 object
+
+    :param del_obj - expected as 's3://my_bucket/object' or 'my_bucket/object'
+
+    :return: True if file success, else False
+    """
+    try:
+        process_logger = ProcessLogger("delete_s3_object", del_obj=del_obj)
+        process_logger.log_start()
+
+        s3_client = get_s3_client()
+
+        # trim off leading s3://
+        del_obj = del_obj.replace("s3://", "")
+
+        # split into bucket and object name
+        bucket, obj = del_obj.split("/", 1)
+
+        # delete the source object
+        _ = s3_client.delete_object(
+            Bucket=bucket,
+            Key=obj,
+        )
+
+        process_logger.log_complete()
+        return True
+
+    except Exception as error:
+        process_logger.log_failure(error)
+        return False
+
+
 def get_zip_buffer(filename: str) -> IO[bytes]:
     """
     Get a buffer for a zip file from s3 so that it can be read by zipfile

--- a/python_src/src/lamp_py/performance_manager/l0_gtfs_rt_events.py
+++ b/python_src/src/lamp_py/performance_manager/l0_gtfs_rt_events.py
@@ -452,7 +452,7 @@ def process_gtfs_rt_files(
     will be logged and the file will be marked with a process_fail in the
     MetadataLog table.
     """
-    hours_to_process = 6
+    hours_to_process = 12
     process_logger = ProcessLogger("l0_gtfs_rt_tables_loader")
     process_logger.log_start()
 

--- a/python_src/src/lamp_py/performance_manager/pipeline.py
+++ b/python_src/src/lamp_py/performance_manager/pipeline.py
@@ -70,8 +70,6 @@ def main(args: argparse.Namespace) -> None:
         db_index=DatabaseIndex.METADATA, verbose=args.verbose
     )
 
-    run_on_app_start()
-
     # schedule object that will control the "event loop"
     scheduler = sched.scheduler(time.time, time.sleep)
 
@@ -122,6 +120,9 @@ def start() -> None:
 
     # run rail performance manager rds migrations
     alembic_upgrade_to_head(db_name=os.getenv("ALEMBIC_RPM_DB_NAME"))
+
+    # run one time actions at every application deployment
+    run_on_app_start()
 
     # run main method with parsed args
     main(parsed_args)

--- a/python_src/src/lamp_py/performance_manager/pipeline.py
+++ b/python_src/src/lamp_py/performance_manager/pipeline.py
@@ -16,6 +16,7 @@ from lamp_py.runtime_utils.env_validation import validate_environment
 from lamp_py.runtime_utils.process_logger import ProcessLogger
 
 from lamp_py.tableau import start_parquet_updates
+from lamp_py.tableau import clean_parquet_paths
 
 from .flat_file import write_flat_files
 from .l0_gtfs_rt_events import process_gtfs_rt_files
@@ -46,6 +47,16 @@ def parse_args(args: List[str]) -> argparse.Namespace:
     return parser.parse_args(args)
 
 
+def run_on_app_start() -> None:
+    """Anything that should be run once at application start"""
+    on_app_start_log = ProcessLogger("run_on_app_start")
+    on_app_start_log.log_start()
+
+    clean_parquet_paths()
+
+    on_app_start_log.log_complete()
+
+
 def main(args: argparse.Namespace) -> None:
     """entrypoint into performance manager event loop"""
     main_process_logger = ProcessLogger("main", **vars(args))
@@ -58,6 +69,8 @@ def main(args: argparse.Namespace) -> None:
     md_db_manager = DatabaseManager(
         db_index=DatabaseIndex.METADATA, verbose=args.verbose
     )
+
+    run_on_app_start()
 
     # schedule object that will control the "event loop"
     scheduler = sched.scheduler(time.time, time.sleep)

--- a/python_src/src/lamp_py/tableau/__init__.py
+++ b/python_src/src/lamp_py/tableau/__init__.py
@@ -31,3 +31,17 @@ def start_parquet_updates(db_manager: DatabaseManager) -> None:
         )
     else:
         pipeline.start_parquet_updates(db_manager=db_manager)
+
+
+def clean_parquet_paths() -> None:
+    """
+    wrapper around pipeline.clean_parquet_paths function. if a module not
+    found error occurs (which happens when using osx arm64 dependencies), log
+    an error and do nothing. else, run the function.
+    """
+    if pipeline is None:
+        logging.error(
+            "Unable to run parquet files on this machine due to Module Not Found error"
+        )
+    else:
+        pipeline.clean_parquet_paths()

--- a/python_src/src/lamp_py/tableau/pipeline.py
+++ b/python_src/src/lamp_py/tableau/pipeline.py
@@ -18,6 +18,7 @@ from lamp_py.tableau.jobs.gtfs_rail import (
     HyperStaticTrips,
 )
 from lamp_py.aws.ecs import check_for_parallel_tasks
+from lamp_py.aws.s3 import delete_object
 
 
 def create_hyper_jobs() -> List[HyperJob]:
@@ -69,3 +70,9 @@ def start_parquet_updates(db_manager: DatabaseManager) -> None:
     # ECS Memory Utilization appeared to stay elevated after initial calling
     # of `run_parquet` to create all parquet files, this may resolve that...
     gc.collect()
+
+
+def clean_parquet_paths() -> None:
+    """Delete all remote parquet files for all hyper jobs"""
+    for job in create_hyper_jobs():
+        delete_object(job.remote_parquet_path)


### PR DESCRIPTION
Deleting all remote parquet paths at application start will allow the parquet files to pick up any changes to made writing the files by the application. All files will be re-generated by the end of the first app `event_loop`. 

Asana Task: https://app.asana.com/0/1205827492903547/1206643238763144
