### PR TITLE
FEAT: Use Github Action to change instance count for BUS-PM application

### DIFF
--- a/.github/workflows/change_task_count.yaml
+++ b/.github/workflows/change_task_count.yaml
@@ -19,6 +19,7 @@ on:
         options:
           - ingestion
           - rail-performance-manager
+          - bus-performance-manager
 
 jobs:
   set_count:


### PR DESCRIPTION
Add `bus-performance-manager` to change_task_count github action.