### PR TITLE
UPDATE: Change partition key in alerts data

### DIFF
--- a/src/lamp_py/performance_manager/alerts.py
+++ b/src/lamp_py/performance_manager/alerts.py
@@ -142,7 +142,7 @@ class AlertParquetHandler:
         new_path = os.path.join("/tmp", "new_alerts.parquet")
         row_group_count = 0
 
-        partition_key = "last_modified_timestamp"
+        partition_key = "active_period.start_timestamp"
         partition_key_arr = joined_ds.to_table(columns=[partition_key]).column(
             partition_key
         )


### PR DESCRIPTION
Initially, the processed alerts archive was partitioned into row groups via the 'last_modified_timestamp' key. After hearing back from Transit Matters, change this key to the 'active_period.start_timestamp', which should improve the types of queries they run.