### PR TITLE
FIX: read_parquet dataset reading not adding hive partition columns

### DIFF
--- a/src/lamp_py/aws/s3.py
+++ b/src/lamp_py/aws/s3.py
@@ -586,7 +586,9 @@ def _get_pyarrow_dataset(
     else:
         to_load = [filename.replace("s3://", "")]
 
-    ds = pd.dataset(to_load, filesystem=active_fs)
+    # using hive partitioning as a default appears to have no negative effects
+    # on non-hive partitioned files/paths
+    ds = pd.dataset(to_load, filesystem=active_fs, partitioning="hive")
     if filters is not None:
         ds = ds.filter(filters)
 


### PR DESCRIPTION
There appears to have been a change in how pyarrow dataset's read file paths with hive partitioning values. 

static table ingestion has been failing because partition columns are no longer being added to final dataframes coming out of the `read_parquet` function. 