### PR TITLE
Ingest More Transit Master Tables

### DIFF
--- a/src/lamp_py/ingestion_tm/ingest.py
+++ b/src/lamp_py/ingestion_tm/ingest.py
@@ -11,11 +11,11 @@ from lamp_py.ingestion_tm.jobs.whole_table import (
     TMMainOperator,
     TMMainRun,
     TMMainWorkPiece,
+    TMDailyLogDailySchedAdhereWaiver,
 )
 from lamp_py.ingestion_tm.jobs.parition_table import (
     TMDailyLogStopCrossing,
     TMDailyLogDailyWorkPiece,
-    TMDailyLogDailySchedAdhereWaiver,
 )
 
 

--- a/src/lamp_py/ingestion_tm/ingest.py
+++ b/src/lamp_py/ingestion_tm/ingest.py
@@ -7,8 +7,35 @@ from lamp_py.ingestion_tm.jobs.whole_table import (
     TMMainRoute,
     TMMainTrip,
     TMMainVehicle,
+    TMMainBlock,
+    TMMainOperator,
+    TMMainRun,
+    TMMainWorkPiece,
 )
-from lamp_py.ingestion_tm.jobs.parition_table import TMDailyLogStopCrossing
+from lamp_py.ingestion_tm.jobs.parition_table import (
+    TMDailyLogStopCrossing,
+    TMDailyLogDailyWorkPiece,
+    TMDailyLogDailySchedAdhereWaiver,
+)
+
+
+def get_ingestion_jobs() -> List[TMExport]:
+    """
+    get a list of all ingestion jobs that
+    """
+    return [
+        TMMainGeoNode(),
+        TMMainRoute(),
+        TMMainTrip(),
+        TMMainVehicle(),
+        TMMainBlock(),
+        TMMainOperator(),
+        TMMainRun(),
+        TMMainWorkPiece(),
+        TMDailyLogStopCrossing(),
+        TMDailyLogDailyWorkPiece(),
+        TMDailyLogDailySchedAdhereWaiver(),
+    ]
 
 
 def ingest_tables() -> None:
