### PR TITLE
FEAT: Retry failed parquet RT file loads

### DIFF
--- a/src/lamp_py/performance_manager/l0_gtfs_static_load.py
+++ b/src/lamp_py/performance_manager/l0_gtfs_static_load.py
@@ -5,6 +5,7 @@ from typing import List, Optional, Dict
 
 import numpy
 import pandas
+import pyarrow
 import sqlalchemy as sa
 from lamp_py.aws.ecs import check_for_sigterm
 from lamp_py.aws.s3 import file_list_from_s3, read_parquet
@@ -312,7 +313,7 @@ def load_parquet_files(
                 paths_to_load, columns=table.column_info.columns_to_pull
             )
             assert table.data_table.shape[0] > 0
-        except KeyError as exception:
+        except pyarrow.ArrowInvalid as exception:
             if table.allow_empty_dataframe is False:
                 raise exception
 

--- a/src/lamp_py/performance_manager/l0_rt_vehicle_positions.py
+++ b/src/lamp_py/performance_manager/l0_rt_vehicle_positions.py
@@ -1,5 +1,4 @@
 from typing import List, Union, Dict, Tuple
-import time
 
 import numpy
 import pandas
@@ -72,21 +71,11 @@ def get_vp_dataframe(
         "vehicle.multi_carriage_details": "multi_carriage_details",
     }
 
-    retry_attempts = 2
-    for retry_attempt in range(retry_attempts + 1):
-        try:
-            process_logger.add_metadata(retry_attempts=retry_attempt)
-            result = read_parquet(
-                to_load,
-                columns=vehicle_position_cols,
-                filters=vehicle_position_filters,
-            )
-            break
-        except Exception as exception:
-            if retry_attempt == retry_attempts:
-                process_logger.log_failure(exception)
-                raise exception
-            time.sleep(1)
+    result = read_parquet(
+        to_load,
+        columns=vehicle_position_cols,
+        filters=vehicle_position_filters,
+    )
 
     result = result.rename(columns=rename_mapper)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,29 +7,30 @@ from typing import (
     Iterator,
     List,
     Optional,
-    Sequence,
-    Tuple,
     Union,
 )
 
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
-from pyarrow import fs, parquet, Table
+from pyarrow import fs
+import pyarrow.dataset as pd
 
 
-@pytest.fixture(autouse=True, name="get_pyarrow_table_patch")
-def fixture_get_pyarrow_table_patch(monkeypatch: MonkeyPatch) -> Iterator[None]:
+@pytest.fixture(autouse=True, name="get_pyarrow_dataset_patch")
+def fixture_get_pyarrow_dataset_patch(
+    monkeypatch: MonkeyPatch,
+) -> Iterator[None]:
     """
-    the aws.s3 function `_get_pyarrow_table` function reads parquet files from
-    s3 and returns a pyarrow table. when testing on our github machines, we
+    the aws.s3 function `_get_pyarrow_dataset` function reads parquet files from
+    s3 and returns a pyarrow dataset. when testing on our github machines, we
     don't have access to s3, so all tests must be run against local files.
     monkeypatch the function to read from a local filepath.
     """
 
-    def mock__get_pyarrow_table(
+    def mock__get_pyarrow_dataset(
         filename: Union[str, List[str]],
-        filters: Optional[Union[Sequence[Tuple], Sequence[List[Tuple]]]] = None,
-    ) -> Table:
+        filters: Optional[pd.Expression] = None,
+    ) -> pd.Dataset:
         active_fs = fs.LocalFileSystem()
 
         if isinstance(filename, list):
@@ -38,14 +39,16 @@ def fixture_get_pyarrow_table_patch(monkeypatch: MonkeyPatch) -> Iterator[None]:
             to_load = [filename]
 
         if len(to_load) == 0:
-            return Table.from_pydict({})
+            return pd.dataset([])
 
-        return parquet.ParquetDataset(
-            to_load, filesystem=active_fs, filters=filters
-        ).read_pandas()
+        ds = pd.dataset(to_load, filesystem=active_fs, partitioning="hive")
+        if filters is not None:
+            ds = ds.filter(filters)
+
+        return ds
 
     monkeypatch.setattr(
-        "lamp_py.aws.s3._get_pyarrow_table", mock__get_pyarrow_table
+        "lamp_py.aws.s3._get_pyarrow_dataset", mock__get_pyarrow_dataset
     )
 
     yield

--- a/tests/performance_manager/test_performance_manager.py
+++ b/tests/performance_manager/test_performance_manager.py
@@ -13,6 +13,7 @@ from typing import (
 )
 
 import pandas
+import pyarrow
 import pytest
 import sqlalchemy as sa
 from _pytest.monkeypatch import MonkeyPatch
@@ -511,7 +512,7 @@ def test_bad_empty_static_table() -> None:
     static_tables = get_table_objects()
     test_table = {"stop_times": static_tables["stop_times"]}
 
-    with pytest.raises(KeyError):
+    with pytest.raises(pyarrow.ArrowInvalid):
         load_parquet_files(test_table, "/tmp/FEED_INFO/timestamp=0000000000")
 
 


### PR DESCRIPTION
Continuous ingestion is resulting additional thrashing of RT springboard files for performance manager. This change incorporates retry logic into RT_VEHICLE_POSITION and RT_TRIP_UPDATE file loads. 

Also made a few changes to the way we read parquet datasets based on information learned since these functions were created. 
