### PR TITLE
FIX: GTFS Ingestion version_key based on published_dt

### DIFF
--- a/tests/ingestion/test_gtfs_converter.py
+++ b/tests/ingestion/test_gtfs_converter.py
@@ -1,6 +1,6 @@
 import os
 from queue import Queue
-from typing import Callable, Iterator, Optional, List, Dict
+from typing import Callable, Iterator, Optional, List, Dict, Tuple
 
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
@@ -359,9 +359,9 @@ def fixture_s3_patch(monkeypatch: MonkeyPatch) -> Iterator[None]:
         mock_write_parquet_file,
     )
 
-    def mock_gtfs_files_to_convert() -> List[str]:
+    def mock_gtfs_files_to_convert() -> List[Tuple[str, int]]:
         """provide list of gtfs paths to convert"""
-        return [os.path.join(incoming_dir, "MBTA_GTFS.zip")]
+        return [(os.path.join(incoming_dir, "MBTA_GTFS.zip"), 1655517536)]
 
     monkeypatch.setattr(
         "lamp_py.ingestion.convert_gtfs.gtfs_files_to_convert",


### PR DESCRIPTION
Our previous implementation of determining a `version_key` was based on the file modified datetime of the `feed_info.txt` file in a GTFS zip archive. This method does not work for ingesting GTFS schedule information from the archive feed. 

GTFS Schedules in the archive feed have their feed_info.txt files modified during the creation of the next GTFS schedule, to update the `feed_end_date` field. Because of this, we will base the `version_key` on the `published_dt` that is extracted from the `feed_version` text of the `feed_info.txt` file. 
