### PR TITLE
FEAT: Run Task from Github Action

### DIFF
--- a/.github/actions/run_task/action.yaml
+++ b/.github/actions/run_task/action.yaml
@@ -1,5 +1,5 @@
-name: Run LAMP ECS Task in Environment
-description: Run an existing task in the LAMP ECS Cluster
+name: Manually Run ECS Task
+description: Run an existing task in an existing AWS Service and Cluster
 
 inputs:
   role-to-assume:
@@ -9,26 +9,25 @@ inputs:
     description: AWS region to use
     required: true
     default: us-east-1
-  environment:
-    description: LAMP environment
+  cluster:
+    description: ECS Cluster for Service
     required: true
-  task_name:
-    description: name of the task to run in kebab case
+  service:
+    description: ECS Service for task to run
     required: true
 
 runs:
   using: composite
   steps:
     - name: Setup AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ inputs.role-to-assume }}
         aws-region: ${{ inputs.aws-region }}
-    - name: Run ECS Task
-      id: run-ecs
-      run: ${{ github.action_path }}/run_task.sh
+        mask-aws-account-id: true
+    - run: ${{ github.action_path }}/run_task.sh
       shell: bash
       env:
         AWS_REGION: ${{ inputs.aws-region }}
-        TASK_NAME: ${{ inputs.task_name }}
-        ENVIRONMENT: ${{ inputs.environment }}
+        CLUSTER: ${{ inputs.cluster }}
+        SERVICE: ${{ inputs.service }}

--- a/.github/workflows/ad_hoc_deploy_run.yml
+++ b/.github/workflows/ad_hoc_deploy_run.yml
@@ -10,18 +10,21 @@ on:
           - dev
           - staging
           - prod
+    secrets:
+      AWS_ROLE_ARN:
+        description: AWS_ROLE_ARN
+        required: true
 
 jobs:
-  deploy:
-    uses: ./.github/workflows/deploy-base.yaml
-    with:
-      # pass the inputs from the workflow dispatch through to the deploy base. the booleans are
-      # converted to strings, so flip them back using fromJson function
-      environment: ${{ github.event.inputs.environment }}
-      deploy-ad-hoc: true
-    secrets: inherit
+  # deploy:
+  #   uses: ./.github/workflows/deploy-base.yaml
+  #   with:
+  #     # pass the inputs from the workflow dispatch through to the deploy base. the booleans are
+  #     # converted to strings, so flip them back using fromJson function
+  #     environment: ${{ github.event.inputs.environment }}
+  #     deploy-ad-hoc: true
+  #   secrets: inherit
   run_ad_hoc_task:
-    needs: deploy
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -29,9 +32,9 @@ jobs:
     steps:
       - name: Checkout Branch
         uses: actions/checkout@v3
-      - name: Run Task Action
+      - name: Run Ad-Hoc Task
         uses: ./.github/actions/run_task
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-          environment: ${{ github.event.inputs.environment }}
-          task_name: 'ad-hoc'
+          cluster: 'lamp'
+          service: lamp-ad-hoc-${{ inputs.environment }}

--- a/.github/workflows/deploy-base.yaml
+++ b/.github/workflows/deploy-base.yaml
@@ -136,13 +136,14 @@ jobs:
       - name: Deploy Ad-Hoc Process
         id: deploy-ad-hoc
         if: ${{ inputs.deploy-ad-hoc }}
-        uses: mbta/actions/deploy-scheduled-ecs@v2
+        uses: mbta/actions/deploy-ecs@v2
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           ecs-cluster: lamp
           ecs-service: lamp-ad-hoc-${{ inputs.environment }}
           ecs-task-definition: lamp-ad-hoc-${{ inputs.environment }}
           docker-tag: ${{ steps.build-push.outputs.docker-tag }}
+          allow-zero-desired: true
       - uses: mbta/actions/notify-slack-deploy@v2
         if: ${{ !cancelled() }}
         with:

--- a/.github/workflows/run-task.yaml
+++ b/.github/workflows/run-task.yaml
@@ -27,14 +27,14 @@ jobs:
         uses: actions/checkout@v3
       - name: Generate Task Name
         run: |
