### PR TITLE
FIX: Add SqlType.timestamp_tz for pq -> hyper type

### DIFF
--- a/src/lamp_py/tableau/hyper.py
+++ b/src/lamp_py/tableau/hyper.py
@@ -111,6 +111,8 @@ class HyperJob(ABC):  # pylint: disable=R0902
             return SqlType.date()
 
         if dtype.startswith("timestamp"):
+            if "tz" in dtype:
+                return SqlType.timestamp_tz()
             return SqlType.timestamp()
 
         return SqlType.text()


### PR DESCRIPTION
The Alerts dataset has timestamp types with timezone information in them. Add a conversion in the `convert_parquet_dtype` method that will correctly convert these pyarrow types into hyper types.