### PR TITLE
FIX: Only pull 1 static parquet file from folder

### DIFF
--- a/src/lamp_py/performance_manager/l0_gtfs_static_load.py
+++ b/src/lamp_py/performance_manager/l0_gtfs_static_load.py
@@ -310,7 +310,7 @@ def load_parquet_files(
         )
         try:
             table.data_table = read_parquet(
-                paths_to_load, columns=table.column_info.columns_to_pull
+                paths_to_load[:1], columns=table.column_info.columns_to_pull
             )
             assert table.data_table.shape[0] > 0
         except pyarrow.ArrowInvalid as exception:


### PR DESCRIPTION
Continuous ingestion is causing 2 parquet files to be placed into a single static file partition on our springboard bucket. 

The static table loading process should never be loading more than 1 file from a folder. 

This is a stop-gap.

