### PR TITLE
FIX: Parquet hive partition reading failing on continuous ingest files

### DIFF
--- a/src/lamp_py/ingestion/convert_gtfs_rt.py
+++ b/src/lamp_py/ingestion/convert_gtfs_rt.py
@@ -445,6 +445,8 @@ class GtfsRtConverter(Converter):
                 f"{partition_dt.isoformat()}.parquet",
             )
 
+            table = table.drop_columns(["year", "month", "day", "hour"])
+
             log.add_metadata(local_path=local_path)
 
             # no existing table file, write new file


### PR DESCRIPTION
ParquetDataset calls to read a hive partition are failing on the continuously ingested GTFS-RT parquet files. This is because I forgot to drop the hive partition data columns before writing the parquet files.