### PR TITLE
Add Function to Choose Files for BPM Ingestion

### DIFF
--- a/src/lamp_py/bus_performance_manager/vehicle_events.py
+++ b/src/lamp_py/bus_performance_manager/vehicle_events.py
@@ -1,0 +1,133 @@
+import re
+from datetime import timedelta, date
+from typing import List, Tuple, Dict
+
+from lamp_py.aws.s3 import (
+    file_list_after,
+    file_list_from_s3,
+    get_datetime_from_partition_path,
+    get_last_modified_object,
+)
+
+from lamp_py.runtime_utils.remote_files import RemoteFileLocations
+
+
+class BusInputFiles:
+    """
+    small dataclass to keep track of vp files and tm files for a given service
+    date
+    """
+
+    def __init__(self, service_date: date):
+        self.service_date: date = service_date
+        self.vp_files: List[str] = []
+        self.tm_files: List[str] = []
+
+
+def get_new_event_files() -> Tuple[List[str], List[str]]:
+    """
+    get new realtime files from the vehicle position and transit master s3
+    locations that have been populated since the last time vehicle events were
+    processed.
+    """
+    latest_event_file = get_last_modified_object(
+        bucket_name=RemoteFileLocations.bus_events.bucket_name,
+        file_prefix=RemoteFileLocations.bus_events.file_prefix,
+        version="1.0",
+    )
+
+    if latest_event_file:
+        cutoff = latest_event_file["last_modified"] - timedelta(hours=1)
+        vp_files = file_list_after(
+            bucket_name=RemoteFileLocations.vehicle_positions.bucket_name,
+            file_prefix=RemoteFileLocations.vehicle_positions.file_prefix,
+            cutoff=cutoff,
+        )
+
+        tm_files = file_list_after(
+            bucket_name=RemoteFileLocations.tm_stop_crossing.bucket_name,
+            file_prefix=RemoteFileLocations.tm_stop_crossing.file_prefix,
+            cutoff=cutoff,
+        )
+
+    else:
+        vp_files = file_list_from_s3(
+            bucket_name=RemoteFileLocations.vehicle_positions.bucket_name,
+            file_prefix=RemoteFileLocations.vehicle_positions.file_prefix,
+        )
+
+        tm_files = file_list_from_s3(
+            bucket_name=RemoteFileLocations.tm_stop_crossing.bucket_name,
+            file_prefix=RemoteFileLocations.tm_stop_crossing.file_prefix,
+        )
+
+    return vp_files, tm_files
+
+
+def files_per_service_date(
+    vp_files: List[str], tm_files: List[str]
+) -> Dict[date, BusInputFiles]:
+    """
+    take a list of input files and bucket them based on the service date they
+    cover.
+    """
+
+    service_dates: Dict[date, BusInputFiles] = {}
+
+    def add_vp_file(service_date: date, vp_file: str) -> None:
+        """helper to add vp file to service dates"""
+        if service_date not in service_dates:
+            service_dates[service_date] = BusInputFiles(
+                service_date=service_date
+            )
+
+        service_dates[service_date].vp_files.append(vp_file)
+
+    def add_tm_file(service_date: date, tm_file: str) -> None:
+        """helper to add tm file to service dates"""
+        if service_date not in service_dates:
+            service_dates[service_date] = BusInputFiles(
+                service_date=service_date
+            )
+
+        service_dates[service_date].tm_files.append(tm_file)
+
+    # parse vp filepaths to infer service dates from the partition paths
+    for vp_file in vp_files:
+        file_datetime = get_datetime_from_partition_path(vp_file)
+
+        # if the partition is hourly (for older files), consider the hour of
+        # the file to determine the service date from the file datetime
+        if "hour" in vp_file:
+            if file_datetime.hour < 6:
+                yesterday = (file_datetime - timedelta(days=1)).date()
+                add_vp_file(yesterday, vp_file)
+            if file_datetime.hour > 3:
+                add_vp_file(file_datetime.date(), vp_file)
+        # if the partition is daily (for newer files), there will be data for
+        # the service date in the partition path and for data in the previous
+        # service date.
+        else:
+            yesterday = (file_datetime - timedelta(days=1)).date()
+            add_vp_file(yesterday, vp_file)
+            add_vp_file(file_datetime.date(), vp_file)
+
+    # parse the tm files to get the service date from the filename
+    for tm_file in tm_files:
+        try:
+            # files are formatted "1YYYYMMDD.parquet"
+            service_date_int = re.findall(r"(\d{8}).parquet", tm_file)[0]
+            year = int(service_date_int[:4])
+            month = int(service_date_int[4:6])
+            day = int(service_date_int[6:])
+
+            service_date = date(year=year, month=month, day=day)
+            add_tm_file(service_date, tm_file)
+        except IndexError:
+            # the tm files may have a lamp version file that will throw when
+            # pulling out a match from the regular expression. ask for
+            # forgiveness and assert that it was this file that caused the
+            # error.
+            assert "lamp_version" in tm_file
+
+    return service_dates

