### PR TITLE
FEAT: Export compressed GTFS schedule to SQLITE db

### DIFF
--- a/src/lamp_py/ingestion/compress_gtfs/pipe.py
+++ b/src/lamp_py/ingestion/compress_gtfs/pipe.py
@@ -1,0 +1,4 @@
+from lamp_py.ingestion.compress_gtfs.gtfs_to_parquet import gtfs_to_parquet
+
+if __name__ == "__main__":
+    gtfs_to_parquet()

--- a/src/lamp_py/ingestion/compress_gtfs/pq_to_sqlite.py
+++ b/src/lamp_py/ingestion/compress_gtfs/pq_to_sqlite.py
@@ -40,7 +40,6 @@ def sqlite_table_query(table_name: str, schema: pyarrow.Schema) -> str:
             {','.join(field_list)}
         );
     """
-    logger.add_metadata(query=query)
     logger.log_complete()
     return query
 

--- a/src/lamp_py/ingestion/compress_gtfs/pq_to_sqlite.py
+++ b/src/lamp_py/ingestion/compress_gtfs/pq_to_sqlite.py
@@ -1,0 +1,83 @@
+import os
+import sqlite3
+
+import pyarrow
+import pyarrow.dataset as pd
+
+from lamp_py.runtime_utils.process_logger import ProcessLogger
+
+
+def sqlite_type(pq_type: str) -> str:
+    """
+    return SQLITE type from pyarrow Field type
+    """
+    if "int" in pq_type:
+        return "INTEGER"
+    if "bool" in pq_type:
+        return "INTEGER"
+    if "float" in pq_type:
+        return "REAL"
+    if "double" in pq_type:
+        return "REAL"
+    return "TEXT"
+
+
+def sqlite_table_query(table_name: str, schema: pyarrow.Schema) -> str:
+    """
+    return CREATE TABLE query for sqlite table from pyarrow schema
+    """
+    logger = ProcessLogger("sqlite_create_table")
+    logger.log_start()
+    field_list = [
+        f"{field.name} {sqlite_type(str(field.type))}" for field in schema
+    ]
+    query = f"""
+        CREATE TABLE 
+        IF NOT EXISTS 
+        {table_name}
+        (
+            {','.join(field_list)}
+        );
+    """
+    logger.add_metadata(query=query)
+    logger.log_complete()
+    return query
+
+
+def pq_folder_to_sqlite(year_path: str) -> None:
+    """
+    load all files from year_path folder into SQLITE3 db file
+    """
+    logger = ProcessLogger("pq_to_sqlite", year_path=year_path)
+    logger.log_start()
+
+    db_path = os.path.join(year_path, "GTFS_ARCHIVE.db")
+    if os.path.exists(db_path):
+        os.remove(db_path)
+    try:
+        for file in os.listdir(year_path):
+            if ".parquet" not in file:
+                continue
+            logger.add_metadata(current_file=file)
+            table = file.replace(".parquet", "")
+            file_path = os.path.join(year_path, file)
+
+            ds = pd.dataset(file_path)
+
+            columns = [f":{col}" for col in ds.schema.names]
+
+            conn = sqlite3.connect(db_path)
+            with conn:
+                conn.execute(sqlite_table_query(table, ds.schema))
+            with conn:
+                insert_query = (
+                    f"INSERT INTO {table} VALUES({','.join(columns)});"
+                )
+                for batch in ds.to_batches(batch_size=250_000):
+                    conn.executemany(insert_query, batch.to_pylist())
+
+            conn.close()
+
+        logger.log_complete()
+    except Exception as exception:
+        logger.log_failure(exception)

--- a/src/lamp_py/ingestion/compress_gtfs/schedule_details.py
+++ b/src/lamp_py/ingestion/compress_gtfs/schedule_details.py
@@ -229,6 +229,8 @@ def schedules_to_compress(tmp_folder: str) -> pl.DataFrame:
             s3_files = file_list_from_s3(bucket, prefix)
             if len(s3_files) > 1:
                 for obj_path in s3_files:
+                    if not obj_path.endswith(".parquet"):
+                        continue
                     local_path = obj_path.replace(f"s3://{bucket}", "/tmp")
                     download_file(obj_path, local_path)
             else:

--- a/src/lamp_py/ingestion/compress_gtfs/schedule_details.py
+++ b/src/lamp_py/ingestion/compress_gtfs/schedule_details.py
@@ -16,9 +16,15 @@ from lamp_py.ingestion.utils import (
     ordered_schedule_frame,
     file_as_bytes_buf,
 )
+from lamp_py.ingestion.compress_gtfs.gtfs_schema_map import gtfs_schema
+from lamp_py.aws.s3 import (
+    file_list_from_s3,
+    download_file,
+)
 
-
-from .gtfs_schema_map import gtfs_schema
+GTFS_PATH = os.path.join(
+    str(os.getenv("PUBLIC_ARCHIVE_BUCKET")), "lamp/gtfs_archive"
+)
 
 
 # pylint: disable=R0902
@@ -218,15 +224,39 @@ def schedules_to_compress(tmp_folder: str) -> pl.DataFrame:
 
         pq_fi_path = os.path.join(tmp_folder, year, "feed_info.parquet")
         if not os.path.exists(pq_fi_path):
-            # check for file in s3_path...
-            continue
+            bucket, prefix = GTFS_PATH.split("/", 1)
+            prefix = os.path.join(prefix, year)
+            s3_files = file_list_from_s3(bucket, prefix)
+            if len(s3_files) > 1:
+                for obj_path in s3_files:
+                    local_path = obj_path.replace(f"s3://{bucket}", "/tmp")
+                    download_file(obj_path, local_path)
+            else:
+                continue
 
         pq_fi_frame = pl.read_parquet(pq_fi_path)
 
-        # anti join against records for 'year' to find records not already in feed_info.parquet
-        feed = feed.filter(pl.col("published_date") > int(f"{year}0000")).join(
-            pq_fi_frame.select("feed_version"), on="feed_version", how="anti"
-        )
+        if int(year) <= 2018:
+            # different filter operation used for less than year 2018 because some
+            # schedules in this date range do not have matching "feed_version"
+            # values between `feed_info` file in schedule and "archived_feeds.txt" file
+            feed = feed.filter(
+                (pl.col("published_date") > int(f"{year}0000"))
+                & (
+                    pl.col("feed_start_date")
+                    > pq_fi_frame.get_column("feed_start_date").max()
+                )
+            )
+        else:
+            # anti join against records for 'year' to find records not already in feed_info.parquet
+            feed = feed.filter(
+                pl.col("published_date") > int(f"{year}0000")
+            ).join(
+                pq_fi_frame.select("feed_version"),
+                on="feed_version",
+                how="anti",
+                coalesce=True,
+            )
 
         break
 

--- a/src/lamp_py/ingestion/ingest_gtfs.py
+++ b/src/lamp_py/ingestion/ingest_gtfs.py
@@ -27,6 +27,7 @@ from lamp_py.ingestion.utils import (
     DEFAULT_S3_PREFIX,
     group_sort_file_list,
 )
+from lamp_py.ingestion.compress_gtfs.gtfs_to_parquet import gtfs_to_parquet
 
 
 class NoImplConverter(Converter):
@@ -138,5 +139,6 @@ def ingest_gtfs(metadata_queue: Queue[Optional[str]]) -> None:
 
     static schedule files should be ingested first
     """
