### PR TITLE
FIX: LAMP_ALL_RT dataset missing partial RED Line trips

### DIFF
--- a/src/lamp_py/tableau/jobs/rt_rail.py
+++ b/src/lamp_py/tableau/jobs/rt_rail.py
@@ -21,7 +21,7 @@ class HyperRtRail(HyperJob):
             self,
             hyper_file_name="LAMP_ALL_RT_fields.hyper",
             remote_parquet_path=f"s3://{os.getenv('PUBLIC_ARCHIVE_BUCKET')}/lamp/tableau/rail/LAMP_ALL_RT_fields.parquet",
-            lamp_version="1.1.0",
+            lamp_version="1.1.1",
         )
         self.table_query = (
             "SELECT"
@@ -91,7 +91,10 @@ class HyperRtRail(HyperJob):
             "   prev_ve.stop_id = prev_ss.stop_id"
             "   AND vt.static_version_key = prev_ss.static_version_key"
             " WHERE "
-            "   ve.canonical_stop_sequence > 1"
+            "   ("
+            "       ve.canonical_stop_sequence > 1"
+            "       OR ve.canonical_stop_sequence IS NULL"
+            "   )"
             "   AND ("
             "       ve.vp_stop_timestamp IS NOT null"
             "       OR ve.vp_move_timestamp IS NOT null"


### PR DESCRIPTION
The query that creates the LAMP_ALL_RT OPMI dataset contains a  `canonical_stop_sequence > 1` WHERE constraint to filter out origination terminal stops from the dataset. As a side effect, this constraint also removed any trips that did not have a valid canonical_stop_sequence from the dataset. This frequently occurred on the red-line during diversions where a `branch_route_id` could not be assigned to the trip because the trip did not pass through a branch station (south of JFK/UMass). 

Ops Analytics has requested that this constraint be updated to include `OR ve.canonical_stop_sequence IS NULL` to add back the Red-line (and any other route) trips without a valid `canonical_stop_sequence`.

Merging this change will trigger a refresh of the LAMP_ALL_RT parquet file on the PROD, which will take a couple hours. This should not be done until the end of the business day to avoid interfering with OPMI/Ops Analytics daily reporting. 

Asana Task: https://app.asana.com/0/1189492770004753/1206770195707444