### PR TITLE
FIX: Add ContentType to index.html upload

### DIFF
--- a/python_src/src/lamp_py/aws/s3.py
+++ b/python_src/src/lamp_py/aws/s3.py
@@ -49,6 +49,7 @@ def upload_file(
         "s3_upload_file",
         file_name=file_name,
         object_path=object_path,
+        **extra_args,
     )
     upload_log.log_start()
 

--- a/python_src/src/lamp_py/aws/s3.py
+++ b/python_src/src/lamp_py/aws/s3.py
@@ -61,7 +61,9 @@ def upload_file(
 
         s3_client = get_s3_client()
 
-        s3_client.upload_file(file_name, bucket, object_name, extra_args)
+        s3_client.upload_file(
+            file_name, bucket, object_name, ExtraArgs=extra_args
+        )
 
         upload_log.log_complete()
 

--- a/python_src/src/lamp_py/publishing/performancedata.py
+++ b/python_src/src/lamp_py/publishing/performancedata.py
@@ -17,7 +17,12 @@ def publish_performance_index() -> None:
     local_index_path = os.path.join(here, index_file)
     upload_index_path = os.path.join(bucket, index_file)
 
+    extra_args = {
+        "ContentType": "text/html",
+    }
+
     upload_file(
         file_name=local_index_path,
         object_path=upload_index_path,
+        extra_args=extra_args,
     )


### PR DESCRIPTION
Our index.html page for performancedata.mbta.com is not being served by CloudFront because the S3 `ContentType` parameter is set to `binary/octet-stream` causing the file to be offered as a download. 

This change will upload index.html with `text/html` set for `ContentType` which should hopefully serve the file as a normal webpage. 

Asana Task: https://app.asana.com/0/1205827492903547/1204907226653450