### PR TITLE
FIX: Ingestion use send_metadata

### DIFF
--- a/src/lamp_py/ingestion/convert_gtfs_rt.py
+++ b/src/lamp_py/ingestion/convert_gtfs_rt.py
@@ -505,6 +505,7 @@ class GtfsRtConverter(Converter):
             log.add_metadata(local_path=local_path)
 
             self.write_local_pq(table, local_path)
+            self.send_metadata(local_path)
 
             log.log_complete()
 


### PR DESCRIPTION
I goofed and removed the send_metadata call for gtfs-rt ingestion