### PR TITLE
Add Versioning to Docker Images

### DIFF
--- a/.github/workflows/deploy-base.yaml
+++ b/.github/workflows/deploy-base.yaml
@@ -63,13 +63,21 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: us-east-1
+      - name: Extract version information
+        id: generate-version
+        run: |
+          git fetch --tags
+          VERSION=$(git tag --list "v[0-9]*.[0-9]*.[0-9]*" --sort=-v:refname | head -n 1)
+          SHA=$(git rev-parse --short HEAD)
+          FULL_VERSION="${VERSION}-${SHA}"
+          echo "version=${FULL_VERSION}" >> $GITHUB_ENV
       - name: Build and Push Docker Image
         id: build-push
         uses: mbta/actions/build-push-ecr@v2
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           docker-repo: ${{ secrets.DOCKER_REPO }}
-          dockerfile-path: .
+          docker-additional-args: --build-arg VERSION=${{ env.version }}
       - name: Deploy Ingestion Application
         id: deploy-ingestion
         if: ${{ inputs.deploy-ingestion }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,4 +48,10 @@ RUN if [ "$TARGETARCH" = "arm64" ]; then \
 # Copy src directory to run against and build lamp py
 COPY src src
 COPY alembic.ini alembic.ini
+
+# Add Version information as an argument, it is provided by GHA and left to the
+# default for local development.
+ARG VERSION="v0.0.0-unknown"
+RUN echo "VERSION = '${VERSION}'" > src/lamp_py/__version__.py
+
 RUN poetry install --no-dev --no-interaction --no-ansi -v

--- a/src/lamp_py/__version__.py
+++ b/src/lamp_py/__version__.py
@@ -1,0 +1,4 @@
+# this is just a stub needed for imports to work correctly.
+#
+# this file will be overwritten in a docker image
+VERSION = "v0.0.0-unknown"

--- a/src/lamp_py/runtime_utils/env_validation.py
+++ b/src/lamp_py/runtime_utils/env_validation.py
@@ -1,7 +1,8 @@
 import os
 from typing import Iterable, List, Optional
 
-from .process_logger import ProcessLogger
+from lamp_py.runtime_utils.process_logger import ProcessLogger
+from lamp_py.__version__ import VERSION
 
 
 def validate_environment(
@@ -19,6 +20,8 @@ def validate_environment(
 
     if private_variables is None:
         private_variables = []
+
+    metadata = {"lamp_version": VERSION}
 
     # every pipeline needs a service name for logging
     required_variables.append("SERVICE_NAME")
@@ -45,7 +48,7 @@ def validate_environment(
         # do not log private variables
         if key in private_variables:
             value = "**********"
-        process_logger.add_metadata(**{key: value})
+            metadata[key] = value
 
     # for optional variables, access ones that exist and add them to logs.
     if optional_variables:
@@ -55,7 +58,9 @@ def validate_environment(
                 # do not log private variables
                 if key in private_variables:
                     value = "**********"
-                process_logger.add_metadata(**{key: value})
+                metadata[key] = value
+
+    process_logger.add_metadata(**metadata)
 
     # if required variables are missing, log a failure and throw.
     if missing_required:


### PR DESCRIPTION
Add a `__version__.py`file to the lamp_py module. This file is left with a default value for local development. In our Dockerfile, overwrite this file with a passed in version argument, allowing the version to be set inside of the docker image. Update the deploy base github action to generate a unique version value for each deployment based on the latest version tag and current commit hash. Lastly, log the version when validating the environment.

Asana Task: [🛠️ Establish Version Logging & Versioning strategy](https://app.asana.com/0/1205827492903547/1206729585163530/f)
