### PR TITLE
FEAT: S3 remote file paths in one location

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1876,6 +1876,24 @@ pytest = ">=4.6"
 testing = ["fields", "hunter", "process-tests", "pytest-xdist", "virtualenv"]
 
 [[package]]
+name = "pytest-env"
+version = "1.1.3"
+description = "pytest plugin that allows you to add environment variables."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pytest_env-1.1.3-py3-none-any.whl", hash = "sha256:aada77e6d09fcfb04540a6e462c58533c37df35fa853da78707b17ec04d17dfc"},
+    {file = "pytest_env-1.1.3.tar.gz", hash = "sha256:fcd7dc23bb71efd3d35632bde1bbe5ee8c8dc4489d6617fb010674880d96216b"},
+]
+
+[package.dependencies]
+pytest = ">=7.4.3"
+tomli = {version = ">=2.0.1", markers = "python_version < \"3.11\""}
+
+[package.extras]
+test = ["covdefaults (>=2.3)", "coverage (>=7.3.2)", "pytest-mock (>=3.12)"]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 description = "Extensions to the standard Python datetime module"
@@ -2394,4 +2412,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "a306b42eaf146c41563b9a09cf28c009208759bf4d714805c497d7e061b654ff"
+content-hash = "fd61547460b7e898737475250cdb0085a3659c28976bda0a074b0bb234eb22b5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ pylint = "^3.2.2"
 pytest = "^8.2.1"
 pytest-cov = "^5.0.0"
 types-python-dateutil = "^2.9.0.20240316"
+pytest-env = "^1.1.3"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]
@@ -76,6 +77,13 @@ warn_unused_ignores = true
 log_cli = true
 log_cli_level = "DEBUG"
 verbose = true