+    gtfs_to_parquet()
     ingest_gtfs_archive(metadata_queue)
     ingest_s3_files(metadata_queue)

--- a/src/lamp_py/ingestion/pipeline.py
+++ b/src/lamp_py/ingestion/pipeline.py
@@ -65,6 +65,7 @@ def start() -> None:
             "ARCHIVE_BUCKET",
             "ERROR_BUCKET",
             "INCOMING_BUCKET",
+            "PUBLIC_ARCHIVE_BUCKET",
             "SPRINGBOARD_BUCKET",
             "ALEMBIC_MD_DB_NAME",
         ],

--- a/src/lamp_py/ingestion/utils.py
+++ b/src/lamp_py/ingestion/utils.py
@@ -168,9 +168,6 @@ def ordered_schedule_frame() -> pl.DataFrame:
         )
     )
 
-    # fix_me: filter for malformed archive schedules
-    feed = feed.filter(feed["feed_start_date"] > 20180200)
-
     return feed
 
 


### PR DESCRIPTION
This change adds the ability to export compressed GTFS schedule data to an SQLITE db file. 

For each year partition folder, in the compressed gtfs archives, one SQLITE db file will be produced that contains a table for each GTFS schedule file that has been compressed.

This implementation utilizes the python built-in sqlite3 library. Locally, I am able to produce each SQLITE db file in about 2 minutes. 

This change also has all of the S3 sync and upload logic to fully implement the compressed GTFS process. 

Asana Task: https://app.asana.com/0/1205827492903547/1207450430015372
