### PR TITLE
FIX: Lost vehicle consist field in GTFS-RT VehiclePositions feed

### DIFF
--- a/src/lamp_py/migrations/versions/performance_manager_staging/006_e20a4f3f8c03_fix_null_vehicle_consist.py
+++ b/src/lamp_py/migrations/versions/performance_manager_staging/006_e20a4f3f8c03_fix_null_vehicle_consist.py
@@ -1,0 +1,50 @@
+"""fix null vehicle consist
+
+Revision ID: e20a4f3f8c03
+Revises: 96187da84955
+Create Date: 2024-03-07 15:44:22.989929
+
+On March 5th 2024, the vehicle consist field was removed from the VehiclePositions GTFS-RT feed
+this broke our data pipeline requiring a switch to the multi_carriage_details field
+this migration should re-process our realtime data from March 5th to present to fix missing
+vehicle consist values
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+from lamp_py.postgres.postgres_utils import DatabaseIndex, DatabaseManager
+
+# revision identifiers, used by Alembic.
+revision = "e20a4f3f8c03"
+down_revision = "96187da84955"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    clear_events = "DELETE FROM vehicle_events WHERE service_date >= 20240305;"
+    op.execute(clear_events)
+
+    clear_trips = "DELETE FROM vehicle_trips WHERE service_date >= 20240305;"
+    op.execute(clear_trips)
+
+    update_md_query = """
+        UPDATE
+            metadata_log 
+        SET rail_pm_processed = false
+        WHERE
+        (
+            "path" like '%RT_VEHICLE_POSITIONS%'
+            OR "path" like '%RT_TRIP_UPDATES%' 
+        )
+        AND
+        (substring("path", 'year=(\d+)') || '-' || substring("path", 'month=(\d+)') || '-' || substring("path", 'day=(\d+)'))::date >= '2024-3-5'::date
+    ;
+    """
+    md_manager = DatabaseManager(DatabaseIndex.METADATA)
+    md_manager.execute(sa.text(update_md_query))
+
+
+def downgrade() -> None:
+    pass

--- a/src/lamp_py/performance_manager/flat_file.py
+++ b/src/lamp_py/performance_manager/flat_file.py
@@ -164,7 +164,7 @@ def write_csv_index() -> None:
 
     # replace "s3://[S3Archive.BUCKET_NAME]" with "https://performancedata.mbta.com"
     df["file_url"] = df["s3_obj_path"].str.replace(
-        f"s3://{S3Archive.BUCKET_NAME}", "https://performancedata.mbta.com/"
+        f"s3://{S3Archive.BUCKET_NAME}", "https://performancedata.mbta.com"
     )
     df = df.drop(columns=["s3_obj_path"])
 

--- a/src/lamp_py/tableau/jobs/rt_rail.py
+++ b/src/lamp_py/tableau/jobs/rt_rail.py
@@ -20,7 +20,7 @@ class HyperRtRail(HyperJob):
             self,
             hyper_file_name="LAMP_ALL_RT_fields.hyper",
             remote_parquet_path=f"s3://{os.getenv('PUBLIC_ARCHIVE_BUCKET')}/lamp/tableau/rail/LAMP_ALL_RT_fields.parquet",
-            lamp_version="1.0.beta",
+            lamp_version="1.1.beta",
         )
         self.table_query = (
             "SELECT"


### PR DESCRIPTION
The vehicle consist field was recently deprecated by transit tech and an alternate data source is needed for that information to be sent to the OPMI Tableau server.

vehicle consist data will be pulled from the multi_carriage_details field and coalesced with the vehicle consist field to allow for processing periods when multi_carriage_details was not available. 

Asana Task: https://app.asana.com/0/1204931788263585/1206785855851419
