### PR TITLE
FEAT: Add Tableau Publishing for Alerts Data

### DIFF
--- a/src/lamp_py/tableau/jobs/rt_alerts.py
+++ b/src/lamp_py/tableau/jobs/rt_alerts.py
@@ -1,0 +1,34 @@
+import pyarrow
+
+from lamp_py.aws.s3 import download_file
+from lamp_py.performance_manager.alerts import AlertsS3Info
+from lamp_py.postgres.postgres_utils import DatabaseManager
+from lamp_py.tableau.hyper import HyperJob
+
+
+class HyperRtAlerts(HyperJob):
+    """HyperJob for LAMP Alerts dataset"""
+
+    def __init__(self) -> None:
+        HyperJob.__init__(
+            self,
+            hyper_file_name="LAMP_ALERTS.hyper",
+            remote_parquet_path=AlertsS3Info.s3_path,
+            lamp_version=AlertsS3Info.file_version,
+        )
+
+    @property
+    def parquet_schema(self) -> pyarrow.schema:
+        return AlertsS3Info.parquet_schema
+
+    def create_parquet(self, _: DatabaseManager) -> None:
+        raise NotImplementedError(
+            "Alerts Hyper Job does not create parquet file"
+        )
+
+    def update_parquet(self, _: DatabaseManager) -> bool:
+        download_file(
+            object_path=self.remote_parquet_path,
+            file_name=self.local_parquet_path,
+        )
+        return False

--- a/src/lamp_py/tableau/pipeline.py
+++ b/src/lamp_py/tableau/pipeline.py
@@ -6,6 +6,7 @@ from lamp_py.runtime_utils.env_validation import validate_environment
 from lamp_py.tableau.hyper import HyperJob
 from lamp_py.postgres.postgres_utils import DatabaseManager
 from lamp_py.tableau.jobs.rt_rail import HyperRtRail
+from lamp_py.tableau.jobs.rt_alerts import HyperRtAlerts
 from lamp_py.tableau.jobs.gtfs_rail import (
     HyperServiceIdByRoute,
     HyperStaticCalendar,
@@ -17,21 +18,6 @@ from lamp_py.tableau.jobs.gtfs_rail import (
     HyperStaticTrips,
 )
 from lamp_py.aws.ecs import check_for_parallel_tasks
-
-
-def create_hyper_jobs() -> List[HyperJob]:
-    """Create Hyper Jobs to Run"""
-    return [
-        HyperRtRail(),
-        HyperServiceIdByRoute(),
-        HyperStaticCalendar(),
-        HyperStaticCalendarDates(),
-        HyperStaticFeedInfo(),
-        HyperStaticRoutes(),
-        HyperStaticStops(),
-        HyperStaticStopTimes(),
-        HyperStaticTrips(),
-    ]
 
 
 def start_hyper_updates() -> None:
@@ -56,12 +42,37 @@ def start_hyper_updates() -> None:
     # make sure only one publisher runs at a time
     check_for_parallel_tasks()
 
-    for job in create_hyper_jobs():
+    hyper_jobs: List[HyperJob] = [
+        HyperRtRail(),
+        HyperServiceIdByRoute(),
+        HyperStaticCalendar(),
+        HyperStaticCalendarDates(),
+        HyperStaticFeedInfo(),
+        HyperStaticRoutes(),
+        HyperStaticStops(),
+        HyperStaticStopTimes(),
+        HyperStaticTrips(),
+        HyperRtAlerts(),
+    ]
+
+    for job in hyper_jobs:
         job.run_hyper()
 
 
 def start_parquet_updates(db_manager: DatabaseManager) -> None:
     """Run all Parquet Update jobs"""
 
-    for job in create_hyper_jobs():
+    parquet_update_jobs: List[HyperJob] = [
+        HyperRtRail(),
+        HyperServiceIdByRoute(),
+        HyperStaticCalendar(),
+        HyperStaticCalendarDates(),
+        HyperStaticFeedInfo(),
+        HyperStaticRoutes(),
+        HyperStaticStops(),
+        HyperStaticStopTimes(),
+        HyperStaticTrips(),
+    ]
+
+    for job in parquet_update_jobs:
         job.run_parquet(db_manager)


### PR DESCRIPTION
The alerts data needs to be on tableau to allow for dashboard creation and some downstream analysis from teams unable to process parquet files.
* Add a Hyper Job for Alerts to handle the publishing
* Pull out static info from `AlertsParquetHandler` into `AlertsS3Info` and use that in both the handler and hyper job classes.
* Update tableau.pipeline.py to use different lists for running the hyper jobs and running the parquet updates.

Asana Task: [📣 Publish alerts data to Tableau](https://app.asana.com/0/1205827492903547/1207101442990597/f)