-          if [ "${{ github.event.inputs.task }}" == "Tableau Publisher" ]; then
+          if [ "${{ inputs.task }}" == "Tableau Publisher" ]; then
             echo "task_name=tableau-publisher" >> $GITHUB_ENV
-          elif [ "${{ github.event.inputs.task }}" == "Transit Master Ingestion" ]; then
+          elif [ "${{ inputs.task }}" == "Transit Master Ingestion" ]; then
             echo "task_name=tm-ingestion" >> $GITHUB_ENV
           fi
       - name: Run Task Action
         uses: ./.github/actions/run_task
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-          environment: ${{ inputs.environment }}
-          task_name: ${{ env.task_name }}
+          cluster: 'lamp'
+          service: lamp-${{ env.task_name }}-${{ inputs.environment }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,4 +54,4 @@ COPY alembic.ini alembic.ini
 ARG VERSION="v0.0.0-unknown"
 RUN echo "VERSION = '${VERSION}'" > src/lamp_py/__version__.py
 
-RUN poetry install --no-dev --no-interaction --no-ansi -v
+RUN poetry install --only main --no-interaction --no-ansi -v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ bus_performance_manager = 'lamp_py.bus_performance_manager.pipeline:start'
 seed_metadata = 'lamp_py.postgres.seed_metadata:run'
 hyper_update = 'lamp_py.tableau.pipeline:start_hyper_updates'
 transit_master_ingestion = 'lamp_py.ingestion_tm.pipeline:start'
+ad_hoc = 'lamp_py.ad_hoc.pipeline:start'
 
 [tool.poetry.dependencies]
 python = "^3.10"

--- a/src/lamp_py/ad_hoc/__init__.py
+++ b/src/lamp_py/ad_hoc/__init__.py
@@ -1,0 +1,1 @@
+"""location for all ad-hoc process runner scripts"""

--- a/src/lamp_py/ad_hoc/pipeline.py
+++ b/src/lamp_py/ad_hoc/pipeline.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+
+import logging
+import os
+
+from lamp_py.aws.ecs import check_for_parallel_tasks
+from lamp_py.runtime_utils.env_validation import validate_environment
+
+from lamp_py.ad_hoc.runner_001 import runner
+
+logging.getLogger().setLevel("INFO")
+DESCRIPTION = """Entry Point For Ad-Hoc Runner"""
+
+
+def start() -> None:
+    """configure and start the ad-hoc runner"""
+    # configure the environment
+    os.environ["SERVICE_NAME"] = "ad_hoc"
+
+    validate_environment(
+        required_variables=[
+            "ARCHIVE_BUCKET",
+            "ERROR_BUCKET",
+            "INCOMING_BUCKET",
+            "PUBLIC_ARCHIVE_BUCKET",
+            "SPRINGBOARD_BUCKET",
+        ],
+        db_prefixes=["MD", "RPM"],
+    )
+
+    check_for_parallel_tasks()
+
+    # run the main method
+    runner()
+
+
+if __name__ == "__main__":
+    start()

--- a/src/lamp_py/ad_hoc/runner_001.py
+++ b/src/lamp_py/ad_hoc/runner_001.py
@@ -1,0 +1,9 @@
+from lamp_py.runtime_utils.process_logger import ProcessLogger
+
+
+def runner() -> None:
+    """Test ad-hoc runner"""
+    logger = ProcessLogger("ad_hoc_runner")
+    logger.log_start()
+    logger.add_metadata(check_ran=True)
+    logger.log_complete()


### PR DESCRIPTION
This change makes it possible to start an ad-hoc ECS Service task via github action. 

.github/actions/run_task/run_task.sh does the bulk of the work. It should be able to be generalized to start any AWS ECS Service Task.

This changes requires additional IAM permissions for the github action role that are found in this devops PR: https://github.com/mbta/devops/pull/2192.

Evidence of script success: https://github.com/mbta/lamp/actions/runs/11069324714

Asana Task: https://app.asana.com/0/1205827492903547/1207556073650893
