### PR TITLE
FIX: check extra_args is dictionary

### DIFF
--- a/python_src/src/lamp_py/aws/s3.py
+++ b/python_src/src/lamp_py/aws/s3.py
@@ -49,8 +49,9 @@ def upload_file(
         "s3_upload_file",
         file_name=file_name,
         object_path=object_path,
-        **extra_args,
     )
+    if isinstance(extra_args, dict):
+        upload_log.add_metadata(**extra_args)
     upload_log.log_start()
 
     try:


### PR DESCRIPTION
Logger is attempting to unpack None Type. Check that extra_args is dictionary before adding to logger. 
