### PR TITLE
FIX: Parquet writing batch_size and profile logging

### DIFF
--- a/src/lamp_py/runtime_utils/process_logger.py
+++ b/src/lamp_py/runtime_utils/process_logger.py
@@ -3,6 +3,7 @@ import os
 import time
 import uuid
 import shutil
+import psutil
 from typing import Any, Dict, Union, Optional
 
 MdValues = Optional[Union[str, int, float]]
@@ -22,9 +23,8 @@ class ProcessLogger:
         "status",
         "duration",
         "error_type",
-        "total_disk_bytes",
-        "used_disk_bytes",
-        "free_disk_bytes",
+        "free_disk_mb",
+        "free_mem_mb",
     ]
 
     def __init__(self, process_name: str, **metadata: MdValues) -> None:
@@ -46,10 +46,10 @@ class ProcessLogger:
 
     def _get_log_string(self) -> str:
         """create logging string for log write"""
-        total, used, free = shutil.disk_usage("/")
-        self.default_data["total_disk_bytes"] = total
-        self.default_data["used_disk_bytes"] = used
-        self.default_data["free_disk_bytes"] = free
+        _, _, free_disk_bytes = shutil.disk_usage("/")
+        free_mem_bytes = psutil.virtual_memory().available
+        self.default_data["free_disk_mb"] = int(free_disk_bytes / (1000*1000))
+        self.default_data["free_mem_mb"] = int(free_mem_bytes / (1000*1000))
         logging_list = []
         # add default data to log output
         for key, value in self.default_data.items():

--- a/src/lamp_py/runtime_utils/process_logger.py
+++ b/src/lamp_py/runtime_utils/process_logger.py
@@ -2,6 +2,7 @@ import logging
 import os
 import time
 import uuid
+import shutil
 from typing import Any, Dict, Union, Optional
 
 MdValues = Optional[Union[str, int, float]]
@@ -21,6 +22,9 @@ class ProcessLogger:
         "status",
         "duration",
         "error_type",
+        "total_disk_bytes",
+        "used_disk_bytes",
+        "free_disk_bytes",
     ]
 
     def __init__(self, process_name: str, **metadata: MdValues) -> None:
@@ -42,6 +46,10 @@ class ProcessLogger:
 
     def _get_log_string(self) -> str:
         """create logging string for log write"""
+        total, used, free = shutil.disk_usage("/")
+        self.default_data["total_disk_bytes"] = total
+        self.default_data["used_disk_bytes"] = used
+        self.default_data["free_disk_bytes"] = free
         logging_list = []
         # add default data to log output
         for key, value in self.default_data.items():
@@ -61,8 +69,10 @@ class ProcessLogger:
             if key in ProcessLogger.protected_keys:
                 continue
             self.metadata[str(key)] = str(value)
-        self.default_data["status"] = "add_metadata"
-        logging.info(self._get_log_string())
+
+        if self.default_data.get("status") is not None:
+            self.default_data["status"] = "add_metadata"
+            logging.info(self._get_log_string())
 
     def log_start(self) -> None:
         """log the start of a proccess"""

--- a/src/lamp_py/runtime_utils/process_logger.py
+++ b/src/lamp_py/runtime_utils/process_logger.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, Union, Optional
 
 import psutil
 
-MdValues = Optional[Union[str, int, float]]
+MdValues = Optional[Union[str, int, float, bool]]
 
 
 class ProcessLogger:
@@ -26,6 +26,7 @@ class ProcessLogger:
         "error_type",
         "free_disk_mb",
         "free_mem_pct",
+        "print_log",
     ]
 
     def __init__(self, process_name: str, **metadata: MdValues) -> None:
@@ -63,7 +64,13 @@ class ProcessLogger:
         return ", ".join(logging_list)
 
     def add_metadata(self, **metadata: MdValues) -> None:
-        """add metadata to the process logger"""
+        """
+        add metadata to the process logger
+
+        :param print_log: if True(default), print log after metadata is added
+        """
+        metadata.setdefault("print_log", True)
+        print_log = bool(metadata.get("print_log"))
         for key, value in metadata.items():
             # skip metadata key if protected as default_data key
             # maybe raise on this? instead of fail silently
@@ -71,7 +78,7 @@ class ProcessLogger:
                 continue
             self.metadata[str(key)] = str(value)
 
-        if self.default_data.get("status") is not None:
+        if self.default_data.get("status") is not None and print_log:
             self.default_data["status"] = "add_metadata"
             logging.info(self._get_log_string())
 

--- a/src/lamp_py/runtime_utils/process_logger.py
+++ b/src/lamp_py/runtime_utils/process_logger.py
@@ -3,8 +3,9 @@ import os
 import time
 import uuid
 import shutil
-import psutil
 from typing import Any, Dict, Union, Optional
+
+import psutil
 
 MdValues = Optional[Union[str, int, float]]
 
@@ -24,7 +25,7 @@ class ProcessLogger:
         "duration",
         "error_type",
         "free_disk_mb",
-        "free_mem_mb",
+        "free_mem_pct",
     ]
 
     def __init__(self, process_name: str, **metadata: MdValues) -> None:
@@ -47,9 +48,9 @@ class ProcessLogger:
     def _get_log_string(self) -> str:
         """create logging string for log write"""
         _, _, free_disk_bytes = shutil.disk_usage("/")
-        free_mem_bytes = psutil.virtual_memory().available
-        self.default_data["free_disk_mb"] = int(free_disk_bytes / (1000*1000))
-        self.default_data["free_mem_mb"] = int(free_mem_bytes / (1000*1000))
+        used_mem_pct = psutil.virtual_memory().percent
+        self.default_data["free_disk_mb"] = int(free_disk_bytes / (1000 * 1000))
+        self.default_data["free_mem_pct"] = int(100 - used_mem_pct)
         logging_list = []
         # add default data to log output
         for key, value in self.default_data.items():

--- a/src/lamp_py/tableau/jobs/rt_rail.py
+++ b/src/lamp_py/tableau/jobs/rt_rail.py
@@ -101,7 +101,7 @@ class HyperRtRail(HyperJob):
             "   ve.service_date, vt.route_id, vt.direction_id, vt.vehicle_id, vt.start_time"
             ";"
         )
-        self.ds_batch_size = int(1024 * 1024 / 2)
+        self.ds_batch_size = 1024 * 256
         self.db_parquet_path = "/tmp/db_local.parquet"
 
     @property

--- a/src/lamp_py/tableau/jobs/rt_rail.py
+++ b/src/lamp_py/tableau/jobs/rt_rail.py
@@ -101,7 +101,7 @@ class HyperRtRail(HyperJob):
             "   ve.service_date, vt.route_id, vt.direction_id, vt.vehicle_id, vt.start_time"
             ";"
         )
-        self.ds_batch_size = 1024 * 1024
+        self.ds_batch_size = int(1024 * 1024 / 2)
         self.db_parquet_path = "/tmp/db_local.parquet"
 
     @property


### PR DESCRIPTION
Very large parquet input files on PROD were resulting in ECS crashes from excessive memory usage.

After local testing, excessive memory usage was re-produced and `batch_size` values were dialed in to limit memory usage during parquet file writing operations. 

Also added some basic system profiling to logging statements `free_disk_mb` & `free_mem_pct` will hopefully help troubleshoot these types of issues more quickly in the future. 