### PR TITLE
HOTFIX: Staging performance_manager ecs instance dying

### DIFF
--- a/python_src/src/lamp_py/tableau/jobs/rt_rail.py
+++ b/python_src/src/lamp_py/tableau/jobs/rt_rail.py
@@ -166,7 +166,7 @@ class HyperRtRail(HyperJob):
         )
 
     def update_parquet(self, db_manager: DatabaseManager) -> bool:
-        dataset_batch_size = 1024 * 1024
+        dataset_batch_size = 1024 * 512
 
         download_file(
             object_path=self.remote_parquet_path,

--- a/python_src/src/lamp_py/tableau/pipeline.py
+++ b/python_src/src/lamp_py/tableau/pipeline.py
@@ -64,6 +64,11 @@ def start_hyper_updates() -> None:
 
 def start_parquet_updates(db_manager: DatabaseManager) -> None:
     """Run all Parquet Update jobs"""
+
+    # ECS dying possibly because of high memory utilization
+    # attempt to free resources before parquet writing
+    gc.collect()
+
     for job in create_hyper_jobs():
         job.run_parquet(db_manager)
 


### PR DESCRIPTION
Our performance_manager application on staging is dying, possibly because of high memory usage.

This should reduce memory usage in an attempt to avoid ECS death. 
