### PR TITLE
FEAT: upload index.html for performancedata.mbta.com

### DIFF
--- a/python_src/src/lamp_py/performance_manager/pipeline.py
+++ b/python_src/src/lamp_py/performance_manager/pipeline.py
@@ -19,6 +19,8 @@ from lamp_py.runtime_utils.process_logger import ProcessLogger
 from lamp_py.tableau import start_parquet_updates
 from lamp_py.tableau import clean_parquet_paths
 
+from lamp_py.publishing.performancedata import publish_performance_index
+
 from .flat_file import write_flat_files
 from .l0_gtfs_rt_events import process_gtfs_rt_files
 from .l0_gtfs_static_load import process_static_tables
@@ -54,6 +56,7 @@ def run_on_app_start() -> None:
     on_app_start_log.log_start()
 
     clean_parquet_paths()
+    publish_performance_index()
 
     on_app_start_log.log_complete()
 

--- a/python_src/src/lamp_py/publishing/__init__.py
+++ b/python_src/src/lamp_py/publishing/__init__.py
@@ -1,0 +1,1 @@
+""" Anything and Everything related to publicly publishing LAMP data """

--- a/python_src/src/lamp_py/publishing/index.html
+++ b/python_src/src/lamp_py/publishing/index.html
@@ -1,0 +1,119 @@
+<html>
+
+<head>
+    <title>MBTA LAMP Public Data</title>
+</head>
+
+<body>
+    <h1>Hello from the MBTA LAMP Team!</h1>
+
+    <h2>What is LAMP?</h2>
+    <p>
+        LAMP (Lightweight Application for Measuring Performance):
+        Our goal is to consume real-time data from the MBTA network, process it
+        to create helpful performance metrics, and make that data publicly
+        available for any and all to use.
+    </p>
+    <p>
+        Our application code is available on github:
+        <a href="https://github.com/mbta/lamp">https://github.com/mbta/lamp</a>
+    </p>
+
+    <p>
+        <b>
+            <i>
+                Please note that we are in the early days of making datasets
+                publicly available. This page may change frequently, check back
+                for updates.
+            </i>
+        </b>
+    </p>
+    <hr>
+
+    <h2>
+        On Time Performance Data (Subway)
+    </h2>
+    <p>
+        Performance Data for the MBTA Subway system partitioned by service date.
+    </p>
+    <p>
+        URL Construction: Replace [YYYY-MM-DD] with the YEAR, MONTH and DAY of the requested service date:
+    </p>
+    <ul>
+        <li>
+            <i>https://performancedata.mbta.com/lamp/subway-on-time-performance-v1/<u>YYYY-MM-DD</u>-subway-on-time-performance-v1.parquet</i>
+        </li>
+    </ul>
+    <p>
+        CSV File of all published service dates, and file paths, available here:
+        <a
+            href="https://performancedata.mbta.com/lamp/subway-on-time-performance-v1/index.csv">https://performancedata.mbta.com/lamp/subway-on-time-performance-v1/index.csv</a>
+    </p>
+    <p>
+        Data dictionary of on time performance files:
+        <a
+            href="https://github.com/mbta/lamp/blob/main/python_src/src/lamp_py/performance_manager/README.md#file-structure">https://github.com/mbta/lamp/blob/main/python_src/src/lamp_py/performance_manager/README.md#file-structure</a>
+    </p>
+
+    <hr>
+    <h2>
+        OMPI Tableau Data Tables
+    </h2>
+    <p>
+        LAMP creates several datasets for
+        <a href="https://www.massdottracker.com/wp/about/what-is-opmi-2/">OPMI</a>'s Tableau server.
+        OPMI uses these datasets to develop dashboards, metrics and reports for the public and MBTA Operations.
+        These datasets are available at the following links.
+    <ul>
+        <li>
+            <a href="https://performancedata.mbta.com/lamp/tableau/rail/LAMP_ALL_RT_fields.parquet">
+                https://performancedata.mbta.com/lamp/tableau/rail/LAMP_ALL_RT_fields.parquet
+            </a>
+        </li>
+        <li>
+            <a href="https://performancedata.mbta.com/lamp/tableau/rail/LAMP_service_id_by_date_and_route.parquet">
+                https://performancedata.mbta.com/lamp/tableau/rail/LAMP_service_id_by_date_and_route.parquet
+            </a>
+        </li>
+        <li>
+            <a href="https://performancedata.mbta.com/lamp/tableau/rail/LAMP_static_calendar_dates.parquet">
+                https://performancedata.mbta.com/lamp/tableau/rail/LAMP_static_calendar_dates.parquet
+            </a>
+        </li>
+        <li>
+            <a href="https://performancedata.mbta.com/lamp/tableau/rail/LAMP_static_calendar.parquet">
+                https://performancedata.mbta.com/lamp/tableau/rail/LAMP_static_calendar.parquet
+            </a>
+        </li>
+        <li>
+            <a href="https://performancedata.mbta.com/lamp/tableau/rail/LAMP_static_feed_info.parquet">
+                https://performancedata.mbta.com/lamp/tableau/rail/LAMP_static_feed_info.parquet
+            </a>
+        </li>
+        <li>
+            <a href="https://performancedata.mbta.com/lamp/tableau/rail/LAMP_static_routes.parquet">
+                https://performancedata.mbta.com/lamp/tableau/rail/LAMP_static_routes.parquet
+            </a>
+        </li>
+        <li>
+            <a href="https://performancedata.mbta.com/lamp/tableau/rail/LAMP_static_stop_times.parquet">
+                https://performancedata.mbta.com/lamp/tableau/rail/LAMP_static_stop_times.parquet
+            </a>
+        </li>
+        <li>
+            <a href="https://performancedata.mbta.com/lamp/tableau/rail/LAMP_static_stops.parquet">
+                https://performancedata.mbta.com/lamp/tableau/rail/LAMP_static_stops.parquet
+            </a>
+        </li>
+        <li>
+            <a href="https://performancedata.mbta.com/lamp/tableau/rail/LAMP_static_trips.parquet">
+                https://performancedata.mbta.com/lamp/tableau/rail/LAMP_static_trips.parquet
+            </a>
+        </li>
+    </ul>
+    </p>
+
+
+</body>
+
+</html>

--- a/python_src/src/lamp_py/publishing/performancedata.py
+++ b/python_src/src/lamp_py/publishing/performancedata.py
@@ -1,0 +1,33 @@
+import os
+
+from lamp_py.aws.s3 import upload_file
+from lamp_py.runtime_utils.process_logger import ProcessLogger
+
+
+def publish_performance_index() -> None:
+    """
+    Upload index.html to https://performancedata.mbta.com bucket
+    """
+    bucket = os.environ.get("PUBLIC_ARCHIVE_BUCKET", "")
+    here = os.path.dirname(os.path.abspath(__file__))
+    index_file = "index.html"
+
+    if bucket == "":
+        return
+
+    local_index_path = os.path.join(here, index_file)
+    upload_index_path = os.path.join(bucket, index_file)
+
+    logger = ProcessLogger(
+        "upload_performancedata_index",
+        local_index_path=local_index_path,
+        upload_index_path=upload_index_path,
+    )
+    logger.log_start()
+
+    upload_file(
+        file_name=local_index_path,
+        object_path=upload_index_path,
+    )
+
+    logger.log_complete()


### PR DESCRIPTION
This change creates an initial draft of `index.html` for https://performancedata.mbta.com. A helper function is also included to upload the index file to our public S3 bucket at every application start. 

We are now web developers. 

Asana Task: https://app.asana.com/0/1205827492903547/1204907226653450
