### PR TITLE
FIX: name tableau dataset based on deploy environment

### DIFF
--- a/src/lamp_py/tableau/hyper.py
+++ b/src/lamp_py/tableau/hyper.py
@@ -44,7 +44,13 @@ class HyperJob(ABC):  # pylint: disable=R0902
         lamp_version: str,
         project_name: str = os.getenv("TABLEAU_PROJECT", ""),
     ) -> None:
+        environment = os.getenv("ECS_TASK_GROUP", "-").split("-")[-1]
+        if environment != "prod":
+            hyper_file_name = (
+                f"{hyper_file_name.replace('.hyper','')}_{environment}.hyper"
+            )
         self.hyper_file_name = hyper_file_name
+
         self.hyper_table_name = hyper_file_name.replace(".hyper", "")
         self.remote_parquet_path = remote_parquet_path
         self.lamp_version = lamp_version


### PR DESCRIPTION
Ops Analytics has requested that Tableau datasets have different names based on development environment (prod, staging, dev).

This change renames staging and dev environment datasets to append `_staging` or `_dev`. Production datasets names remain un-changed. 

Asana Task: https://app.asana.com/0/1205827492903547/1207800774457790