--- a/src/lamp_py/runtime_utils/remote_files.py
+++ b/src/lamp_py/runtime_utils/remote_files.py
@@ -28,7 +28,7 @@ class RemoteFileLocations:
     )
 
     # files ingested from tranist master
-    tm_prefix = file_prefix = os.path.join("lamp", "TM")
+    tm_prefix = os.path.join("lamp", "TM")
     tm_stop_crossing = S3Location(
         bucket_name=springboard_bucket,
         file_prefix=os.path.join(tm_prefix, "STOP_CROSSING"),

--- a/src/lamp_py/runtime_utils/remote_files.py
+++ b/src/lamp_py/runtime_utils/remote_files.py
@@ -1,0 +1,57 @@
+import os
+from dataclasses import dataclass
+
+
+@dataclass
+class S3Location:
+    """
+    wrapper for a bucket name and prefix pair used to define an s3 location
+    """
+
+    bucket_name: str
+    file_prefix: str
+
+
+class RemoteFileLocations:
+    """
+    Constant S3 File Locations Used in Bus Performance Manager
+    """
+
+    # define buckets that we put our data into, both public and private
+    springboard_bucket: str = os.environ.get("SPRINGBOARD_BUCKET", "")
+    public_bucket: str = os.environ.get("PUBLIC_ARCHIVE_BUCKET", "")
+
+    # files ingested from delta
+    vehicle_positions = S3Location(
+        bucket_name=springboard_bucket,
+        file_prefix=os.path.join("lamp", "RT_VEHICLE_POSITIONS"),
+    )
+
+    # files ingested from tranist master
+    tm_prefix = file_prefix = os.path.join("lamp", "TM")
+    tm_stop_crossing = S3Location(
+        bucket_name=springboard_bucket,
+        file_prefix=os.path.join(tm_prefix, "STOP_CROSSING"),
+    )
+    tm_geo_node_file = S3Location(
+        bucket_name=springboard_bucket,
+        file_prefix=os.path.join(tm_prefix, "TMMAIN_GEO_NODE.parquet"),
+    )
+    tm_route_file = S3Location(
+        bucket_name=springboard_bucket,
+        file_prefix=os.path.join(tm_prefix, "TMMAIN_ROUTE.parquet"),
+    )
+    tm_trip_file = S3Location(
+        bucket_name=springboard_bucket,
+        file_prefix=os.path.join(tm_prefix, "TMMAIN_TRIP.parquet"),
+    )
+    tm_vehicle_file = S3Location(
+        bucket_name=springboard_bucket,
+        file_prefix=os.path.join(tm_prefix, "TMMAIN_VEHICLE.parquet"),
+    )
+
+    # output of public bus events published by LAMP
+    bus_events = S3Location(
+        bucket_name=public_bucket,
+        file_prefix=os.path.join("lamp", "bus_vehicle_events"),
+    )


### PR DESCRIPTION
Add Function to Choose Files for BPM Ingestion 

Instead of using the metadata db, we plan on using last modified
timestamps on incoming buckets and comparing them with the last modified
timestamps on our outgoing vehicle event files.

* Create two new S3 Utilities
  * one gets the last modified file object in an s3 bucket / prefix.
  * one gets all of the files in a s3 bucket / prefix that have been
    modified after a given time.
* Create `remote_files.py` which will house the s3 location information
  for various files LAMP uses.
* Create `bus_performance_manager/vehicle_events.py` and create the
  function for collecting files that have been modified since the last
  update and a function that will group those files based on service
  date.

Asana Task: [🚌 Create function for choosing files for ingestion](https://github.com/mbta/lamp/commit/13851b8dfb5ac3338be37022cb2ca1ee28055394) 