### PR TITLE
FIX: remove s3:// from flat file paths

### DIFF
--- a/python_src/src/lamp_py/aws/s3.py
+++ b/python_src/src/lamp_py/aws/s3.py
@@ -202,12 +202,14 @@ def file_list_from_s3(
     bucket_name: str, file_prefix: str, max_list_size: int = 250_000
 ) -> List[str]:
     """
-    generate filename, filesize tuples for every file in an s3 bucket
+    get a list of s3 objects
 
     :param bucket_name: the name of the bucket to look inside of
-    :param file_prefix: prefix for files to generate
+    :param file_prefix: prefix filter for object keys
 
-    :return list of s3 filepaths
+    :return List[
+        object path as s3://bucket-name/object-key
+    ]
     """
     process_logger = ProcessLogger(
         "file_list_from_s3", bucket_name=bucket_name, file_prefix=file_prefix
@@ -243,7 +245,18 @@ def file_list_from_s3_with_details(
     bucket_name: str, file_prefix: str
 ) -> List[Dict]:
     """
-    get a list of files from s3 along with size and last modified details
+    get a list of s3 objects with additional details
+
+    :param bucket_name: the name of the bucket to look inside of
+    :param file_prefix: prefix filter for object keys
+
+    return_dict = {
+        "s3_obj_path": "str: object path as s3://bucket-name/object-key",
+        "size_bytes": "int: size of object in bytes",
+        "last_modified": "datetime.datetime: object creation date",
+    }
+
+    :return List[return_dict]
     """
     s3_client = get_s3_client()
     response = s3_client.list_objects_v2(Bucket=bucket_name, Prefix=file_prefix)
@@ -255,8 +268,8 @@ def file_list_from_s3_with_details(
 
         file_list.append(
             {
-                "filepath": os.path.join("s3://", bucket_name, obj["Key"]),
-                "size": obj["Size"],
+                "s3_obj_path": os.path.join("s3://", bucket_name, obj["Key"]),
+                "size_bytes": obj["Size"],
                 "last_modified": obj["LastModified"],
             }
         )

--- a/python_src/src/lamp_py/performance_manager/flat_file.py
+++ b/python_src/src/lamp_py/performance_manager/flat_file.py
@@ -157,8 +157,16 @@ def write_csv_index() -> None:
     df = pandas.DataFrame(file_details)
 
     # drop details for the index cvs and add in service date column
-    df = df[~df["filepath"].str.endswith(S3Archive.INDEX_FILENAME)]
-    df["service_date"] = df["filepath"].apply(lambda x: x.split("/")[-1][:10])
+    df = df[~df["s3_obj_path"].str.endswith(S3Archive.INDEX_FILENAME)]
+    df["service_date"] = df["s3_obj_path"].apply(
+        lambda x: x.split("/")[-1][:10]
+    )
+
+    # replace "s3://[S3Archive.BUCKET_NAME]" with "https://performancedata.mbta.com"
+    df["file_url"] = df["s3_obj_path"].str.replace(
+        f"s3://{S3Archive.BUCKET_NAME}", "https://performancedata.mbta.com/"
+    )
+    df = df.drop(columns=["s3_obj_path"])
 
     # write to local csv and upload file to s3
     csv_path = "/tmp/rpm_archive_index.csv"

--- a/python_src/tests/performance_manager/test_performance_manager.py
+++ b/python_src/tests/performance_manager/test_performance_manager.py
@@ -185,18 +185,18 @@ def fixture_flat_file_s3_patch(monkeypatch: MonkeyPatch) -> Iterator[None]:
     """
     public_archive_file_details = [
         {
-            "filepath": "s3://bucket_name/lamp/subway_on_time_performance-v1/index.csv",
-            "size": 123,
+            "s3_obj_path": "s3://bucket_name/lamp/subway_on_time_performance-v1/index.csv",
+            "size_bytes": 123,
             "last_modified": datetime.datetime.now(),
         },
         {
-            "filepath": "s3://bucket_name/lamp/subway_on_time_performance-v1/2023-04-06-subway-on-time-performance-v1.parquet",
-            "size": 123,
+            "s3_obj_path": "s3://bucket_name/lamp/subway_on_time_performance-v1/2023-04-06-subway-on-time-performance-v1.parquet",
+            "size_bytes": 123,
             "last_modified": datetime.datetime.now(),
         },
         {
-            "filepath": "s3://bucket_name/lamp/subway_on_time_performance-v1/2023-04-07-subway-on-time-performance-v1.parquet",
-            "size": 123,
+            "s3_obj_path": "s3://bucket_name/lamp/subway_on_time_performance-v1/2023-04-07-subway-on-time-performance-v1.parquet",
+            "size_bytes": 123,
             "last_modified": datetime.datetime.now(),
         },
     ]
@@ -216,7 +216,7 @@ def fixture_flat_file_s3_patch(monkeypatch: MonkeyPatch) -> Iterator[None]:
 
         files: List[str] = []
         for file in public_archive_file_details:
-            filepath = cast(str, file["filepath"])
+            filepath = cast(str, file["s3_obj_path"])
             files.append(filepath)
 
         return files
@@ -256,9 +256,9 @@ def fixture_flat_file_s3_patch(monkeypatch: MonkeyPatch) -> Iterator[None]:
 
             # check that the columns are correct
             expected_columns = [
-                "filepath",
+                "file_url",
                 "service_date",
-                "size",
+                "size_bytes",
                 "last_modified",
             ]
             assert set(index_data.columns) == set(
@@ -267,7 +267,7 @@ def fixture_flat_file_s3_patch(monkeypatch: MonkeyPatch) -> Iterator[None]:
 
             # ensure that the index didn't refer to itself
             assert not (
-                index_data["filepath"].str.endswith("index.csv")
+                index_data["file_url"].str.endswith("index.csv")
             ).any(), 'Found a record with filepath value "index.csv"'
 
             assert len(index_data) == 2, "index.csv has incorrect length"


### PR DESCRIPTION
The `index.csv` file generated for On Time Performance flat files contained s3:// paths instead of https:// paths. 

This change replaces s3://bucket-name paths with https://performancedata.mbta.com.

This change also updates the `file_list_from_s3_with_details` function with more description return dictionary labels of `s3_obj_path` and `size_bytes`. 
