### PR TITLE
FIX: Retry logic for `write_to_parquet` method of `MSSQLManager`

### DIFF
--- a/src/lamp_py/mssql/mssql_utils.py
+++ b/src/lamp_py/mssql/mssql_utils.py
@@ -178,6 +178,7 @@ class MSSQLManager:
                             )
 
                 process_logger.log_complete()
+                break
 
             except Exception as exception:
                 if retry_attempts == max_retries:

--- a/src/lamp_py/mssql/mssql_utils.py
+++ b/src/lamp_py/mssql/mssql_utils.py
@@ -1,4 +1,5 @@
 import os
+import logging
 from typing import Any, Dict, List, Union
 
 import pyodbc
@@ -183,3 +184,5 @@ class MSSQLManager:
             except Exception as exception:
                 if retry_attempts == max_retries:
                     process_logger.log_failure(exception)
+                else:
+                    logging.exception(exception)


### PR DESCRIPTION
TM Ingestion `write_to_parquet` operations have been failing with the following error:

```
pyodbc.Error: ('40001', '[40001] [Microsoft][ODBC Driver 18 for SQL Server][SQL Server]Transaction (Process ID 63) was deadlocked on lock resources with another process and has been chosen as the deadlock victim. Rerun the transaction. (1205) (SQLFetch)')
```

This change adds retry logic to the `write_to_parquet` method of the `MSSQLManager` class in an effort to avoid the failure of these TM Ingestion table export jobs. 

Asana Task: https://app.asana.com/0/1205827492903547/1207692276182265