@@ -16,14 +43,7 @@ def ingest_tables() -> None:
     ingest tables from transmaster database
     """
     tm_db = MSSQLManager(verbose=True)
-
-    jobs: List[TMExport] = [
-        TMMainGeoNode(),
-        TMMainRoute(),
-        TMMainTrip(),
-        TMMainVehicle(),
-        TMDailyLogStopCrossing(),
-    ]
+    jobs: List[TMExport] = get_ingestion_jobs()
 
     for job in jobs:
         job.run_export(tm_db)

--- a/src/lamp_py/ingestion_tm/jobs/parition_table.py
+++ b/src/lamp_py/ingestion_tm/jobs/parition_table.py
@@ -160,12 +160,11 @@ class TMDailyTable(TMExport):
                     )
                     upload_file(local_pq, s3_export_path)
 
+                self.update_version_file()
                 logger.log_complete()
 
             except Exception as exception:
                 logger.log_failure(exception)
-
-        self.update_version_file()
 
 
 class TMDailyLogStopCrossing(TMDailyTable):
@@ -243,39 +242,5 @@ class TMDailyLogDailyWorkPiece(TMDailyTable):
                 ("ASSIGNED_VEHICLE_ID", pyarrow.int64()),
                 ("CURRENT_VEHICLE_ID", pyarrow.int64()),
                 ("INSERTED_FLAG", pyarrow.bool_()),
-            ]
-        )
-
-
-class TMDailyLogDailySchedAdhereWaiver(TMDailyTable):
-    """Export SCHED_ADHERE_WAIVER table from TMDailyLog"""
-
-    def __init__(self) -> None:
-        TMDailyTable.__init__(
-            self,
-            s3_location=RemoteFileLocations.tm_daily_sched_adherence_waiver,
-            tm_table="TMDailyLog.dbo.SCHED_ADHERE_WAIVER",
-            lamp_version="0.0.1",
-        )
-
-    @property
-    def export_schema(self) -> pyarrow.schema:
-        return pyarrow.schema(
-            [
-                ("WAIVER_ID", pyarrow.int64()),
-                ("CALENDAR_ID", pyarrow.int64()),
-                ("EARLY_ALLOWED_FLAG", pyarrow.int8()),
-                ("LATE_ALLOWED_FLAG", pyarrow.int8()),
-                ("CREATE_BY_DISPATCH_ID", pyarrow.int64()),
-                ("CREATE_DATETIME", pyarrow.timestamp("ms")),
-                ("ENDED_BY_DISPATCH_ID", pyarrow.int64()),
-                ("ENDED_DATE_TIME", pyarrow.timestamp("ms")),
-                ("REMARK", pyarrow.string()),
-                ("UPDATE_TIMESTAMP", pyarrow.timestamp("ms")),
-                ("MISSED_ALLOWED_FLAG", pyarrow.int8()),
-                ("NO_REVENUE_FLAG", pyarrow.bool_()),
-                ("WAIVER_TIMEOUT", pyarrow.int64()),
-                ("SCHEDULED_WAIVER_ID", pyarrow.int64()),
-                ("SERVICE_NOTICE_CAUSE_ID", pyarrow.int64()),
             ]
         )

--- a/src/lamp_py/ingestion_tm/jobs/parition_table.py
+++ b/src/lamp_py/ingestion_tm/jobs/parition_table.py
@@ -12,6 +12,8 @@ import sqlalchemy as sa
 from lamp_py.ingestion_tm.tm_export import TMExport
 from lamp_py.mssql.mssql_utils import MSSQLManager
 from lamp_py.runtime_utils.process_logger import ProcessLogger
+from lamp_py.runtime_utils.remote_files import RemoteFileLocations, S3Location
+
 from lamp_py.aws.s3 import (
     file_list_from_s3,
     upload_file,
@@ -19,19 +21,162 @@ from lamp_py.aws.s3 import (
 )
 
 
-class TMDailyLogStopCrossing(TMExport):
+class TMDailyTable(TMExport):
+    """Export Daily table from TMDailyLog"""
+
+    def __init__(
+        self,
+        s3_location: S3Location,
+        tm_table: str,
+        lamp_version: str,
+    ) -> None:
+        self.s3_location = s3_location
+        self.tm_table = tm_table
+        self.lamp_version = lamp_version
+        self.version_key = "lamp_version"
+        self.s3_version_path = os.path.join(
+            self.s3_location.get_s3_path(),
+            self.version_key,
+        )
+
+    def update_version_file(self) -> None:
+        """write version file to s3 for partition dataset"""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            local_version = os.path.join(temp_dir, self.version_key)
+
+            with open(local_version, "w", encoding="utf8") as f:
+                f.write(self.lamp_version)
+
+            upload_file(
+                file_name=local_version,
+                object_path=self.s3_version_path,
+                extra_args={"Metadata": {self.version_key: self.lamp_version}},
+            )
+
+    def dates_from_tm(self, tm_db: MSSQLManager) -> List[int]:
+        """
+        retrieve dates to process from Transit Master database
+
+        returns sorted list of CALENDAR_ID dates
+
+        :return [120240101, 120240102]
+        """
+        tm_dates_query = sa.text(
+            f"SELECT DISTINCT CALENDAR_ID FROM {self.tm_table};"
+        )
+        tm_dates = tm_db.select_as_dataframe(tm_dates_query)
+
+        return sorted(tm_dates["CALENDAR_ID"].astype(int).to_list())
+
+    def dates_from_s3(self) -> List[int]:
+        """
+        retrive list of already exported dates from S3 prefix
+
+        returns sorted list of CALENDAR_ID extracted from paths
+
+        :return [120240101, 120240102]
+        """
+        s3_files = file_list_from_s3(
+            self.s3_location.bucket_name, self.s3_location.file_prefix
+        )
+
+        def date_match(s: str) -> Optional[int]:
+            match = re.search(r"\d{9}", s)
+            if match:
+                return int(match.group())
+            return None
+
+        return sorted([s for s in map(date_match, s3_files) if s])
+
+    def dates_to_export(self, tm_db: MSSQLManager) -> List[int]:
+        """
+        compare S3 exported file dates to available dates in Transit Master
+        export any dates from Transit Master that are not found in S3 as well as
+        the last two dates found in Transit Master
+
+        if expected lamp_version does not match, return all available Transit Master dates
+
+        :return [120240101, 120240102]
+        """
+        s3_version = None
+        tm_dates = self.dates_from_tm(tm_db)
+
+        version_file = file_list_from_s3(
+            self.s3_location.bucket_name,
+            os.path.join(self.s3_location.file_prefix, self.version_key),
+        )
+        if len(version_file) == 1:
+            s3_version = object_metadata(self.s3_version_path).get(
+                self.version_key
+            )
+
+        if s3_version != self.lamp_version:
+            return tm_dates
+
+        s3_dates = self.dates_from_s3()
+
+        export_dates = set(tm_dates).difference(set(s3_dates))
+        export_dates.update(tm_dates[-2:])
+
+        return sorted(export_dates)
+
+    def run_export(self, tm_db: MSSQLManager) -> None:
+        table_columns = ",".join([col.name for col in self.export_schema])
+
+        for date in self.dates_to_export(tm_db):
+            try:
+                logger = ProcessLogger(
+                    "tm_daily_log_export", tm_table=self.tm_table, date=date
+                )
+                logger.log_start()
+
+                query = sa.text(
+                    f"""
+                    SELECT
+                        {table_columns}
+                    FROM
+                        {self.tm_table}
+                    WHERE 
+                        CALENDAR_ID = {date}
+                    ;
+                    """
+                )
+
+                s3_export_path = os.path.join(
+                    self.s3_location.get_s3_path(),
+                    f"{date}.parquet",
+                )
+
+                with tempfile.TemporaryDirectory() as temp_dir:
+                    local_pq = os.path.join(temp_dir, "out.parquet")
+                    tm_db.write_to_parquet(
+                        select_query=query,
+                        write_path=local_pq,
+                        schema=self.export_schema,
+                    )
+                    logger.add_metadata(
+                        last_export_path=s3_export_path,
+                        last_export_bytes=os.stat(local_pq).st_size,
+                    )
+                    upload_file(local_pq, s3_export_path)
+
+                logger.log_complete()
+
+            except Exception as exception:
+                logger.log_failure(exception)
+
+        self.update_version_file()
+
+
+class TMDailyLogStopCrossing(TMDailyTable):
     """Export STOP_CROSSING table from TMDailyLog"""
 
     def __init__(self) -> None:
-        TMExport.__init__(self)
-
-        self.s3_export_prefix = "lamp/TM/STOP_CROSSING"
-        self.lamp_version = "0.0.1"
-        self.version_key = "lamp_version"
-        self.s3_version_path = os.path.join(
-            self.export_bucket,
-            self.s3_export_prefix,
-            self.version_key,
+        TMDailyTable.__init__(
+            self,
+            s3_location=RemoteFileLocations.tm_stop_crossing,
+            tm_table="TMDailyLog.dbo.STOP_CROSSING",
+            lamp_version="0.0.1",
         )
 
     @property
@@ -67,123 +212,70 @@ class TMDailyLogStopCrossing(TMExport):
             ]
         )
 
-    def update_version_file(self) -> None:
-        """write version file to s3 for partition dataset"""
-        with tempfile.TemporaryDirectory() as temp_dir:
-            local_version = os.path.join(temp_dir, self.version_key)
 
-            with open(local_version, "w", encoding="utf8") as f:
-                f.write(self.lamp_version)
+class TMDailyLogDailyWorkPiece(TMDailyTable):
+    """Export DAILY_WORK_PIECE table from TMDailyLog"""
 
-            upload_file(
-                file_name=local_version,
-                object_path=self.s3_version_path,
-                extra_args={"Metadata": {self.version_key: self.lamp_version}},
-            )
-
-    def dates_from_tm(self, tm_db: MSSQLManager) -> List[int]:
-        """
-        retrieve dates to process from Transit Master database
-
-        returns sorted list of CALENDAR_ID dates
-
-        :return [120240101, 120240102]
-        """
-        tm_dates_query = sa.text(
-            "SELECT DISTINCT CALENDAR_ID FROM TMDailyLog.dbo.STOP_CROSSING;"
+    def __init__(self) -> None:
+        TMDailyTable.__init__(
+            self,
+            s3_location=RemoteFileLocations.tm_daily_work_piece,
+            tm_table="TMDailyLog.dbo.DAILY_WORK_PIECE",
+            lamp_version="0.0.1",
         )
-        tm_dates = tm_db.select_as_dataframe(tm_dates_query)
 
-        return sorted(tm_dates["CALENDAR_ID"].astype(int).to_list())
-
-    def dates_from_s3(self) -> List[int]:
-        """
-        retrive list of already exported dates from S3 prefix
-
-        returns sorted list of CALENDAR_ID extracted from paths
-
-        :return [120240101, 120240102]
-        """
-        s3_files = file_list_from_s3(self.export_bucket, self.s3_export_prefix)
-
-        def date_match(s: str) -> Optional[int]:
-            match = re.search(r"\d{9}", s)
-            if match:
-                return int(match.group())
-            return None
-
-        return sorted([s for s in map(date_match, s3_files) if s])
-
-    def dates_to_export(self, tm_db: MSSQLManager) -> List[int]:
-        """
-        compare S3 exported file dates to available dates in Transit Master
-        export any dates from Transit Master that are not found in S3 as well as
-        the last two dates found in Transit Master
-
-        if expected lamp_version does not match, return all available Transit Master dates
-
-        :return [120240101, 120240102]
-        """
-        s3_version = None
-        tm_dates = self.dates_from_tm(tm_db)
-
-        version_file = file_list_from_s3(
-            self.export_bucket,
-            os.path.join(self.s3_export_prefix, self.version_key),
+    @property
+    def export_schema(self) -> pyarrow.schema:
+        return pyarrow.schema(
+            [
+                ("DAILY_WORK_PIECE_ID", pyarrow.int64()),
+                ("WORK_PIECE_ID", pyarrow.int64()),
+                ("CALENDAR_ID", pyarrow.int64()),
+                ("ASSIGNED_OPERATOR_ID", pyarrow.int64()),
+                ("CURRENT_OPERATOR_ID", pyarrow.int64()),
+                ("SCHEDULED_LOGON_TIME", pyarrow.int64()),
+                ("SCHEDULED_LOGOFF_TIME", pyarrow.int64()),
+                ("ACTUAL_LOGON_TIME", pyarrow.int64()),
+                ("ACTUAL_LOGOFF_TIME", pyarrow.int64()),
+                ("ALARM_STATUS_ID", pyarrow.int64()),
+                ("PULLOUT_ID", pyarrow.int64()),
+                ("RUN_ID", pyarrow.int64()),
+                ("ASSIGNED_VEHICLE_ID", pyarrow.int64()),
+                ("CURRENT_VEHICLE_ID", pyarrow.int64()),
+                ("INSERTED_FLAG", pyarrow.bool_()),
+            ]
         )
-        if len(version_file) == 1:
-            s3_version = object_metadata(self.s3_version_path).get(
-                self.version_key
-            )
 
-        if s3_version != self.lamp_version:
-            return tm_dates
 
-        s3_dates = self.dates_from_s3()
+class TMDailyLogDailySchedAdhereWaiver(TMDailyTable):
+    """Export SCHED_ADHERE_WAIVER table from TMDailyLog"""
 
-        export_dates = set(tm_dates).difference(set(s3_dates))
-        export_dates.update(tm_dates[-2:])
+    def __init__(self) -> None:
+        TMDailyTable.__init__(
+            self,
+            s3_location=RemoteFileLocations.tm_daily_sched_adherence_waiver,
+            tm_table="TMDailyLog.dbo.SCHED_ADHERE_WAIVER",
+            lamp_version="0.0.1",
+        )
 
-        return sorted(export_dates)
-
-    def run_export(self, tm_db: MSSQLManager) -> None:
-        table_columns = ",".join([col.name for col in self.export_schema])
-
-        logger = ProcessLogger("tm_stop_crossing_export")
-        logger.log_start()
-        try:
-            for date in self.dates_to_export(tm_db):
-                query = sa.text(
-                    f"""
-                    SELECT
-                        {table_columns}
-                    FROM 
-                        TMDailyLog.dbo.STOP_CROSSING
-                    WHERE 
-                        CALENDAR_ID = {date}
-                    ;
-                    """
-                )
-                s3_export_path = os.path.join(
-                    self.export_bucket,
-                    self.s3_export_prefix,
-                    f"{date}.parquet",
-                )
-                with tempfile.TemporaryDirectory() as temp_dir:
-                    local_pq = os.path.join(temp_dir, "out.parquet")
-                    tm_db.write_to_parquet(
-                        select_query=query,
-                        write_path=local_pq,
-                        schema=self.export_schema,
-                    )
-                    logger.add_metadata(
-                        last_export_path=s3_export_path,
-                        last_export_bytes=os.stat(local_pq).st_size,
-                    )
-                    upload_file(local_pq, s3_export_path)
-
-            self.update_version_file()
-            logger.log_complete()
-
-        except Exception as exception:
-            logger.log_failure(exception)
+    @property
+    def export_schema(self) -> pyarrow.schema:
+        return pyarrow.schema(
+            [
+                ("WAIVER_ID", pyarrow.int64()),
+                ("CALENDAR_ID", pyarrow.int64()),
+                ("EARLY_ALLOWED_FLAG", pyarrow.int8()),
+                ("LATE_ALLOWED_FLAG", pyarrow.int8()),
+                ("CREATE_BY_DISPATCH_ID", pyarrow.int64()),
+                ("CREATE_DATETIME", pyarrow.timestamp("ms")),
+                ("ENDED_BY_DISPATCH_ID", pyarrow.int64()),
+                ("ENDED_DATE_TIME", pyarrow.timestamp("ms")),
+                ("REMARK", pyarrow.string()),
+                ("UPDATE_TIMESTAMP", pyarrow.timestamp("ms")),
+                ("MISSED_ALLOWED_FLAG", pyarrow.int8()),
+                ("NO_REVENUE_FLAG", pyarrow.bool_()),
+                ("WAIVER_TIMEOUT", pyarrow.int64()),
+                ("SCHEDULED_WAIVER_ID", pyarrow.int64()),
+                ("SERVICE_NOTICE_CAUSE_ID", pyarrow.int64()),
+            ]
+        )

--- a/src/lamp_py/ingestion_tm/jobs/whole_table.py
+++ b/src/lamp_py/ingestion_tm/jobs/whole_table.py
@@ -7,6 +7,7 @@ import sqlalchemy as sa
 from lamp_py.ingestion_tm.tm_export import TMExport
 from lamp_py.mssql.mssql_utils import MSSQLManager
 from lamp_py.runtime_utils.process_logger import ProcessLogger
+from lamp_py.runtime_utils.remote_files import S3Location, RemoteFileLocations
 from lamp_py.aws.s3 import upload_file
 
 
@@ -15,19 +16,11 @@ class TMWholeTable(TMExport):
 
     def __init__(
         self,
-        pq_file_name: str,
+        s3_location: S3Location,
         tm_table: str,
     ) -> None:
-        TMExport.__init__(self)
-
+        self.s3_location = s3_location
         self.tm_table = tm_table
-        self.remote_parquet_path = (
-            f"s3://{self.export_bucket}/lamp/TM/{pq_file_name}"
-        )
-
-    @property
-    def export_schema(self) -> pyarrow.schema:
-        """Schema for export"""
 
     def run_export(self, tm_db: MSSQLManager) -> None:
         table_columns = ",".join([col.name for col in self.export_schema])
@@ -47,7 +40,7 @@ class TMWholeTable(TMExport):
                 logger.add_metadata(
                     pq_export_bytes=os.stat(local_export_path).st_size
                 )
-                upload_file(local_export_path, self.remote_parquet_path)
+                upload_file(local_export_path, self.s3_location.get_s3_path())
                 logger.log_complete()
 
         except Exception as exception:
@@ -60,7 +53,7 @@ class TMMainGeoNode(TMWholeTable):
     def __init__(self) -> None:
         TMWholeTable.__init__(
             self,
-            pq_file_name="TMMAIN_GEO_NODE.parquet",
+            s3_location=RemoteFileLocations.tm_geo_node_file,
             tm_table="TMMain.dbo.GEO_NODE",
         )
 
@@ -108,7 +101,7 @@ class TMMainTrip(TMWholeTable):
     def __init__(self) -> None:
         TMWholeTable.__init__(
             self,
-            pq_file_name="TMMAIN_TRIP.parquet",
+            s3_location=RemoteFileLocations.tm_trip_file,
             tm_table="TMMain.dbo.TRIP",
         )
 
@@ -143,7 +136,7 @@ class TMMainRoute(TMWholeTable):
     def __init__(self) -> None:
         TMWholeTable.__init__(
             self,
-            pq_file_name="TMMAIN_ROUTE.parquet",
+            s3_location=RemoteFileLocations.tm_route_file,
             tm_table="TMMain.dbo.ROUTE",
         )
 
@@ -169,7 +162,7 @@ class TMMainVehicle(TMWholeTable):
     def __init__(self) -> None:
         TMWholeTable.__init__(
             self,
-            pq_file_name="TMMAIN_VEHICLE.parquet",
+            s3_location=RemoteFileLocations.tm_vehicle_file,
             tm_table="TMMain.dbo.VEHICLE",
         )
 
@@ -214,5 +207,126 @@ class TMMainVehicle(TMWholeTable):
                 ("COLLECT_APC_DATA", pyarrow.bool_()),
                 ("TSP_DEVICE_ID", pyarrow.string()),
                 ("RADIO_DEVICE_ID", pyarrow.string()),
+            ]
+        )
+
+
+class TMMainOperator(TMWholeTable):
+    """Export OPERATOR table from TMMain"""
+
+    def __init__(self) -> None:
+        TMWholeTable.__init__(
+            self,
+            s3_location=RemoteFileLocations.tm_operator_file,
+            tm_table="TMMain.dbo.OPERATOR",
+        )
+
+    @property
+    def export_schema(self) -> pyarrow.schema:
+        return pyarrow.schema(
+            [
+                ("OPERATOR_ID", pyarrow.int64()),
+                ("ONBOARD_LOGON_ID", pyarrow.int64()),
+                ("BADGE", pyarrow.string()),
+                ("FIRST_NAME", pyarrow.string()),
+                ("MIDDLE_NAME", pyarrow.string()),
+                ("LAST_NAME", pyarrow.string()),
+                ("TRANSIT_DIV_ID", pyarrow.int64()),
+                ("DIVISION", pyarrow.string()),
+                ("DEPARTMENT", pyarrow.string()),
+                ("ACTIVATION_DATE", pyarrow.timestamp("ms")),
+                ("DEACTIVATION_DATE", pyarrow.timestamp("ms")),
+                ("OPERATOR_TYPE_ID", pyarrow.int64()),
+            ]
+        )
+
+
+class TMMainRun(TMWholeTable):
+    """Export RUN table from TMMain"""
+
+    def __init__(self) -> None:
+        TMWholeTable.__init__(
+            self,
+            s3_location=RemoteFileLocations.tm_run_file,
+            tm_table="TMMain.dbo.RUN",
+        )
+
+    @property
+    def export_schema(self) -> pyarrow.schema:
+        return pyarrow.schema(
+            [
+                ("RUN_ID", pyarrow.int64()),
+                ("RUN_DESIGNATOR", pyarrow.string()),
+                ("RUN_TYPE_ID", pyarrow.int64()),
+                ("SERVICE_TYPE_ID", pyarrow.int64()),
+                ("TRANSIT_DIV_ID", pyarrow.int64()),
+                ("TIME_TABLE_VERSION_ID", pyarrow.int64()),
+                ("RUN_NUM", pyarrow.int64()),
+                ("MDT_RUN_ID", pyarrow.int64()),
+                ("MASTER_RUN_ID", pyarrow.int64()),
+            ]
+        )
+
+
+class TMMainBlock(TMWholeTable):
+    """Export BLOCK table from TMMain"""
+
+    def __init__(self) -> None:
+        TMWholeTable.__init__(
+            self,
+            s3_location=RemoteFileLocations.tm_block_file,
+            tm_table="TMMain.dbo.BLOCK",
+        )
+
+    @property
+    def export_schema(self) -> pyarrow.schema:
+        return pyarrow.schema(
+            [
+                ("BLOCK_ID", pyarrow.int64()),
+                ("TIME_TABLE_VERSION_ID", pyarrow.int64()),
+                ("VEHICLE_ID", pyarrow.int64()),
+                ("TRANSIT_DIV_ID", pyarrow.int64()),
+                ("BLOCK_ABBR", pyarrow.string()),
+                ("BLOCK_NUM", pyarrow.int64()),
+                ("SERVICE_TYPE_ID", pyarrow.int64()),
+                ("VEHICLE_TYPE_ID", pyarrow.int64()),
+                ("PADDLE_NOTES", pyarrow.string()),
+                ("MDT_BLOCK_ID", pyarrow.int64()),
+                ("SOURCE_BLOCK_ID", pyarrow.int64()),
+                ("MASTER_BLOCK_ID", pyarrow.int64()),
+                ("VEHICLE_ATTRIBUTES_REQUIRED", pyarrow.string()),
+                ("OPERATING_MODE_ID", pyarrow.int64()),
+                ("AGENCY_ID", pyarrow.int64()),
+            ]
+        )
+
+
+class TMMainWorkPiece(TMWholeTable):
+    """Export WORK_PIECE table from TMMain"""
+
+    def __init__(self) -> None:
+        TMWholeTable.__init__(
+            self,
+            s3_location=RemoteFileLocations.tm_work_piece_file,
+            tm_table="TMMain.dbo.WORK_PIECE",
+        )
+
+    @property
+    def export_schema(self) -> pyarrow.schema:
+        return pyarrow.schema(
+            [
+                ("WORK_PIECE_ID", pyarrow.int64()),
+                ("TIME_TABLE_VERSION_ID", pyarrow.int64()),
+                ("RUN_ID", pyarrow.int64()),
+                ("OPERATING_TIME_ID", pyarrow.int64()),
+                ("PAY_ID", pyarrow.int64()),
+                ("BEGIN_TIME", pyarrow.int64()),
+                ("END_TIME", pyarrow.int64()),
+                ("BLOCK_ID", pyarrow.int64()),
+                ("SERVICE_TYPE_ID", pyarrow.int64()),
+                ("REPORT_TIME", pyarrow.int64()),
+                ("CLEAR_TIME", pyarrow.int64()),
+                ("EXC_COMBO_ID", pyarrow.int64()),
+                ("AGENCY_ID", pyarrow.int64()),
             ]
         )

--- a/src/lamp_py/ingestion_tm/jobs/whole_table.py
+++ b/src/lamp_py/ingestion_tm/jobs/whole_table.py
@@ -330,3 +330,36 @@ class TMMainWorkPiece(TMWholeTable):
                 ("AGENCY_ID", pyarrow.int64()),
             ]
         )
+
+
+class TMDailyLogDailySchedAdhereWaiver(TMWholeTable):
+    """Export SCHED_ADHERE_WAIVER table from TMDailyLog"""
+
+    def __init__(self) -> None:
+        TMWholeTable.__init__(
+            self,
+            s3_location=RemoteFileLocations.tm_daily_sched_adherence_waiver_file,
+            tm_table="TMDailyLog.dbo.SCHED_ADHERE_WAIVER",
+        )
+
+    @property
+    def export_schema(self) -> pyarrow.schema:
+        return pyarrow.schema(
+            [
+                ("WAIVER_ID", pyarrow.int64()),
+                ("CALENDAR_ID", pyarrow.int64()),
+                ("EARLY_ALLOWED_FLAG", pyarrow.int8()),
+                ("LATE_ALLOWED_FLAG", pyarrow.int8()),
+                ("CREATE_BY_DISPATCH_ID", pyarrow.int64()),
+                ("CREATE_DATETIME", pyarrow.timestamp("ms")),
+                ("ENDED_BY_DISPATCH_ID", pyarrow.int64()),
+                ("ENDED_DATE_TIME", pyarrow.timestamp("ms")),
+                ("REMARK", pyarrow.string()),
+                ("UPDATE_TIMESTAMP", pyarrow.timestamp("ms")),
+                ("MISSED_ALLOWED_FLAG", pyarrow.int8()),
+                ("NO_REVENUE_FLAG", pyarrow.bool_()),
+                ("WAIVER_TIMEOUT", pyarrow.int64()),
+                ("SCHEDULED_WAIVER_ID", pyarrow.int64()),
+                ("SERVICE_NOTICE_CAUSE_ID", pyarrow.int64()),
+            ]
+        )

--- a/src/lamp_py/ingestion_tm/tm_export.py
+++ b/src/lamp_py/ingestion_tm/tm_export.py
@@ -1,4 +1,3 @@
-import os
 from abc import ABC
 from abc import abstractmethod
 
@@ -11,11 +10,6 @@ class TMExport(ABC):
     """
     Abstract Base Class for TM Export jobs
     """
-
-    def __init__(
-        self,
-    ) -> None:
-        self.export_bucket = os.getenv("SPRINGBOARD_BUCKET")
 
     @property
     @abstractmethod

--- a/src/lamp_py/mssql/mssql_utils.py
+++ b/src/lamp_py/mssql/mssql_utils.py
@@ -186,3 +186,4 @@ class MSSQLManager:
                     process_logger.log_failure(exception)
                 else:
                     logging.exception(exception)
+                    raise exception

--- a/src/lamp_py/mssql/mssql_utils.py
+++ b/src/lamp_py/mssql/mssql_utils.py
@@ -184,6 +184,5 @@ class MSSQLManager:
             except Exception as exception:
                 if retry_attempts == max_retries:
                     process_logger.log_failure(exception)
-                else:
-                    logging.exception(exception)
                     raise exception
+                logging.exception(exception)

--- a/src/lamp_py/runtime_utils/remote_files.py
+++ b/src/lamp_py/runtime_utils/remote_files.py
@@ -37,6 +37,14 @@ class RemoteFileLocations:
         bucket_name=springboard_bucket,
         file_prefix=os.path.join(tm_prefix, "STOP_CROSSING"),
     )
+    tm_daily_work_piece = S3Location(
+        bucket_name=springboard_bucket,
+        file_prefix=os.path.join(tm_prefix, "DAILY_WORK_PIECE"),
+    )
+    tm_daily_sched_adherence_waiver = S3Location(
+        bucket_name=springboard_bucket,
+        file_prefix=os.path.join(tm_prefix, "DAILY_SCHED_ADHERE_WAIVER"),
+    )
     tm_geo_node_file = S3Location(
         bucket_name=springboard_bucket,
         file_prefix=os.path.join(tm_prefix, "TMMAIN_GEO_NODE.parquet"),
@@ -52,6 +60,22 @@ class RemoteFileLocations:
     tm_vehicle_file = S3Location(
         bucket_name=springboard_bucket,
         file_prefix=os.path.join(tm_prefix, "TMMAIN_VEHICLE.parquet"),
+    )
+    tm_operator_file = S3Location(
+        bucket_name=springboard_bucket,
+        file_prefix=os.path.join(tm_prefix, "TMMAIN_OPERATOR.parquet"),
+    )
+    tm_run_file = S3Location(
+        bucket_name=springboard_bucket,
+        file_prefix=os.path.join(tm_prefix, "TMMAIN_RUN.parquet"),
+    )
+    tm_block_file = S3Location(
+        bucket_name=springboard_bucket,
+        file_prefix=os.path.join(tm_prefix, "TMMAIN_BLOCK.parquet"),
+    )
+    tm_work_piece_file = S3Location(
+        bucket_name=springboard_bucket,
+        file_prefix=os.path.join(tm_prefix, "TMMAIN_WORK_PIECE.parquet"),
     )
 
     # output of public bus events published by LAMP

--- a/src/lamp_py/runtime_utils/remote_files.py
+++ b/src/lamp_py/runtime_utils/remote_files.py
@@ -41,9 +41,11 @@ class RemoteFileLocations:
         bucket_name=springboard_bucket,
         file_prefix=os.path.join(tm_prefix, "DAILY_WORK_PIECE"),
     )
-    tm_daily_sched_adherence_waiver = S3Location(
+    tm_daily_sched_adherence_waiver_file = S3Location(
         bucket_name=springboard_bucket,
-        file_prefix=os.path.join(tm_prefix, "DAILY_SCHED_ADHERE_WAIVER"),
+        file_prefix=os.path.join(
+            tm_prefix, "DAILY_SCHED_ADHERE_WAIVER.parquet"
+        ),
     )
     tm_geo_node_file = S3Location(
         bucket_name=springboard_bucket,

--- a/tests/ingestion_tm/test_ingest.py
+++ b/tests/ingestion_tm/test_ingest.py
@@ -1,0 +1,40 @@
+import inspect
+from typing import Set, List
+
+from lamp_py.ingestion_tm.tm_export import TMExport
+from lamp_py.ingestion_tm.ingest import get_ingestion_jobs
+
+
+def get_tm_export_subclasses(
+    cls: type[TMExport] = TMExport,
+) -> Set[type[TMExport]]:
+    """
+    recursively get all of the concrete TMExport child classes
+    """
+    subclasses: List[type[TMExport]] = []
+    for subclass in cls.__subclasses__():
+        if inspect.isabstract(subclass):
+            subclasses += get_tm_export_subclasses(subclass)
+        else:
+            subclasses.append(subclass)
+
+    return set(subclasses)
+
+
+def test_ingestion_job_count() -> None:
+    """
+    test that the ingestion pipeline is aware of each tm export class
+    """
+    # get all of the jobs run in ingestion, assert its not empty
+    ingestion_jobs = get_ingestion_jobs()
+    job_types = {type(job) for job in ingestion_jobs}
+    assert job_types
+
+    # get all potential jobs based on subclasses. assert its not empty
+    all_job_types = get_tm_export_subclasses()
+    assert all_job_types
+
+    # ensure all job types are accounted for in ingestion
+    assert (
+        all_job_types == job_types
+    ), f"Missing instances for subclasses: {all_job_types - job_types}"


### PR DESCRIPTION
* Add Block, Operator, Run and WorkPiece to the whole table ingestion jobs.
* Create new abstract base class `TMDailyTable` that will pull in daily tables from transit master. (Its largely an abstraction based on the existing `TMDailyLogStopCrossing` class.
* Add Daily Work Piece and Schedule Adherence Waiver tables to the daily log jobs.
* All TM Ingestion jobs now use Remote File Location constants to define s3 locations.
* Add tests to ensure all TM Ingestion Jobs are run in the pipeline.

Asana Task: [🚌 Ingest TM data for block, run, & operator](https://app.asana.com/0/1205827492903547/1207935724478899/f)
