### PR TITLE
FEAT: Start LAMP Ad-Hoc Task with Github

### DIFF
--- a/.github/actions/run_task/action.yaml
+++ b/.github/actions/run_task/action.yaml
@@ -10,7 +10,7 @@ inputs:
     required: true
     default: us-east-1
   environment:
-    description: prod or staging
+    description: LAMP environment
     required: true
   task_name:
     description: name of the task to run in kebab case

--- a/.github/actions/run_task/run_task.sh
+++ b/.github/actions/run_task/run_task.sh
@@ -11,10 +11,10 @@ set -e -u
 # - ENVIRONMENT
 
 # Get the VPC ID based on the VPC name
-if [ "$ENVIRONMENT" == "staging" ]; then
+if [ "$ENVIRONMENT" == "staging" ] || [ "$ENVIRONMENT" == "dev" ]; then
     VPC_NAME="vpc-dev-ctd-itd"
 elif [ "$ENVIRONMENT" == "prod" ]; then
-    VPC_NAME="vpc-prod-ctd-itd"A
+    VPC_NAME="vpc-prod-ctd-itd"
 else
     echo "Invalid environment: $ENVIRONMENT"
     exit 1

--- a/.github/workflows/ad_hoc_deploy_run.yml
+++ b/.github/workflows/ad_hoc_deploy_run.yml
@@ -1,5 +1,4 @@
 name: Ad-Hoc Deploy & Run
-description: Deploy and Run Ad-Hoc process on LAMP environment (be careful!). 
 
 on:
   workflow_dispatch:
@@ -36,4 +35,3 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           environment: ${{ github.event.inputs.environment }}
           task_name: 'ad-hoc'
-

--- a/.github/workflows/ad_hoc_deploy_run.yml
+++ b/.github/workflows/ad_hoc_deploy_run.yml
@@ -1,0 +1,39 @@
+name: Ad-Hoc Deploy & Run
+description: Deploy and Run Ad-Hoc process on LAMP environment (be careful!). 
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Environment
+        type: choice
+        options:
+          - dev
+          - staging
+          - prod
+
+jobs:
+  deploy:
+    uses: ./.github/workflows/deploy-base.yaml
+    with:
+      # pass the inputs from the workflow dispatch through to the deploy base. the booleans are
+      # converted to strings, so flip them back using fromJson function
+      environment: ${{ github.event.inputs.environment }}
+      deploy-ad-hoc: true
+    secrets: inherit
+  run_ad_hoc_task:
+    needs: deploy
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout Branch
+        uses: actions/checkout@v3
+      - name: Run Task Action
+        uses: ./.github/actions/run_task
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          environment: ${{ github.event.inputs.environment }}
+          task_name: 'ad-hoc'
+

--- a/.github/workflows/deploy-base.yaml
+++ b/.github/workflows/deploy-base.yaml
@@ -37,6 +37,11 @@ on:
         required: false
         default: false
         type: boolean
+      deploy-ad-hoc:
+        description: Should the Ad-Hoc Runner be Deployed
+        required: false
+        default: false
+        type: boolean
     secrets:
       DOCKER_REPO:
         description: ECR Docker repo to push to
@@ -127,6 +132,16 @@ jobs:
           ecs-cluster: lamp
           ecs-service: lamp-tableau-publisher-${{ inputs.environment }}
           ecs-task-definition: lamp-tableau-publisher-${{ inputs.environment }}
+          docker-tag: ${{ steps.build-push.outputs.docker-tag }}
+      - name: Deploy Ad-Hoc Process
+        id: deploy-ad-hoc
+        if: ${{ inputs.deploy-ad-hoc }}
+        uses: mbta/actions/deploy-scheduled-ecs@v2
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          ecs-cluster: lamp
+          ecs-service: lamp-ad-hoc-${{ inputs.environment }}
+          ecs-task-definition: lamp-ad-hoc-${{ inputs.environment }}
           docker-tag: ${{ steps.build-push.outputs.docker-tag }}
       - uses: mbta/actions/notify-slack-deploy@v2
         if: ${{ !cancelled() }}

--- a/.github/workflows/run-task.yaml
+++ b/.github/workflows/run-task.yaml
@@ -7,14 +7,12 @@ on:
         description: Environment
         type: choice
         options:
-          - dev
           - staging
           - prod
       task:
         description: Task
         type: choice
         options:
-          - Ad-Hoc Runner
           - Tableau Publisher
           - Transit Master Ingestion
 
@@ -33,8 +31,6 @@ jobs:
             echo "task_name=tableau-publisher" >> $GITHUB_ENV
           elif [ "${{ github.event.inputs.task }}" == "Transit Master Ingestion" ]; then
             echo "task_name=tm-ingestion" >> $GITHUB_ENV
-          elif [ "${{ github.event.inputs.task }}" == "Ad-Hoc Runner" ]; then
-            echo "task_name=ad-hoc" >> $GITHUB_ENV
           fi
       - name: Run Task Action
         uses: ./.github/actions/run_task

--- a/.github/workflows/run-task.yaml
+++ b/.github/workflows/run-task.yaml
@@ -7,12 +7,14 @@ on:
         description: Environment
         type: choice
         options:
+          - dev
           - staging
           - prod
       task:
         description: Task
         type: choice
         options:
+          - Ad-Hoc Runner
           - Tableau Publisher
           - Transit Master Ingestion
 
@@ -31,6 +33,8 @@ jobs:
             echo "task_name=tableau-publisher" >> $GITHUB_ENV
           elif [ "${{ github.event.inputs.task }}" == "Transit Master Ingestion" ]; then
             echo "task_name=tm-ingestion" >> $GITHUB_ENV
+          elif [ "${{ github.event.inputs.task }}" == "Ad-Hoc Runner" ]; then
+            echo "task_name=ad-hoc" >> $GITHUB_ENV
           fi
       - name: Run Task Action
         uses: ./.github/actions/run_task


### PR DESCRIPTION
This change allows LAMP Ad-Hoc ECS Task to be triggered with github action.

Ad-Hoc ECS Task created by devops PR: https://github.com/mbta/devops/pull/2184

Asana Task: https://app.asana.com/0/1205827492903547/1207556073650893
