### PR TITLE
FEAT: USE allow-zero-desired from deploy-ecs@v2

### DIFF
--- a/.github/workflows/deploy-base.yaml
+++ b/.github/workflows/deploy-base.yaml
@@ -79,6 +79,7 @@ jobs:
           ecs-cluster: lamp
           ecs-service: lamp-ingestion-${{ inputs.environment }}
           docker-tag: ${{ steps.build-push.outputs.docker-tag }}
+          allow-zero-desired: true
       - name: Deploy Rail Performance Manager Application
         id: deploy-rail-performance-manager
         if: ${{ inputs.deploy-rail-pm }}
@@ -88,6 +89,7 @@ jobs:
           ecs-cluster: lamp
           ecs-service: lamp-rail-performance-manager-${{ inputs.environment }}
           docker-tag: ${{ steps.build-push.outputs.docker-tag }}
+          allow-zero-desired: true
       - name: Deploy Bus Performance Manager Application
         id: deploy-bus-performance-manager
         if: ${{ inputs.deploy-bus-pm }}
@@ -97,6 +99,7 @@ jobs:
           ecs-cluster: lamp
           ecs-service: lamp-bus-performance-manager-${{ inputs.environment }}
           docker-tag: ${{ steps.build-push.outputs.docker-tag }}
+          allow-zero-desired: true
       - name: Deploy TransitMaster Ingestion Application
         id: deploy-tm-ingestion
         if: ${{ inputs.deploy-tm-ingestion && inputs.environment != 'dev' }}


### PR DESCRIPTION
The `mbta/actions/deploy-ecs@v2` action has been updated to have `allow-zero-desired` as an input. (https://github.com/mbta/actions/blob/main/deploy-ecs/action.yml)

This updates our deploy-base action to not fail if no instance tasks are currently running for a service. 
