### PR TITLE
feat: Remove "on-time" nomenclature from documentation 

### DIFF
--- a/Data_Dictionary.md
+++ b/Data_Dictionary.md
@@ -3,10 +3,10 @@
 Access instructions for all LAMP public data exports are available at [https://performancedata.mbta.com](https://performancedata.mbta.com). 
 
 LAMP currently produces the following sets of public data exports:
-- [On Time Performance Data (Subway)](#on-time-performance-data-subway)
+- [Subway Performance Data](#subway-performance-data)
 - [OPMI Tableau Exports](#opmi-tableau-exports)
 
-# On Time Performance Data (Subway) 
+# Subway Performance Data
 
 Each row represents a unique `trip_id`-`stop_id` pair for rail service.
 

--- a/src/lamp_py/publishing/index.html
+++ b/src/lamp_py/publishing/index.html
@@ -35,7 +35,7 @@
     <hr>
 
     <h2>
-        On Time Performance Data (Subway)
+        Subway Performance Data
     </h2>
     <p>
         Performance Data for the MBTA Subway system partitioned by service date.


### PR DESCRIPTION
Based on request from ops analytics. 
