### PR TITLE
Add Investigation Group to Dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ erl_crash.dump
 .elixir_ls/
 /performance_manager/test.db
 /notebook
+/investigation
 
 
 __pycache__

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,12 +35,20 @@ optional = false
 tableauhyperapi = "^0.0.18618"
 tableauserverclient = "0.30"
 
+[tool.poetry.group.investigation]
+optional = true
+
+[tool.poetry.group.investigation.dependencies]
+ipykernel = "^6.29.2"
+matplotlib = "^3.8.3"
+seaborn = "^0.13.2"
+tabulate = "^0.9.0"
+
 [tool.poetry.group.dev.dependencies]
 black = "^24.2.0"
 mypy = "^1.1.1"
 pylint = "^3.1.0"
 pytest = "^8.0.2"
-ipykernel = "^6.29.2"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
Add a new dependency group to pyproject.toml that contains libraries that are useful for data investigations. I've used this flow while working on the bus stop crossing investigation and it allows me to install libraries that aren't needed by LAMP applications locally while still using LAMP utilities.

The can be installed with
`poetry install --with investigation`

I also added a directory to .gitignore where I've been putting notebook and datafiles.