### PR TITLE
FIX: remove timestamp tz type from hyper type map

### DIFF
--- a/src/lamp_py/tableau/hyper.py
+++ b/src/lamp_py/tableau/hyper.py
@@ -111,8 +111,6 @@ class HyperJob(ABC):  # pylint: disable=R0902
             return SqlType.date()
 
         if dtype.startswith("timestamp"):
-            if "tz" in dtype:
-                return SqlType.timestamp_tz()
             return SqlType.timestamp()
 
         return SqlType.text()


### PR DESCRIPTION
I added this type when the alerts data had timezoned datetime fields. In talking to Heather about downstream user preferences, we decided to drop the timezone part of the datetimes and ensure they were formatted to Boston time.

This type was still being used when converting the types however, causing the alerts hyper job to fail on a mismatched type. Dropping it as its no longer needed and was causing issues.