### PR TITLE
FEAT Update Data Dictionary for Alerts Data

### DIFF
--- a/Data_Dictionary.md
+++ b/Data_Dictionary.md
@@ -217,7 +217,9 @@ LAMP calculated dataset containing planned `route_id` and `service_id` combinati
 
 ## LAMP_RT_ALERTS
 
-The GTFS Realtime Alerts feed is archived here. Each alert contains a list of possibly many active periods and another list of arrays describing stops along routes in directions that are impacted by the alert. Both lists are exploded in this dataset. Each record represents an updated to an alert impacting a stop along a route in a direction with for a given active period.
+The MBTA GTFS Realtime [Alerts](https://github.com/mbta/gtfs-documentation/blob/master/reference/gtfs-realtime.md) feed is archived in this dataset. 
+
+Each row of this dataset represents an entry from the [`informed_entity`](https://gtfs.org/realtime/reference/#message-entityselector) and [`active_period`](https://gtfs.org/realtime/reference/#message-timerange) fields of the Alert message being exploded.
 
 In generating this dataset, translation string fields contain only the English translation. All timestamp fields are in POSIX Time, the integer number of seconds since 1 January 1970 00:00:00 UTC. These are converted to datetimes in are Eastern Standard Time for user convenience.
 

--- a/Data_Dictionary.md
+++ b/Data_Dictionary.md
@@ -27,7 +27,7 @@ Each row represents a unique `trip_id`-`stop_id` pair for rail service.
 | vehicle_consist | string | Pipe separated concatenation of `multi_carriage_details` labels in [CarridageDetails](https://gtfs.org/realtime/reference/#message-carriagedetails) | GTFS-RT
 | stop_id | string | equivalent to GTFS-RT `stop_id` value in [VehiclePosition](https://gtfs.org/realtime/reference/#message-vehicleposition)| GTFS-RT |
 | parent_station | string | `stop_name` of the `parent_station` associated with the `stop_id` from [stops.txt](https://gtfs.org/schedule/reference/#stopstxt)  | GTFS |
-| stop_sequence | int16 | equivalent to GTFS-RT jj/`current_stop_sequence` value in [VehiclePosition](https://gtfs.org/realtime/reference/#message-vehicleposition) | GTFS-RT |
+| stop_sequence | int16 | equivalent to GTFS-RT `current_stop_sequence` value in [VehiclePosition](https://gtfs.org/realtime/reference/#message-vehicleposition) | GTFS-RT |
 | move_timestamp | int64 | earliest "IN_TRANSIT_TO" or "INCOMING_AT" status `timestamp` for a trip-stop pair from GTFS-RT [VehiclePosition](https://gtfs.org/realtime/reference/#message-vehicleposition) | GTFS-RT |
 | stop_timestamp | int64 | earliest "STOPPED_AT" status `timestamp` for a trip-stop pair from GTFS-RT [VehiclePosition](https://gtfs.org/realtime/reference/#message-vehicleposition) or last `arrival` timestamp from GTFS-RT [StopTimeUpdate](https://gtfs.org/realtime/reference/#message-stoptimeupdate) if VehiclePosition value is not available | GTFS-RT |
 | travel_time_seconds | int64 | seconds the vehicle spent traveling to the `stop_id` of trip-stop pair from previous `stop_id` on trip | LAMP Calculated |

--- a/Data_Dictionary.md
+++ b/Data_Dictionary.md
@@ -5,6 +5,7 @@ Access instructions for all LAMP public data exports are available at [https://p
 LAMP currently produces the following sets of public data exports:
 - [On Time Performance Data (Subway)](#on-time-performance-data-subway)
 - [OPMI Tableau Exports](#opmi-tableau-exports)
+- [GTFS Realtime Alerts Archive](#gtfs-alerts-archive)
 
 # On Time Performance Data (Subway) 
 
@@ -212,3 +213,43 @@ LAMP calculated dataset containing planned `route_id` and `service_id` combinati
 | direction_id | int8 | `direction_id` from [trips.txt](https://gtfs.org/schedule/reference/#tripstxt)
 | block_id | string | `block_id` from [trips.txt](https://gtfs.org/schedule/reference/#tripstxt)
 | static_version_key | int64 | key used to link GTFS static schedule versions between tables |
+
+
+# GTFS Alerts Archive
+
+Each row represents an update to an Realtime Alert, paired with unique Route, Stop, and Direction information. All timestamp fields are in POSIX time, the integer number of seconds since 1 January 1970 00:00:00 UTC. All datetimes in are Eastern Standard Time.
+
+| field name | type | description |
+| ---------- | ---- | ----------- |
+| id | int64 | Unique identifier for this Alert. Subsequent updates to it will have the same ID. |
+| cause | string | String from [Cause](https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/reference.md#enum-cause) enum. Will be present if `cause_detail` is not null. |
+| cause_detail | string | Description of the cause of the alert that allows for agency-specific language; more specific than the Cause. If cause_detail is included, then `cause` must also be included. |
+| effect | string | String from [Effect](https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/reference.md#enum-effect) enum. Will be present if `effect_detail` is not null.|
+| effect_detail | string | Description of the effect of the alert that allows for agency-specific language; more specific than the Effect. If effect_detail is included, then `effect` must also be included. |
+| severity_level | string | Severity of the alert. Values described in [SeverityLevel](https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/reference.md#enum-severitylevel) enum.|
+| severity | int8 | Integer representation of Severity |
+| alert_lifecycle | string | Whether the alert is in effect now, will be in the future, or has been for a while. One of NEW, UPCOMING, ONGOING, ONGOING_UPCOMING. |
+| duration_certainty | string | Whether the alert has a KNOWN, UNKNOWN, or ESTIMATED end time. |
+| header_text.translation.text | string | Header for the alert. Short plain-text string describing the alert. |
+| description_text.translation.text | string | Description for the alert. This longer description should add to the information of the header. |
+| service_effect_text.translation.text | string | Brief summary of effect and affected service. |
+| timeframe_text.translation.text | string | Human readable summary of when service will be disrupted.Human readable summary of when service will be disrupted. |
+| recurrence_text.translation.text | string | Human readable summary of how active_period values are repeating (ex: “daily”, “weekdays”). |
+| created_datetime | datetime | Time this alert was created. |
+| created_timestamp | uint64 | Time this alert was created. |
+| last_modified_datetime | datetime | Time this alert was last modified. This is updated when the alert is modified in any way after creation. |
+| last_modified_timestamp | uint64 | Time this alert was last modified. This is updated when the alert is modified in any way after creation. |
+| last_push_notification_datetime | datetime | Time this alert was last _meaningfully_ modified. Addition of the field or a change in value indicates that a notification should be sent to riders. |
+| last_push_notification_timestamp | uint64 | Time this alert was last _meaningfully_ modified. Addition of the field or a change in value indicates that a notification should be sent to riders. |
+| closed_datetime | datetime | Time this alert was closed. |
+| closed_timestamp | uint64 | Time this alert was closed. |
+| active_period.start_datetime | datetime | Start time when this alert is in effect. If null, the alert is in effect from when this alert's `created_datetime` |
+| active_period.start_timestamp | uint64 |  Start time when this alert is in effect. If null, the alert is in effect from when this alert's `created_timestamp` |
+| active_period.end_datetime | datetime | End time when this alert is in effect. If null, the alert is in effect until an alert update with a matching `id` has a `closed_datetime` |
+| active_period.end_timestamp | uint64 | End time when this alert is in effect. If null, the alert is in effect until an alert update with a matching `id` has a `closed_datetime` |
+| informed_entity.route_id | string | The route_id from the GTFS that this alert effects. |
+| informed_entity.route_type | int8 | The route_type from GTFS that this alert effects|
+| informed_entity.direction_id | int8 | The direction_id from GTFS feeds [trips.txt](https://gtfs.org/schedule/reference/#tripstxt), used to select all trips in one direction for a route, specified by `route_id`. If provided, `route_id` must also be provided.
+| informed_entity.stop_id | string | The stop_id from the GTFS feed that this selector refers to. |
+| informed_entity.facility_id | string | Facility abbreviation that contains the `stop_id`. |
+| informed_entity.activities | string | A `\|` delimitated string of activities, defined in the [Activity](https://github.com/mbta/gtfs-documentation/blob/master/reference/gtfs-realtime.md#enum-activity) enum that are impacted by this alert at this location.|

--- a/src/lamp_py/publishing/index.html
+++ b/src/lamp_py/publishing/index.html
@@ -109,18 +109,6 @@
                 https://performancedata.mbta.com/lamp/tableau/rail/LAMP_static_trips.parquet
             </a>
         </li>
-    </ul>
-    </p>
-
-    <hr>
-
-    <h2>
-        GTFS Alerts Archive
-    </h2>
-    <p>
-        Archive of all GTFS issued Alerts in a single parquet file.
-    </p>
-    <ul>
         <li>
             <a href="https://performancedata.mbta.com/lamp/tableau/alerts/LAMP_RT_ALERTS.parquet">
                 https://performancedata.mbta.com/lamp/tableau/alerts/LAMP_RT_ALERTS.parquet

--- a/src/lamp_py/publishing/index.html
+++ b/src/lamp_py/publishing/index.html
@@ -112,6 +112,21 @@
     </ul>
     </p>
 
+    <hr>
+
+    <h2>
+        GTFS Alerts Archive
+    </h2>
+    <p>
+        Archive of all GTFS issued Alerts in a single parquet file.
+    </p>
+    <ul>
+        <li>
+            <a href="https://performancedata.mbta.com/lamp/tableau/alerts/LAMP_RT_ALERTS.parquet">
+                https://performancedata.mbta.com/lamp/tableau/alerts/LAMP_RT_ALERTS.parquet
+            </a>
+        </li>
+    </ul>
 
 </body>
 


### PR DESCRIPTION
Now that Alerts data is being published to the public bucket for consumption, we need to update our public index to include its url and the data dictionary to describe its contents.