### PR TITLE
FIX: Test deploy action that allows zero desired count

### DIFF
--- a/.github/workflows/deploy-base.yaml
+++ b/.github/workflows/deploy-base.yaml
@@ -86,12 +86,13 @@ jobs:
       - name: Deploy Bus Performance Manager Application
         id: deploy-bus-performance-manager
         if: ${{ inputs.deploy-bus-pm }}
-        uses: mbta/actions/deploy-ecs@v2
+        uses: mbta/actions/deploy-ecs@feat-deploy-ecs-allow-zero-desired
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           ecs-cluster: lamp
           ecs-service: lamp-bus-performance-manager-${{ inputs.environment }}
           docker-tag: ${{ steps.build-push.outputs.docker-tag }}
+          allow-zero-desired: true
       - name: Deploy Tableau Publisher Application
         id: deploy-tableau-publisher
         if: ${{ inputs.deploy-tableau-publisher && inputs.environment == 'prod' }}


### PR DESCRIPTION
I created a PR for the mbta/actions/deploy-ecs action to allow zero `desiredCount` values for ECS instances that are not running during a deploy. 

https://github.com/mbta/actions/pull/56

@paulswartz requested we test this feat before merging to the actions repo.