### PR TITLE
FEAT: Update Tableau Parquet files based on S3 Metdata Version field

### DIFF
--- a/python_src/src/lamp_py/aws/s3.py
+++ b/python_src/src/lamp_py/aws/s3.py
@@ -52,9 +52,6 @@ def upload_file(
     )
     upload_log.log_start()
 
-    if extra_args is None:
-        extra_args = {}
-
     try:
         if not os.path.exists(file_name):
             raise FileNotFoundError(f"{file_name} not found locally")

--- a/python_src/src/lamp_py/aws/s3.py
+++ b/python_src/src/lamp_py/aws/s3.py
@@ -41,6 +41,7 @@ def upload_file(
 
     :param file_name: local file path to upload
     :param object_path: S3 object path to upload to (including bucket)
+    :param extra_agrs: additional upload ags available per: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/customizations/s3.html#boto3.s3.transfer.S3Transfer.ALLOWED_UPLOAD_ARGS
 
     :return: True if file was uploaded, else False
     """

--- a/python_src/src/lamp_py/performance_manager/pipeline.py
+++ b/python_src/src/lamp_py/performance_manager/pipeline.py
@@ -17,7 +17,6 @@ from lamp_py.runtime_utils.env_validation import validate_environment
 from lamp_py.runtime_utils.process_logger import ProcessLogger
 
 from lamp_py.tableau import start_parquet_updates
-from lamp_py.tableau import clean_parquet_paths
 
 from lamp_py.publishing.performancedata import publish_performance_index
 
@@ -55,7 +54,6 @@ def run_on_app_start() -> None:
     on_app_start_log = ProcessLogger("run_on_app_start")
     on_app_start_log.log_start()
 
-    clean_parquet_paths()
     publish_performance_index()
 
     on_app_start_log.log_complete()

--- a/python_src/src/lamp_py/tableau/hyper.py
+++ b/python_src/src/lamp_py/tableau/hyper.py
@@ -293,6 +293,7 @@ class HyperJob(ABC):  # pylint: disable=R0902
 
         try:
             remote_schema_match = False
+            remote_version_match = False
             file_info = self.remote_fs.get_file_info(self.remote_parquet_path)
 
             if file_info.type == fs.FileType.File:
@@ -302,11 +303,9 @@ class HyperJob(ABC):  # pylint: disable=R0902
                     filesystem=self.remote_fs,
                 )
                 remote_schema_match = self.parquet_schema.equals(remote_schema)
+                remote_version_match = self.remote_version_match()
 
-            if (
-                remote_schema_match is False
-                or self.remote_version_match() is False
-            ):
+            if remote_schema_match is False or remote_version_match is False:
                 # create new parquet if no remote parquet found or
                 # remote schema does not match expected local schema
                 run_action = "create"

--- a/python_src/src/lamp_py/tableau/hyper.py
+++ b/python_src/src/lamp_py/tableau/hyper.py
@@ -150,10 +150,7 @@ class HyperJob(ABC):  # pylint: disable=R0902
             "lamp_version", ""
         )
 
-        if lamp_version == self.lamp_version:
-            return True
-
-        return False
+        return lamp_version == self.lamp_version
 
     def create_local_hyper(self) -> int:
         """

--- a/python_src/src/lamp_py/tableau/jobs/gtfs_rail.py
+++ b/python_src/src/lamp_py/tableau/jobs/gtfs_rail.py
@@ -28,6 +28,7 @@ class HyperGTFS(HyperJob):
             self,
             hyper_file_name=f"LAMP_{gtfs_table_name}.hyper",
             remote_parquet_path=f"s3://{os.getenv('PUBLIC_ARCHIVE_BUCKET')}/lamp/tableau/rail/LAMP_{gtfs_table_name}.parquet",
+            lamp_version="1.0",
         )
         self.gtfs_table_name = gtfs_table_name
         self.create_query = table_query % ""

--- a/python_src/src/lamp_py/tableau/jobs/gtfs_rail.py
+++ b/python_src/src/lamp_py/tableau/jobs/gtfs_rail.py
@@ -28,7 +28,7 @@ class HyperGTFS(HyperJob):
             self,
             hyper_file_name=f"LAMP_{gtfs_table_name}.hyper",
             remote_parquet_path=f"s3://{os.getenv('PUBLIC_ARCHIVE_BUCKET')}/lamp/tableau/rail/LAMP_{gtfs_table_name}.parquet",
-            lamp_version="1.0",
+            lamp_version="1.0.beta",
         )
         self.gtfs_table_name = gtfs_table_name
         self.create_query = table_query % ""

--- a/python_src/src/lamp_py/tableau/jobs/rt_rail.py
+++ b/python_src/src/lamp_py/tableau/jobs/rt_rail.py
@@ -20,7 +20,7 @@ class HyperRtRail(HyperJob):
             self,
             hyper_file_name="LAMP_ALL_RT_fields.hyper",
             remote_parquet_path=f"s3://{os.getenv('PUBLIC_ARCHIVE_BUCKET')}/lamp/tableau/rail/LAMP_ALL_RT_fields.parquet",
-            lamp_version="1.0",
+            lamp_version="1.0.beta",
         )
         self.table_query = (
             "SELECT"

--- a/python_src/src/lamp_py/tableau/jobs/rt_rail.py
+++ b/python_src/src/lamp_py/tableau/jobs/rt_rail.py
@@ -20,6 +20,7 @@ class HyperRtRail(HyperJob):
             self,
             hyper_file_name="LAMP_ALL_RT_fields.hyper",
             remote_parquet_path=f"s3://{os.getenv('PUBLIC_ARCHIVE_BUCKET')}/lamp/tableau/rail/LAMP_ALL_RT_fields.parquet",
+            lamp_version="1.0",
         )
         self.table_query = (
             "SELECT"

--- a/python_src/src/lamp_py/tableau/pipeline.py
+++ b/python_src/src/lamp_py/tableau/pipeline.py
@@ -17,7 +17,6 @@ from lamp_py.tableau.jobs.gtfs_rail import (
     HyperStaticTrips,
 )
 from lamp_py.aws.ecs import check_for_parallel_tasks
-from lamp_py.aws.s3 import delete_object
 
 
 def create_hyper_jobs() -> List[HyperJob]:
@@ -66,9 +65,3 @@ def start_parquet_updates(db_manager: DatabaseManager) -> None:
 
     for job in create_hyper_jobs():
         job.run_parquet(db_manager)
-
-
-def clean_parquet_paths() -> None:
-    """Delete all remote parquet files for all hyper jobs"""
-    for job in create_hyper_jobs():
-        delete_object(job.remote_parquet_path)


### PR DESCRIPTION
Previously, all Tableau parquet files were being deleted and re-created on every application deployment.

This change utilizes the S3 `Metadata` head field to store a `lamp_version` value to determine when datasets should be re-freshed / re-created. 

Asana Task: https://app.asana.com/0/1189492770004753/1206729585163530
