### PR TITLE
FEAT: Remove Commuter Rail data from exports

### DIFF
--- a/src/lamp_py/tableau/jobs/rt_rail.py
+++ b/src/lamp_py/tableau/jobs/rt_rail.py
@@ -21,7 +21,7 @@ class HyperRtRail(HyperJob):
             self,
             hyper_file_name="LAMP_ALL_RT_fields.hyper",
             remote_parquet_path=f"s3://{os.getenv('PUBLIC_ARCHIVE_BUCKET')}/lamp/tableau/rail/LAMP_ALL_RT_fields.parquet",
-            lamp_version="1.1.1",
+            lamp_version="1.1.2",
         )
         self.table_query = (
             "SELECT"
@@ -90,8 +90,14 @@ class HyperRtRail(HyperJob):
             " ON "
             "   prev_ve.stop_id = prev_ss.stop_id"
             "   AND vt.static_version_key = prev_ss.static_version_key"
+            " LEFT JOIN "
+            "   static_routes sr"
+            " ON "
+            "   vt.route_id = sr.route_id"
+            "   AND vt.static_version_key = sr.static_version_key"
             " WHERE "
-            "   ("
+            "   sr.route_type < 2"
+            "   AND ("
             "       ve.canonical_stop_sequence > 1"
             "       OR ve.canonical_stop_sequence IS NULL"
             "   )"


### PR DESCRIPTION
This change removes commuter rain data from flat file and OPMI ALL_RT export files. 

As tested on STAGING, these changes have no significant impact on query duration. 

flat file query remained constant at ~4 seconds, for one service_date

ALL_RT query stayed at ~12 seconds, for one service_date

Deployment of this change to PROD will result in re-creation of export datasets, which should be done at the end of the business day to avoid interference with Tableau dashboarding operations. 

Asana Task: https://app.asana.com/0/1205827492903547/1207059327607966
