### PR TITLE
FIX: Reduce resource usage during parquet file creation

### DIFF
--- a/python_src/src/lamp_py/performance_manager/l1_rt_trips.py
+++ b/python_src/src/lamp_py/performance_manager/l1_rt_trips.py
@@ -183,7 +183,7 @@ def load_new_trip_data(db_manager: DatabaseManager) -> None:
             VehicleTrips.trip_id == distinct_update_query.c.trip_id,
         )
     )
-    db_manager.execute(trip_update_query)
+    db_manager.execute(trip_update_query, disable_trip_tigger=True)
 
     process_logger.log_complete()
 
@@ -217,7 +217,7 @@ def update_static_version_key(db_manager: DatabaseManager) -> None:
 
     process_logger = ProcessLogger("l1_trips.update_static_version_key")
     process_logger.log_start()
-    db_manager.execute(update_query)
+    db_manager.execute(update_query, disable_trip_tigger=True)
     process_logger.log_complete()
 
 
@@ -270,13 +270,13 @@ def update_start_times(db_manager: DatabaseManager) -> None:
         .subquery("scheduled_start_times")
     )
 
-    schedule_start_times_update_query = (
+    schedule_start_times_update = (
         sa.update(VehicleTrips.__table__)
         .where(VehicleTrips.pm_trip_id == schedule_start_times_sub.c.pm_trip_id)
         .values(start_time=schedule_start_times_sub.c.start_time)
     )
 
-    db_manager.execute(schedule_start_times_update_query)
+    db_manager.execute(schedule_start_times_update, disable_trip_tigger=True)
 
     # get the start times for added trips. by definition, these will not be in
     # the static schedule, so find the earliest departure from the real time
@@ -320,7 +320,9 @@ def update_start_times(db_manager: DatabaseManager) -> None:
         )
 
         db_manager.execute_with_data(
-            start_times_update_query, unscheduled_start_times
+            start_times_update_query,
+            unscheduled_start_times,
+            disable_trip_tigger=True,
         )
 
 
@@ -453,7 +455,7 @@ def update_static_trip_id_guess_exact(db_manager: DatabaseManager) -> None:
 
     process_logger = ProcessLogger("l1_trips.update_exact_trip_matches")
     process_logger.log_start()
-    db_manager.execute(update_query)
+    db_manager.execute(update_query, disable_trip_tigger=True)
     process_logger.log_complete()
 
 
@@ -504,7 +506,7 @@ def update_directions(db_manager: DatabaseManager) -> None:
 
     process_logger = ProcessLogger("l1_trips.update_directions")
     process_logger.log_start()
-    db_manager.execute(update_query)
+    db_manager.execute(update_query, disable_trip_tigger=True)
     process_logger.log_complete()
 
 
@@ -952,7 +954,7 @@ def backup_rt_static_trip_match(
         )
     )
 
-    db_manager.execute(update_query)
+    db_manager.execute(update_query, disable_trip_tigger=True)
 
 
 def update_backup_static_trip_id(db_manager: DatabaseManager) -> None:

--- a/python_src/src/lamp_py/performance_manager/pipeline.py
+++ b/python_src/src/lamp_py/performance_manager/pipeline.py
@@ -3,6 +3,7 @@
 import argparse
 import logging
 import os
+import gc
 import sched
 import sys
 import time
@@ -91,6 +92,7 @@ def main(args: argparse.Namespace) -> None:
         except Exception as exception:
             process_logger.log_failure(exception)
         finally:
+            gc.collect()
             scheduler.enter(int(args.interval), 1, iteration)
 
     # schedule the initial loop and start the scheduler

--- a/python_src/src/lamp_py/tableau/jobs/gtfs_rail.py
+++ b/python_src/src/lamp_py/tableau/jobs/gtfs_rail.py
@@ -42,13 +42,10 @@ class HyperGTFS(HyperJob):
         if os.path.exists(self.local_parquet_path):
             os.remove(self.local_parquet_path)
 
-        db_batch_size = int(1024 * 1024 / 2)
-
         db_manager.write_to_parquet(
             select_query=sa.text(self.create_query),
             write_path=self.local_parquet_path,
             schema=self.parquet_schema,
-            batch_size=db_batch_size,
         )
 
     def update_parquet(self, db_manager: DatabaseManager) -> bool:

--- a/python_src/src/lamp_py/tableau/jobs/rt_rail.py
+++ b/python_src/src/lamp_py/tableau/jobs/rt_rail.py
@@ -151,10 +151,6 @@ class HyperRtRail(HyperJob):
     def create_parquet(self, db_manager: DatabaseManager) -> None:
         create_query = self.table_query % ""
 
-        # this is a fairly wide dataset, so dial back the batch size
-        # to limit memory usage
-        db_batch_size = int(1024 * 1024 / 2)
-
         if os.path.exists(self.local_parquet_path):
             os.remove(self.local_parquet_path)
 
@@ -162,11 +158,10 @@ class HyperRtRail(HyperJob):
             select_query=sa.text(create_query),
             write_path=self.local_parquet_path,
             schema=self.parquet_schema,
-            batch_size=db_batch_size,
         )
 
     def update_parquet(self, db_manager: DatabaseManager) -> bool:
-        dataset_batch_size = 1024 * 512
+        dataset_batch_size = 1024 * 1024
 
         download_file(
             object_path=self.remote_parquet_path,

--- a/python_src/src/lamp_py/tableau/pipeline.py
+++ b/python_src/src/lamp_py/tableau/pipeline.py
@@ -1,5 +1,4 @@
 import os
-import gc
 from typing import List
 
 from lamp_py.runtime_utils.env_validation import validate_environment
@@ -65,16 +64,8 @@ def start_hyper_updates() -> None:
 def start_parquet_updates(db_manager: DatabaseManager) -> None:
     """Run all Parquet Update jobs"""
 
-    # ECS dying possibly because of high memory utilization
-    # attempt to free resources before parquet writing
-    gc.collect()
-
     for job in create_hyper_jobs():
         job.run_parquet(db_manager)
-
-    # ECS Memory Utilization appeared to stay elevated after initial calling
-    # of `run_parquet` to create all parquet files, this may resolve that...
-    gc.collect()
 
 
 def clean_parquet_paths() -> None:


### PR DESCRIPTION
The LAMP staging environment has been displaying excessively high memory usage and crashes during the creation of parquet files for Tableau publishing. The issue was traced back to the `write_to_parquet` function of our DatabaseManager object. 

SQLAlchemy result streaming through use of the `yield_per` method, was not behaving as intended. Instead of incrementally streaming results from a query, it was materializing the entire result stream in memory before iterating through the results. Updating the `write_to_parquet` function to use the `execute_options` parameter has resolved this issue and results are now correctly streamed incrementally and memory usage during streaming is contained to a single `batch_size` amount. 

Additionally, this change adds helper functions to our DatabaseManager objects to ENABLE and DISABLE the `rt_trips_update_branch_trunk` TRIGGER of our `vehicle_trips` table. This trigger was causing excessively long query team for an UPDATE operation against the `vehicle_trips` table and is generally not required. This is a bit of a band-aid fix for now, that can be fixed with architectural RDS and/or application changes in the future. 

Asana Task: https://app.asana.com/0/1205827492903547/1206703823960612