### PR TITLE
FIX: performance of l1_rt_trips.py updates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,8 @@ disable = [
   "unsubscriptable-object",
   # Converter abstract base class only has one common function
   "too-few-public-methods",
+  # l1_rt_trips.py over 1000 lines
+  "too-many-lines",
 ]
 good-names = ["e", "i", "s"]
 max-line-length = 80


### PR DESCRIPTION
This will hopefully fix a lot of the performance issues we are seeing in the `l1_rt_trips.py` file.

Two main changes:

1. 
Don't update trunk_route_id and branch_route_id with database functions, instead `update_branch_trunk_route_id` function will perform this operation locally, and then update the `vehicle_trips` table.

2.
perform updates in `update_stop_sequence` function on unique `service_date` and `static_version_key` combinations with for loop. Previous implementation used a where statement that compared to an array of values, that I think was not allowing our indexes to be used. 