+
+[tool.pytest.ini_options]
+env = [
+  "SPRINGBOARD_BUCKET=SPRINGBOARD",
+  "PUBLIC_ARCHIVE_BUCKET=PUBLIC_ARCHIVE",
+  "INCOMING_BUCKET=INCOMING",
+]
 
 [tool.pylint]
 disable = [

--- a/src/lamp_py/bus_performance_manager/gtfs.py
+++ b/src/lamp_py/bus_performance_manager/gtfs.py
@@ -4,7 +4,7 @@ from datetime import date
 
 import polars as pl
 
-from lamp_py.runtime_utils.remote_files import RemoteFileLocations
+from lamp_py.runtime_utils.remote_files import compressed_gtfs
 from lamp_py.aws.s3 import file_list_from_s3, download_file
 from lamp_py.performance_manager.gtfs_utils import start_time_to_seconds
 from lamp_py.runtime_utils.process_logger import ProcessLogger
@@ -37,10 +37,8 @@ def sync_gtfs_files(service_date: date) -> None:
     os.makedirs(gtfs_date_folder, exist_ok=True)
 
     s3_objects = file_list_from_s3(
-        bucket_name=RemoteFileLocations.compressed_gtfs.bucket_name,
-        file_prefix=os.path.join(
-            RemoteFileLocations.compressed_gtfs.file_prefix, str(gtfs_year)
-        ),
+        bucket_name=compressed_gtfs.bucket,
+        file_prefix=os.path.join(compressed_gtfs.prefix, str(gtfs_year)),
     )
 
     # check previous calendar year for s3_files, if none for current year
@@ -50,10 +48,8 @@ def sync_gtfs_files(service_date: date) -> None:
         gtfs_year -= 1
 
         s3_objects = file_list_from_s3(
-            bucket_name=RemoteFileLocations.compressed_gtfs.bucket_name,
-            file_prefix=os.path.join(
-                RemoteFileLocations.compressed_gtfs.file_prefix, str(gtfs_year)
-            ),
+            bucket_name=compressed_gtfs.bucket,
+            file_prefix=os.path.join(compressed_gtfs.prefix, str(gtfs_year)),
         )
 
         if len(s3_objects) == 0:

--- a/src/lamp_py/bus_performance_manager/gtfs_utils.py
+++ b/src/lamp_py/bus_performance_manager/gtfs_utils.py
@@ -3,27 +3,28 @@ from typing import List
 
 import polars as pl
 
-from lamp_py.runtime_utils.remote_files import get_gtfs_parquet_file
+from lamp_py.runtime_utils.remote_files import compressed_gtfs
 
 
 def bus_routes_for_service_date(service_date: date) -> List[str]:
     """get a list of bus route ids for a given service date"""
-    routes_file = get_gtfs_parquet_file(
-        year=service_date.year, filename="routes.parquet"
-    ).get_s3_path()
+    routes_file = compressed_gtfs.parquet_path(
+        year=service_date.year, file="routes"
+    ).s3_uri
 
     # generate an integer date for the service date
     target_date = int(service_date.strftime("%Y%m%d"))
 
     bus_routes = (
         pl.scan_parquet(routes_file)
-        .select(["route_id", "route_type", "gtfs_active_date", "gtfs_end_date"])
         .filter(
             (pl.col("gtfs_active_date") <= target_date)
             & (pl.col("gtfs_end_date") >= target_date)
             & (pl.col("route_type") == 3)
         )
+        .select("route_id")
+        .unique()
         .collect()
     )
 
-    return bus_routes["route_id"].unique().to_list()
+    return bus_routes.get_column("route_id").to_list()

--- a/src/lamp_py/bus_performance_manager/vehicle_events.py
+++ b/src/lamp_py/bus_performance_manager/vehicle_events.py
@@ -11,7 +11,9 @@ from lamp_py.aws.s3 import (
 )
 
 from lamp_py.runtime_utils.remote_files import (
-    RemoteFileLocations,
+    rt_vehicle_positions,
+    tm_stop_crossing,
+    bus_events,
 )
 
 
@@ -54,8 +56,8 @@ def get_new_event_files() -> List[Dict[str, date | List[str]]]:
     # modified datetime. convert to a dataframe and generate a service date
     # from the partition paths. add a source column for later merging.
     vp_objects = file_list_from_s3_with_details(
-        bucket_name=RemoteFileLocations.vehicle_positions.bucket_name,
-        file_prefix=RemoteFileLocations.vehicle_positions.file_prefix,
+        bucket_name=rt_vehicle_positions.bucket,
+        file_prefix=rt_vehicle_positions.prefix,
     )
     vp_df = pl.DataFrame(vp_objects).with_columns(
         pl.col("s3_obj_path")
@@ -111,8 +113,8 @@ def get_new_event_files() -> List[Dict[str, date | List[str]]]:
     # modified datetime. convert to a dataframe and generate a service date
     # from the filename. add a source column for later merging.
     tm_objects = file_list_from_s3_with_details(
-        bucket_name=RemoteFileLocations.tm_stop_crossing.bucket_name,
-        file_prefix=RemoteFileLocations.tm_stop_crossing.file_prefix,
+        bucket_name=tm_stop_crossing.bucket,
+        file_prefix=tm_stop_crossing.prefix,
     )
     tm_df = pl.DataFrame(tm_objects).with_columns(
         pl.col("s3_obj_path")
@@ -126,8 +128,8 @@ def get_new_event_files() -> List[Dict[str, date | List[str]]]:
 
     # get the last modified object in the output file s3 location
     latest_event_file = get_last_modified_object(
-        bucket_name=RemoteFileLocations.bus_events.bucket_name,
-        file_prefix=RemoteFileLocations.bus_events.file_prefix,
+        bucket_name=bus_events.bucket,
+        file_prefix=bus_events.prefix,
         version="1.0",
     )
 

--- a/src/lamp_py/ingestion/compress_gtfs/schedule_details.py
+++ b/src/lamp_py/ingestion/compress_gtfs/schedule_details.py
@@ -21,10 +21,7 @@ from lamp_py.aws.s3 import (
     file_list_from_s3,
     download_file,
 )
-
-GTFS_PATH = os.path.join(
-    str(os.getenv("PUBLIC_ARCHIVE_BUCKET")), "lamp/gtfs_archive"
-)
+from lamp_py.runtime_utils.remote_files import compressed_gtfs
 
 
 # pylint: disable=R0902
@@ -224,14 +221,15 @@ def schedules_to_compress(tmp_folder: str) -> pl.DataFrame:
 
         pq_fi_path = os.path.join(tmp_folder, year, "feed_info.parquet")
         if not os.path.exists(pq_fi_path):
-            bucket, prefix = GTFS_PATH.split("/", 1)
-            prefix = os.path.join(prefix, year)
-            s3_files = file_list_from_s3(bucket, prefix)
+            prefix = os.path.join(compressed_gtfs.prefix, year)
+            s3_files = file_list_from_s3(compressed_gtfs.bucket, prefix)
             if len(s3_files) > 1:
                 for obj_path in s3_files:
                     if not obj_path.endswith(".parquet"):
                         continue
-                    local_path = obj_path.replace(f"s3://{bucket}", "/tmp")
+                    local_path = obj_path.replace(
+                        f"s3://{compressed_gtfs.bucket}", "/tmp"
+                    )
                     download_file(obj_path, local_path)
             else:
                 continue

--- a/src/lamp_py/ingestion/convert_gtfs.py
+++ b/src/lamp_py/ingestion/convert_gtfs.py
@@ -17,8 +17,11 @@ from lamp_py.ingestion.utils import (
     ordered_schedule_frame,
     file_as_bytes_buf,
 )
+from lamp_py.runtime_utils.remote_files import (
+    S3_SPRINGBOARD,
+    LAMP,
+)
 from .converter import Converter
-from .utils import DEFAULT_S3_PREFIX
 
 
 def gtfs_files_to_convert() -> List[Tuple[str, int]]:
@@ -30,8 +33,8 @@ def gtfs_files_to_convert() -> List[Tuple[str, int]]:
     mbta_schedule_feed = ordered_schedule_frame()
 
     last_s3_pq = file_list_from_s3(
-        bucket_name=os.getenv("SPRINGBOARD_BUCKET"),
-        file_prefix="lamp/FEED_INFO/",
+        bucket_name=S3_SPRINGBOARD,
+        file_prefix=f"{LAMP}/FEED_INFO/",
     )[-1:]
     if len(last_s3_pq) > 0:
         last_s3_df = pl.read_parquet(last_s3_pq[0])
@@ -135,8 +138,8 @@ class GtfsConverter(Converter):
             table=table,
             file_type=s3_prefix,
             s3_dir=os.path.join(
-                os.environ["SPRINGBOARD_BUCKET"],
-                DEFAULT_S3_PREFIX,
+                S3_SPRINGBOARD,
+                LAMP,
                 s3_prefix,
             ),
             partition_cols=["timestamp"],

--- a/src/lamp_py/ingestion/glides.py
+++ b/src/lamp_py/ingestion/glides.py
@@ -16,6 +16,10 @@ from lamp_py.aws.s3 import download_file, upload_file
 from lamp_py.aws.kinesis import KinesisReader
 from lamp_py.ingestion.utils import explode_table_column, flatten_schema
 from lamp_py.runtime_utils.process_logger import ProcessLogger
+from lamp_py.runtime_utils.remote_files import (
+    LAMP,
+    S3_SPRINGBOARD,
+)
 
 
 class GlidesConverter(ABC):
@@ -51,7 +55,9 @@ class GlidesConverter(ABC):
         self.base_filename = base_filename
         self.type = self.base_filename.replace(".parquet", "")
         self.local_path = os.path.join(self.tmp_dir, self.base_filename)
-        self.remote_path = f"s3://{os.environ['SPRINGBOARD_BUCKET']}/lamp/GLIDES/{base_filename}"
+        self.remote_path = (
+            f"s3://{S3_SPRINGBOARD}/{LAMP}/GLIDES/{base_filename}"
+        )
 
         self.records: List[Dict] = []
 

--- a/src/lamp_py/ingestion/ingest_gtfs.py
+++ b/src/lamp_py/ingestion/ingest_gtfs.py
@@ -23,10 +23,8 @@ from lamp_py.ingestion.error import (
     ConfigTypeFromFilenameException,
     NoImplException,
 )
-from lamp_py.ingestion.utils import (
-    DEFAULT_S3_PREFIX,
-    group_sort_file_list,
-)
+from lamp_py.runtime_utils.remote_files import LAMP, S3_ERROR, S3_INCOMING
+from lamp_py.ingestion.utils import group_sort_file_list
 from lamp_py.ingestion.compress_gtfs.gtfs_to_parquet import gtfs_to_parquet
 
 
@@ -40,7 +38,7 @@ class NoImplConverter(Converter):
     def convert(self) -> None:
         move_s3_objects(
             self.files,
-            os.path.join(os.environ["ERROR_BUCKET"], DEFAULT_S3_PREFIX),
+            os.path.join(S3_ERROR, LAMP),
         )
 
 
@@ -77,8 +75,8 @@ def ingest_s3_files(metadata_queue: Queue[Optional[str]]) -> None:
 
     try:
         files = file_list_from_s3(
-            bucket_name=os.environ["INCOMING_BUCKET"],
-            file_prefix=DEFAULT_S3_PREFIX,
+            bucket_name=S3_INCOMING,
+            file_prefix=LAMP,
         )
 
         grouped_files = group_sort_file_list(files)

--- a/src/lamp_py/ingestion/utils.py
+++ b/src/lamp_py/ingestion/utils.py
@@ -20,7 +20,6 @@ import polars as pl
 
 from lamp_py.runtime_utils.process_logger import ProcessLogger
 
-DEFAULT_S3_PREFIX = "lamp"
 GTFS_RT_HASH_COL = "lamp_record_hash"
 
 

--- a/src/lamp_py/ingestion_tm/jobs/whole_table.py
+++ b/src/lamp_py/ingestion_tm/jobs/whole_table.py
@@ -7,7 +7,18 @@ import sqlalchemy as sa
 from lamp_py.ingestion_tm.tm_export import TMExport
 from lamp_py.mssql.mssql_utils import MSSQLManager
 from lamp_py.runtime_utils.process_logger import ProcessLogger
-from lamp_py.runtime_utils.remote_files import S3Location, RemoteFileLocations
+from lamp_py.runtime_utils.remote_files import (
+    S3Location,
+    tm_geo_node_file,
+    tm_trip_file,
+    tm_route_file,
+    tm_vehicle_file,
+    tm_operator_file,
+    tm_run_file,
+    tm_block_file,
+    tm_work_piece_file,
+    tm_daily_sched_adherence_waiver_file,
+)
 from lamp_py.aws.s3 import upload_file
 
 
@@ -40,7 +51,7 @@ class TMWholeTable(TMExport):
                 logger.add_metadata(
                     pq_export_bytes=os.stat(local_export_path).st_size
                 )
-                upload_file(local_export_path, self.s3_location.get_s3_path())
+                upload_file(local_export_path, self.s3_location.s3_uri)
                 logger.log_complete()
 
         except Exception as exception:
@@ -53,7 +64,7 @@ class TMMainGeoNode(TMWholeTable):
     def __init__(self) -> None:
         TMWholeTable.__init__(
             self,
-            s3_location=RemoteFileLocations.tm_geo_node_file,
+            s3_location=tm_geo_node_file,
             tm_table="TMMain.dbo.GEO_NODE",
         )
 
@@ -101,7 +112,7 @@ class TMMainTrip(TMWholeTable):
     def __init__(self) -> None:
         TMWholeTable.__init__(
             self,
-            s3_location=RemoteFileLocations.tm_trip_file,
+            s3_location=tm_trip_file,
             tm_table="TMMain.dbo.TRIP",
         )
 
@@ -136,7 +147,7 @@ class TMMainRoute(TMWholeTable):
     def __init__(self) -> None:
         TMWholeTable.__init__(
             self,
-            s3_location=RemoteFileLocations.tm_route_file,
+            s3_location=tm_route_file,
             tm_table="TMMain.dbo.ROUTE",
         )
 
@@ -162,7 +173,7 @@ class TMMainVehicle(TMWholeTable):
     def __init__(self) -> None:
         TMWholeTable.__init__(
             self,
-            s3_location=RemoteFileLocations.tm_vehicle_file,
+            s3_location=tm_vehicle_file,
             tm_table="TMMain.dbo.VEHICLE",
         )
 
@@ -217,7 +228,7 @@ class TMMainOperator(TMWholeTable):
     def __init__(self) -> None:
         TMWholeTable.__init__(
             self,
-            s3_location=RemoteFileLocations.tm_operator_file,
+            s3_location=tm_operator_file,
             tm_table="TMMain.dbo.OPERATOR",
         )
 
@@ -247,7 +258,7 @@ class TMMainRun(TMWholeTable):
     def __init__(self) -> None:
         TMWholeTable.__init__(
             self,
-            s3_location=RemoteFileLocations.tm_run_file,
+            s3_location=tm_run_file,
             tm_table="TMMain.dbo.RUN",
         )
 
@@ -274,7 +285,7 @@ class TMMainBlock(TMWholeTable):
     def __init__(self) -> None:
         TMWholeTable.__init__(
             self,
-            s3_location=RemoteFileLocations.tm_block_file,
+            s3_location=tm_block_file,
             tm_table="TMMain.dbo.BLOCK",
         )
 
@@ -307,7 +318,7 @@ class TMMainWorkPiece(TMWholeTable):
     def __init__(self) -> None:
         TMWholeTable.__init__(
             self,
-            s3_location=RemoteFileLocations.tm_work_piece_file,
+            s3_location=tm_work_piece_file,
             tm_table="TMMain.dbo.WORK_PIECE",
         )
 
@@ -338,7 +349,7 @@ class TMDailyLogDailySchedAdhereWaiver(TMWholeTable):
     def __init__(self) -> None:
         TMWholeTable.__init__(
             self,
-            s3_location=RemoteFileLocations.tm_daily_sched_adherence_waiver_file,
+            s3_location=tm_daily_sched_adherence_waiver_file,
             tm_table="TMDailyLog.dbo.SCHED_ADHERE_WAIVER",
         )
 

--- a/src/lamp_py/performance_manager/alerts.py
+++ b/src/lamp_py/performance_manager/alerts.py
@@ -20,6 +20,10 @@ from lamp_py.aws.s3 import (
 from lamp_py.postgres.metadata_schema import MetadataLog
 from lamp_py.postgres.postgres_utils import DatabaseManager
 from lamp_py.runtime_utils.process_logger import ProcessLogger
+from lamp_py.runtime_utils.remote_files import (
+    S3_PUBLIC,
+    LAMP,
+)
 
 from .gtfs_utils import BOSTON_TZ
 
@@ -27,9 +31,8 @@ from .gtfs_utils import BOSTON_TZ
 class AlertsS3Info:
     """S3 Constant info for Alerts Parquet File"""
 
-    bucket_name: str = os.environ.get("PUBLIC_ARCHIVE_BUCKET", "")
     s3_path: str = "s3://" + os.path.join(
-        bucket_name, "lamp", "tableau", "alerts", "LAMP_RT_ALERTS.parquet"
+        S3_PUBLIC, LAMP, "tableau", "alerts", "LAMP_RT_ALERTS.parquet"
     )
     version_key: str = "lamp_version"
     file_version: str = "1.1.0"

--- a/src/lamp_py/performance_manager/alerts.py
+++ b/src/lamp_py/performance_manager/alerts.py
@@ -20,10 +20,7 @@ from lamp_py.aws.s3 import (
 from lamp_py.postgres.metadata_schema import MetadataLog
 from lamp_py.postgres.postgres_utils import DatabaseManager
 from lamp_py.runtime_utils.process_logger import ProcessLogger
-from lamp_py.runtime_utils.remote_files import (
-    S3_PUBLIC,
-    LAMP,
-)
+from lamp_py.runtime_utils.remote_files import public_alerts_file
 
 from .gtfs_utils import BOSTON_TZ
 
@@ -31,9 +28,7 @@ from .gtfs_utils import BOSTON_TZ
 class AlertsS3Info:
     """S3 Constant info for Alerts Parquet File"""
 
-    s3_path: str = "s3://" + os.path.join(
-        S3_PUBLIC, LAMP, "tableau", "alerts", "LAMP_RT_ALERTS.parquet"
-    )
+    s3_path: str = public_alerts_file.s3_uri
     version_key: str = "lamp_version"
     file_version: str = "1.1.0"
 

--- a/src/lamp_py/performance_manager/flat_file.py
+++ b/src/lamp_py/performance_manager/flat_file.py
@@ -28,6 +28,10 @@ from lamp_py.postgres.rail_performance_manager_schema import (
 )
 from lamp_py.postgres.postgres_utils import DatabaseManager
 from lamp_py.runtime_utils.process_logger import ProcessLogger
+from lamp_py.runtime_utils.remote_files import (
+    LAMP,
+    S3_PUBLIC,
+)
 
 
 class S3Archive:
@@ -35,9 +39,9 @@ class S3Archive:
     Class for holding constant information about the public archive s3 bucket
     """
 
-    BUCKET_NAME = os.environ.get("PUBLIC_ARCHIVE_BUCKET", "")
+    BUCKET_NAME = S3_PUBLIC
     RAIL_PERFORMANCE_PREFIX = os.path.join(
-        "lamp", "subway-on-time-performance-v1"
+        LAMP, "subway-on-time-performance-v1"
     )
     INDEX_FILENAME = "index.csv"
     VERSION_KEY = "rpm_version"

--- a/src/lamp_py/performance_manager/l0_gtfs_static_load.py
+++ b/src/lamp_py/performance_manager/l0_gtfs_static_load.py
@@ -1,4 +1,3 @@
-import os
 import pathlib
 from dataclasses import dataclass
 from typing import List, Optional, Dict
@@ -27,6 +26,7 @@ from lamp_py.postgres.postgres_utils import (
 )
 from lamp_py.runtime_utils.process_logger import ProcessLogger
 from lamp_py.runtime_utils.infinite_wait import infinite_wait
+from lamp_py.runtime_utils.remote_files import S3_SPRINGBOARD
 
 from .gtfs_utils import start_time_to_seconds
 
@@ -291,10 +291,9 @@ def get_static_parquet_paths(table_type: str, feed_info_path: str) -> List[str]:
     """
     get static table parquet files from FEED_INFO path
     """
-    springboard_bucket = os.environ["SPRINGBOARD_BUCKET"]
     static_prefix = feed_info_path.replace("FEED_INFO", table_type)
-    static_prefix = static_prefix.replace(f"{springboard_bucket}/", "")
-    return file_list_from_s3(springboard_bucket, static_prefix)
+    static_prefix = static_prefix.replace(f"{S3_SPRINGBOARD}/", "")
+    return file_list_from_s3(S3_SPRINGBOARD, static_prefix)
 
 
 def load_parquet_files(

--- a/src/lamp_py/publishing/performancedata.py
+++ b/src/lamp_py/publishing/performancedata.py
@@ -1,21 +1,21 @@
 import os
 
 from lamp_py.aws.s3 import upload_file
+from lamp_py.runtime_utils.remote_files import S3_PUBLIC
 
 
 def publish_performance_index() -> None:
     """
     Upload index.html to https://performancedata.mbta.com bucket
     """
-    bucket = os.environ.get("PUBLIC_ARCHIVE_BUCKET", "")
     here = os.path.dirname(os.path.abspath(__file__))
     index_file = "index.html"
 
-    if bucket == "":
+    if S3_PUBLIC == "":
         return
 
     local_index_path = os.path.join(here, index_file)
-    upload_index_path = os.path.join(bucket, index_file)
+    upload_index_path = os.path.join(S3_PUBLIC, index_file)
 
     extra_args = {
         "ContentType": "text/html",

--- a/src/lamp_py/publishing/performancedata.py
+++ b/src/lamp_py/publishing/performancedata.py
@@ -11,7 +11,7 @@ def publish_performance_index() -> None:
     here = os.path.dirname(os.path.abspath(__file__))
     index_file = "index.html"
 
-    if S3_PUBLIC == "":
+    if "unset" in S3_PUBLIC:
         return
 
     local_index_path = os.path.join(here, index_file)

--- a/src/lamp_py/runtime_utils/remote_files.py
+++ b/src/lamp_py/runtime_utils/remote_files.py
@@ -3,15 +3,16 @@ from dataclasses import dataclass
 from typing import Union
 
 # bucket constants
-S3_SPRINGBOARD: str = os.environ.get("SPRINGBOARD_BUCKET", "")
-S3_PUBLIC: str = os.environ.get("PUBLIC_ARCHIVE_BUCKET", "")
-S3_INCOMING: str = os.environ.get("INCOMING_BUCKET", "")
-S3_ARCHIVE: str = os.environ.get("ARCHIVE_BUCKET", "")
-S3_ERROR: str = os.environ.get("ERROR_BUCKET", "")
+S3_SPRINGBOARD: str = os.environ.get("SPRINGBOARD_BUCKET", "unset_SPRINGBOARD")
+S3_PUBLIC: str = os.environ.get("PUBLIC_ARCHIVE_BUCKET", "unset_PUBLIC")
+S3_INCOMING: str = os.environ.get("INCOMING_BUCKET", "unset_INCOMING")
+S3_ARCHIVE: str = os.environ.get("ARCHIVE_BUCKET", "unset_ARCHIVE")
+S3_ERROR: str = os.environ.get("ERROR_BUCKET", "unset_ERROR")
 
 # prefix constants
 LAMP = "lamp"
 TM = os.path.join(LAMP, "TM")
+TABLEAU = os.path.join(LAMP, "tableau")
 
 
 @dataclass
@@ -101,10 +102,17 @@ tm_work_piece_file = S3Location(
     prefix=os.path.join(TM, "TMMAIN_WORK_PIECE.parquet"),
 )
 
-# bus events published by LAMP
+# published by LAMP
 bus_events = S3Location(
     bucket=S3_PUBLIC,
     prefix=os.path.join(LAMP, "bus_vehicle_events"),
+)
+public_alerts_file = S3Location(
+    bucket=S3_PUBLIC,
+    prefix=os.path.join(TABLEAU, "alerts", "LAMP_RT_ALERTS.parquet"),
+)
+tableau_rail = S3Location(
+    bucket=S3_PUBLIC, prefix=os.path.join(TABLEAU, "rail")
 )
 
 

--- a/src/lamp_py/runtime_utils/remote_files.py
+++ b/src/lamp_py/runtime_utils/remote_files.py
@@ -1,5 +1,17 @@
 import os
 from dataclasses import dataclass
+from typing import Union
+
+# bucket constants
+S3_SPRINGBOARD: str = os.environ.get("SPRINGBOARD_BUCKET", "")
+S3_PUBLIC: str = os.environ.get("PUBLIC_ARCHIVE_BUCKET", "")
+S3_INCOMING: str = os.environ.get("INCOMING_BUCKET", "")
+S3_ARCHIVE: str = os.environ.get("ARCHIVE_BUCKET", "")
+S3_ERROR: str = os.environ.get("ERROR_BUCKET", "")
+
+# prefix constants
+LAMP = "lamp"
+TM = os.path.join(LAMP, "TM")
 
 
 @dataclass
@@ -8,98 +20,115 @@ class S3Location:
     wrapper for a bucket name and prefix pair used to define an s3 location
     """
 
-    bucket_name: str
-    file_prefix: str
+    bucket: str
+    prefix: str
 
-    def get_s3_path(self) -> str:
-        """generate the full s3 url that can be used to describe the location"""
-        return f"s3://{self.bucket_name}/{self.file_prefix}"
-
-
-class RemoteFileLocations:
-    """
-    Constant S3 File Locations Used in Bus Performance Manager
-    """
-
-    # define buckets that we put our data into, both public and private
-    springboard_bucket: str = os.environ.get("SPRINGBOARD_BUCKET", "")
-    public_bucket: str = os.environ.get("PUBLIC_ARCHIVE_BUCKET", "")
-
-    # files ingested from delta
-    vehicle_positions = S3Location(
-        bucket_name=springboard_bucket,
-        file_prefix=os.path.join("lamp", "RT_VEHICLE_POSITIONS"),
-    )
-
-    # files ingested from tranist master
-    tm_prefix = os.path.join("lamp", "TM")
-    tm_stop_crossing = S3Location(
-        bucket_name=springboard_bucket,
-        file_prefix=os.path.join(tm_prefix, "STOP_CROSSING"),
-    )
-    tm_daily_work_piece = S3Location(
-        bucket_name=springboard_bucket,
-        file_prefix=os.path.join(tm_prefix, "DAILY_WORK_PIECE"),
-    )
-    tm_daily_sched_adherence_waiver_file = S3Location(
-        bucket_name=springboard_bucket,
-        file_prefix=os.path.join(
-            tm_prefix, "DAILY_SCHED_ADHERE_WAIVER.parquet"
-        ),
-    )
-    tm_geo_node_file = S3Location(
-        bucket_name=springboard_bucket,
-        file_prefix=os.path.join(tm_prefix, "TMMAIN_GEO_NODE.parquet"),
-    )
-    tm_route_file = S3Location(
-        bucket_name=springboard_bucket,
-        file_prefix=os.path.join(tm_prefix, "TMMAIN_ROUTE.parquet"),
-    )
-    tm_trip_file = S3Location(
-        bucket_name=springboard_bucket,
-        file_prefix=os.path.join(tm_prefix, "TMMAIN_TRIP.parquet"),
-    )
-    tm_vehicle_file = S3Location(
-        bucket_name=springboard_bucket,
-        file_prefix=os.path.join(tm_prefix, "TMMAIN_VEHICLE.parquet"),
-    )
-    tm_operator_file = S3Location(
-        bucket_name=springboard_bucket,
-        file_prefix=os.path.join(tm_prefix, "TMMAIN_OPERATOR.parquet"),
-    )
-    tm_run_file = S3Location(
-        bucket_name=springboard_bucket,
-        file_prefix=os.path.join(tm_prefix, "TMMAIN_RUN.parquet"),
-    )
-    tm_block_file = S3Location(
-        bucket_name=springboard_bucket,
-        file_prefix=os.path.join(tm_prefix, "TMMAIN_BLOCK.parquet"),
-    )
-    tm_work_piece_file = S3Location(
-        bucket_name=springboard_bucket,
-        file_prefix=os.path.join(tm_prefix, "TMMAIN_WORK_PIECE.parquet"),
-    )
-
-    # output of public bus events published by LAMP
-    bus_events = S3Location(
-        bucket_name=public_bucket,
-        file_prefix=os.path.join("lamp", "bus_vehicle_events"),
-    )
-
-    # Compressed GTFS Static Schedule files
-    compressed_gtfs = S3Location(
-        bucket_name=public_bucket,
-        file_prefix=os.path.join("lamp", "gtfs_archive"),
-    )
+    @property
+    def s3_uri(self) -> str:
+        """generate the full s3 uri for the location"""
+        return f"s3://{self.bucket}/{self.prefix}"
 
 
-def get_gtfs_parquet_file(year: int, filename: str) -> S3Location:
-    """
-    generate an S3Location instance for a gtfs schedule parquet file for a
-    given type in a given year.
-    """
-    file_object = os.path.join("lamp", "gtfs_archive", str(year), filename)
+# files ingested from delta
+rt_vehicle_positions = S3Location(
+    bucket=S3_SPRINGBOARD,
+    prefix=os.path.join(LAMP, "RT_VEHICLE_POSITIONS"),
+)
 
-    return S3Location(
-        bucket_name=RemoteFileLocations.public_bucket, file_prefix=file_object
-    )
+rt_trip_updates = S3Location(
+    bucket=S3_SPRINGBOARD,
+    prefix=os.path.join(LAMP, "RT_TRIP_UPDATES"),
+)
+
+rt_alerts = S3Location(
+    bucket=S3_SPRINGBOARD,
+    prefix=os.path.join(LAMP, "RT_ALERTS"),
+)
+
+bus_vehicle_positions = S3Location(
+    bucket=S3_SPRINGBOARD,
+    prefix=os.path.join(LAMP, "BUS_VEHICLE_POSITIONS"),
+)
+
+bus_trip_updates = S3Location(
+    bucket=S3_SPRINGBOARD,
+    prefix=os.path.join(LAMP, "BUS_TRIP_UPDATES"),
+)
+
+# files ingested from transit master
+tm_stop_crossing = S3Location(
+    bucket=S3_SPRINGBOARD,
+    prefix=os.path.join(TM, "STOP_CROSSING"),
+)
+tm_daily_work_piece = S3Location(
+    bucket=S3_SPRINGBOARD,
+    prefix=os.path.join(TM, "DAILY_WORK_PIECE"),
+)
+tm_daily_sched_adherence_waiver_file = S3Location(
+    bucket=S3_SPRINGBOARD,
+    prefix=os.path.join(TM, "DAILY_SCHED_ADHERE_WAIVER.parquet"),
+)
+tm_geo_node_file = S3Location(
+    bucket=S3_SPRINGBOARD,
+    prefix=os.path.join(TM, "TMMAIN_GEO_NODE.parquet"),
+)
+tm_route_file = S3Location(
+    bucket=S3_SPRINGBOARD,
+    prefix=os.path.join(TM, "TMMAIN_ROUTE.parquet"),
+)
+tm_trip_file = S3Location(
+    bucket=S3_SPRINGBOARD,
+    prefix=os.path.join(TM, "TMMAIN_TRIP.parquet"),
+)
+tm_vehicle_file = S3Location(
+    bucket=S3_SPRINGBOARD,
+    prefix=os.path.join(TM, "TMMAIN_VEHICLE.parquet"),
+)
+tm_operator_file = S3Location(
+    bucket=S3_SPRINGBOARD,
+    prefix=os.path.join(TM, "TMMAIN_OPERATOR.parquet"),
+)
+tm_run_file = S3Location(
+    bucket=S3_SPRINGBOARD,
+    prefix=os.path.join(TM, "TMMAIN_RUN.parquet"),
+)
+tm_block_file = S3Location(
+    bucket=S3_SPRINGBOARD,
+    prefix=os.path.join(TM, "TMMAIN_BLOCK.parquet"),
+)
+tm_work_piece_file = S3Location(
+    bucket=S3_SPRINGBOARD,
+    prefix=os.path.join(TM, "TMMAIN_WORK_PIECE.parquet"),
+)
+
+# bus events published by LAMP
+bus_events = S3Location(
+    bucket=S3_PUBLIC,
+    prefix=os.path.join(LAMP, "bus_vehicle_events"),
+)
+
+
+class GTFSArchive(S3Location):
+    """S3Location for Compressed GTFS Archive"""
+
+    def __init__(self, bucket: str, prefix: str) -> None:
+        S3Location.__init__(self, bucket, prefix)
+
+    def parquet_path(self, year: Union[str, int], file: str) -> S3Location:
+        """
+        produce parquet S3Location with year and file for specific GTFS archive
+
+        :param year: archive year
+        :param file: GTFS file type (e.g. routes)
+        """
+        file = file.replace(".parquet", "")
+        return S3Location(
+            bucket=self.bucket,
+            prefix=os.path.join(self.prefix, str(year), f"{file}.parquet"),
+        )
+
+
+compressed_gtfs = GTFSArchive(
+    bucket=S3_PUBLIC,
+    prefix=os.path.join(LAMP, "gtfs_archive"),
+)

--- a/src/lamp_py/tableau/jobs/gtfs_rail.py
+++ b/src/lamp_py/tableau/jobs/gtfs_rail.py
@@ -8,6 +8,10 @@ import sqlalchemy as sa
 from lamp_py.tableau.hyper import HyperJob
 from lamp_py.aws.s3 import download_file
 from lamp_py.postgres.postgres_utils import DatabaseManager
+from lamp_py.runtime_utils.remote_files import (
+    LAMP,
+    S3_PUBLIC,
+)
 
 
 class HyperGTFS(HyperJob):
@@ -27,7 +31,7 @@ class HyperGTFS(HyperJob):
         HyperJob.__init__(
             self,
             hyper_file_name=f"LAMP_{gtfs_table_name}.hyper",
-            remote_parquet_path=f"s3://{os.getenv('PUBLIC_ARCHIVE_BUCKET')}/lamp/tableau/rail/LAMP_{gtfs_table_name}.parquet",
+            remote_parquet_path=f"s3://{S3_PUBLIC}/{LAMP}/tableau/rail/LAMP_{gtfs_table_name}.parquet",
             lamp_version="1.0.0",
         )
         self.gtfs_table_name = gtfs_table_name

--- a/src/lamp_py/tableau/jobs/gtfs_rail.py
+++ b/src/lamp_py/tableau/jobs/gtfs_rail.py
@@ -8,10 +8,7 @@ import sqlalchemy as sa
 from lamp_py.tableau.hyper import HyperJob
 from lamp_py.aws.s3 import download_file
 from lamp_py.postgres.postgres_utils import DatabaseManager
-from lamp_py.runtime_utils.remote_files import (
-    LAMP,
-    S3_PUBLIC,
-)
+from lamp_py.runtime_utils.remote_files import tableau_rail
 
 
 class HyperGTFS(HyperJob):
@@ -31,7 +28,7 @@ class HyperGTFS(HyperJob):
         HyperJob.__init__(
             self,
             hyper_file_name=f"LAMP_{gtfs_table_name}.hyper",
-            remote_parquet_path=f"s3://{S3_PUBLIC}/{LAMP}/tableau/rail/LAMP_{gtfs_table_name}.parquet",
+            remote_parquet_path=f"{tableau_rail.s3_uri}/LAMP_{gtfs_table_name}.parquet",
             lamp_version="1.0.0",
         )
         self.gtfs_table_name = gtfs_table_name

--- a/src/lamp_py/tableau/jobs/rt_rail.py
+++ b/src/lamp_py/tableau/jobs/rt_rail.py
@@ -11,6 +11,10 @@ from lamp_py.tableau.hyper import HyperJob
 from lamp_py.aws.s3 import download_file
 from lamp_py.postgres.postgres_utils import DatabaseManager
 from lamp_py.runtime_utils.process_logger import ProcessLogger
+from lamp_py.runtime_utils.remote_files import (
+    LAMP,
+    S3_PUBLIC,
+)
 
 
 class HyperRtRail(HyperJob):
@@ -20,7 +24,7 @@ class HyperRtRail(HyperJob):
         HyperJob.__init__(
             self,
             hyper_file_name="LAMP_ALL_RT_fields.hyper",
-            remote_parquet_path=f"s3://{os.getenv('PUBLIC_ARCHIVE_BUCKET')}/lamp/tableau/rail/LAMP_ALL_RT_fields.parquet",
+            remote_parquet_path=f"s3://{S3_PUBLIC}/{LAMP}/tableau/rail/LAMP_ALL_RT_fields.parquet",
             lamp_version="1.1.4",
         )
         self.table_query = (

--- a/src/lamp_py/tableau/jobs/rt_rail.py
+++ b/src/lamp_py/tableau/jobs/rt_rail.py
@@ -11,10 +11,7 @@ from lamp_py.tableau.hyper import HyperJob
 from lamp_py.aws.s3 import download_file
 from lamp_py.postgres.postgres_utils import DatabaseManager
 from lamp_py.runtime_utils.process_logger import ProcessLogger
-from lamp_py.runtime_utils.remote_files import (
-    LAMP,
-    S3_PUBLIC,
-)
+from lamp_py.runtime_utils.remote_files import tableau_rail
 
 
 class HyperRtRail(HyperJob):
@@ -24,7 +21,7 @@ class HyperRtRail(HyperJob):
         HyperJob.__init__(
             self,
             hyper_file_name="LAMP_ALL_RT_fields.hyper",
-            remote_parquet_path=f"s3://{S3_PUBLIC}/{LAMP}/tableau/rail/LAMP_ALL_RT_fields.parquet",
+            remote_parquet_path=f"{tableau_rail.s3_uri}/LAMP_ALL_RT_fields.parquet",
             lamp_version="1.1.4",
         )
         self.table_query = (

--- a/tests/bus_performance_manager/test_gtfs_rt_ingestion.py
+++ b/tests/bus_performance_manager/test_gtfs_rt_ingestion.py
@@ -11,7 +11,7 @@ from lamp_py.bus_performance_manager.gtfs_rt_ingestion import (
     generate_gtfs_rt_events,
 )
 
-from ..test_resources import LocalFileLocaions
+from ..test_resources import rt_vehicle_positions as s3_vp
 
 
 def get_service_date_and_files() -> Tuple[date, List[str]]:
@@ -24,7 +24,7 @@ def get_service_date_and_files() -> Tuple[date, List[str]]:
     only have rail performance test data.
     """
     vp_files = []
-    vp_dir = LocalFileLocaions.vehicle_positions.get_s3_path()
+    vp_dir = s3_vp.s3_uri
     assert os.path.exists(vp_dir)
 
     for root, _, files in os.walk(vp_dir):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,10 +15,7 @@ from _pytest.monkeypatch import MonkeyPatch
 from pyarrow import fs
 import pyarrow.dataset as pd
 
-from .test_resources import (
-    LocalS3Location,
-    compressed_gtfs,
-)
+from .test_resources import LocalS3Location
 
 
 @pytest.fixture(autouse=True, name="get_pyarrow_dataset_patch")
@@ -71,11 +68,6 @@ def fixture_remote_file_locations_patch(
     """
     monkeypatch.setattr(
         "lamp_py.runtime_utils.remote_files.S3Location", LocalS3Location
-    )
-
-    monkeypatch.setattr(
-        "lamp_py.bus_performance_manager.gtfs_utils.compressed_gtfs",
-        compressed_gtfs,
     )
 
     yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,8 +17,7 @@ import pyarrow.dataset as pd
 
 from .test_resources import (
     LocalS3Location,
-    LocalFileLocaions,
-    get_local_gtfs_parquet_files,
+    compressed_gtfs,
 )
 
 
@@ -75,13 +74,8 @@ def fixture_remote_file_locations_patch(
     )
 
     monkeypatch.setattr(
-        "lamp_py.runtime_utils.remote_files.RemoteFileLocations",
-        LocalFileLocaions,
-    )
-
-    monkeypatch.setattr(
-        "lamp_py.runtime_utils.remote_files.get_gtfs_parquet_file",
-        get_local_gtfs_parquet_files,
+        "lamp_py.bus_performance_manager.gtfs_utils.compressed_gtfs",
+        compressed_gtfs,
     )
 
     yield

--- a/tests/ingestion/test_gtfs_converter.py
+++ b/tests/ingestion/test_gtfs_converter.py
@@ -304,14 +304,6 @@ def all_table_attributes() -> Dict:
     }
 
 
-@pytest.fixture(name="_set_env_vars")
-def fixture_set_env_vars() -> None:
-    """setup bucket names for this test"""
-    os.environ["SPRINGBOARD_BUCKET"] = "springboard"
-    os.environ["ERROR_BUCKET"] = "error"
-    os.environ["ARCHIVE_BUCKET"] = "archive"
-
-
 @pytest.fixture(name="_s3_patch")
 def fixture_s3_patch(monkeypatch: MonkeyPatch) -> Iterator[None]:
     """
@@ -379,9 +371,7 @@ def fixture_s3_patch(monkeypatch: MonkeyPatch) -> Iterator[None]:
     assert tables_written[-1] == "feed_info"
 
 
-def test_schedule_conversion(
-    _set_env_vars: Callable[..., None], _s3_patch: Callable[..., None]
-) -> None:
+def test_schedule_conversion(_s3_patch: Callable[..., None]) -> None:
     """
     test that a schedule zip file can be processed correctly, checking for files
     table names, table column names, and table lengths
@@ -402,6 +392,6 @@ def test_schedule_conversion(
     while not metadata_queue.empty():
         s3_path = metadata_queue.get(block=False)
 
-        assert "springboard" in s3_path
+        assert "SPRINGBOARD" in s3_path
         assert "FEED_INFO" in s3_path
         assert "written.parquet" in s3_path

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -5,9 +5,7 @@ import pyarrow
 from pyarrow import csv, parquet
 
 from lamp_py.runtime_utils.remote_files import (
-    GTFSArchive,
     S3_SPRINGBOARD,
-    S3_PUBLIC,
     S3_INCOMING,
 )
 

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -63,8 +63,3 @@ rt_vehicle_positions = LocalS3Location(
     bucket=S3_SPRINGBOARD,
     prefix="RT_VEHICLE_POSITIONS",
 )
-
-compressed_gtfs = GTFSArchive(
-    bucket=S3_PUBLIC,
-    prefix="lamp/gtfs_archive",
-)

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass
 import pyarrow
 from pyarrow import csv, parquet
 
+from lamp_py.runtime_utils.remote_files import GTFSArchive
+
 test_files_dir = os.path.join(os.path.dirname(__file__), "test_files")
 
 incoming_dir = os.path.join(test_files_dir, "INCOMING")
@@ -42,60 +44,21 @@ def csv_to_vp_parquet(csv_filepath: str, parquet_filepath: str) -> None:
 class LocalS3Location:
     """replace an s3 location wrapper class so it can be used in testing"""
 
-    bucket_name: str
-    file_prefix: str
+    bucket: str
+    prefix: str
 
-    def get_s3_path(self) -> str:
+    @property
+    def s3_uri(self) -> str:
         """generate the local path to the test file for this object"""
-        return os.path.join(test_files_dir, self.bucket_name, self.file_prefix)
+        return os.path.join(test_files_dir, self.bucket, self.prefix)
 
 
-class LocalFileLocaions:
-    """Replace S3 File Locations with Local Files"""
+rt_vehicle_positions = LocalS3Location(
+    bucket="SPRINGBOARD",
+    prefix="RT_VEHICLE_POSITIONS",
+)
 
-    springboard_bucket = "SPRINGBOARD"
-    public_bucket = "PUBLIC_ARCHIVE"
-
-    # files ingested from delta
-    vehicle_positions = LocalS3Location(
-        bucket_name=springboard_bucket,
-        file_prefix="RT_VEHICLE_POSITIONS",
-    )
-
-    # files ingested from tranist master
-    tm_prefix = "TM"
-    tm_stop_crossing = LocalS3Location(
-        bucket_name=springboard_bucket,
-        file_prefix=os.path.join(tm_prefix, "STOP_CROSSING"),
-    )
-    tm_geo_node_file = LocalS3Location(
-        bucket_name=springboard_bucket,
-        file_prefix=os.path.join(tm_prefix, "TMMAIN_GEO_NODE.parquet"),
-    )
-    tm_route_file = LocalS3Location(
-        bucket_name=springboard_bucket,
-        file_prefix=os.path.join(tm_prefix, "TMMAIN_ROUTE.parquet"),
-    )
-    tm_trip_file = LocalS3Location(
-        bucket_name=springboard_bucket,
-        file_prefix=os.path.join(tm_prefix, "TMMAIN_TRIP.parquet"),
-    )
-    tm_vehicle_file = LocalS3Location(
-        bucket_name=springboard_bucket,
-        file_prefix=os.path.join(tm_prefix, "TMMAIN_VEHICLE.parquet"),
-    )
-
-    # output of public bus events published by LAMP
-    bus_events = LocalS3Location(
-        bucket_name=public_bucket,
-        file_prefix="bus_vehicle_events",
-    )
-
-
-def get_local_gtfs_parquet_files(year: int, filename: str) -> LocalS3Location:
-    """Replace get_gtfs_parquet_files to work on local files."""
-    file_object = os.path.join("gtfs_archive", str(year), filename)
-
-    return LocalS3Location(
-        bucket_name=LocalFileLocaions.public_bucket, file_prefix=file_object
-    )
+compressed_gtfs = GTFSArchive(
+    bucket="PUBLIC_ARCHIVE",
+    prefix="lamp/gtfs_archive",
+)

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -4,12 +4,14 @@ from dataclasses import dataclass
 import pyarrow
 from pyarrow import csv, parquet
 
-from lamp_py.runtime_utils.remote_files import GTFSArchive
+from lamp_py.runtime_utils.remote_files import (
+    GTFSArchive,
+    S3_SPRINGBOARD,
+    S3_PUBLIC,
+    S3_INCOMING,
+)
 
 test_files_dir = os.path.join(os.path.dirname(__file__), "test_files")
-
-incoming_dir = os.path.join(test_files_dir, "INCOMING")
-springboard_dir = os.path.join(test_files_dir, "SPRINGBOARD")
 
 
 def csv_to_vp_parquet(csv_filepath: str, parquet_filepath: str) -> None:
@@ -40,6 +42,10 @@ def csv_to_vp_parquet(csv_filepath: str, parquet_filepath: str) -> None:
     parquet.write_table(table, parquet_filepath)
 
 
+incoming_dir = os.path.join(test_files_dir, S3_INCOMING)
+springboard_dir = os.path.join(test_files_dir, S3_SPRINGBOARD)
+
+
 @dataclass
 class LocalS3Location:
     """replace an s3 location wrapper class so it can be used in testing"""
@@ -54,11 +60,11 @@ class LocalS3Location:
 
 
 rt_vehicle_positions = LocalS3Location(
-    bucket="SPRINGBOARD",
+    bucket=S3_SPRINGBOARD,
     prefix="RT_VEHICLE_POSITIONS",
 )
 
 compressed_gtfs = GTFSArchive(
-    bucket="PUBLIC_ARCHIVE",
+    bucket=S3_PUBLIC,
     prefix="lamp/gtfs_archive",
 )


### PR DESCRIPTION
This changes attempts to consolidate references to S3 paths all in one location. 

Original version of `remote_files.py` was modified to reduce the verbosity of calling resources defined by the file. Also added all bucket references and lamp file prefix constants to the file. 

Hopefully I found all the places where we reference S3 file locations....

Asana Task: https://app.asana.com/0/1205827492903547/1207771349226027
