### PR TITLE
FEAT: Add workflows for deploying TM Ingestion

### DIFF
--- a/.github/workflows/deploy-base.yaml
+++ b/.github/workflows/deploy-base.yaml
@@ -27,6 +27,11 @@ on:
         required: false
         default: false
         type: boolean
+      deploy-tm-ingestion:
+        description: Should the TransitMaster Ingestion Application be Deployed
+        required: false
+        default: false
+        type: boolean
       deploy-tableau-publisher:
         description: Should the Tableau Publisher Application be Deployed
         required: false
@@ -91,6 +96,16 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           ecs-cluster: lamp
           ecs-service: lamp-bus-performance-manager-${{ inputs.environment }}
+          docker-tag: ${{ steps.build-push.outputs.docker-tag }}
+      - name: Deploy TransitMaster Ingestion Application
+        id: deploy-tm-ingestion
+        if: ${{ inputs.deploy-tm-ingestion && inputs.environment != 'dev' }}
+        uses: mbta/actions/deploy-scheduled-ecs@v2
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          ecs-cluster: lamp
+          ecs-service: lamp-tm-ingestion-${{ inputs.environment }}
+          ecs-task-definition: lamp-tm-ingestion-${{ inputs.environment }}
           docker-tag: ${{ steps.build-push.outputs.docker-tag }}
       - name: Deploy Tableau Publisher Application
         id: deploy-tableau-publisher

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -17,5 +17,6 @@ jobs:
       deploy-ingestion: true
       deploy-rail-pm: true
       deploy-bus-pm: true
+      deploy-tm-ingestion: true
       deploy-tableau-publisher: true
     secrets: inherit

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -20,4 +20,5 @@ jobs:
       deploy-ingestion: true
       deploy-rail-pm: true
       deploy-bus-pm: true
+      deploy-tm-ingestion: true
     secrets: inherit

--- a/.github/workflows/manual-deploy.yaml
+++ b/.github/workflows/manual-deploy.yaml
@@ -22,6 +22,10 @@ on:
         description: Deploy Bus Performance Manager
         default: false
         type: boolean
+      deploy-tm-ingestion:
+        description: Deploy TransitMaster Ingestion (not run on Dev)
+        default: false
+        type: boolean
       deploy-tableau-publisher:
         description: Deploy Tableau Publisher (only run on Prod)
         default: false
@@ -39,5 +43,6 @@ jobs:
       deploy-ingestion: ${{ fromJson(github.event.inputs.deploy-ingestion) }}
       deploy-rail-pm: ${{ fromJson(github.event.inputs.deploy-rail-pm) }}
       deploy-bus-pm: ${{ fromJson(github.event.inputs.deploy-bus-pm) }}
+      deploy-tm-ingestion: ${{ fromJson(github.event.inputs.deploy-tm-ingestion) }}
       deploy-tableau-publisher: ${{ fromJson(github.event.inputs.deploy-tableau-publisher) }}
     secrets: inherit


### PR DESCRIPTION
TransitMaster Ingestion is a new application that will run a cron schedule on the ITD Transit Gateway subnet in staging and prod environments.

Expand the `deploy-base.yaml` to deploy this application conditionally. Set that flag to true for both prod and staging deployment scripts and add it as an input in the manual deployment script.

Asana Task: [🚌 Create ECS infrastructure TM Ingestion runs on](https://app.asana.com/0/1189492770004753/1207188685726595/f)
