### PR TITLE
FEAT: Ad-Hoc Runner Script to add revenue to Springboard file

### DIFF
--- a/.github/actions/run_task/action.yaml
+++ b/.github/actions/run_task/action.yaml
@@ -25,7 +25,8 @@ runs:
         role-to-assume: ${{ inputs.role-to-assume }}
         aws-region: ${{ inputs.aws-region }}
         mask-aws-account-id: true
-    - run: ${{ github.action_path }}/run_task.sh
+    - name: Start ECS Task
+      run: ${{ github.action_path }}/run_task.sh
       shell: bash
       env:
         AWS_REGION: ${{ inputs.aws-region }}

--- a/.github/workflows/ad_hoc_deploy_run.yml
+++ b/.github/workflows/ad_hoc_deploy_run.yml
@@ -25,6 +25,7 @@ jobs:
       deploy-ad-hoc: true
     secrets: inherit
   run_ad_hoc_task:
+    needs: deploy
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/src/lamp_py/ad_hoc/runner_001.py
+++ b/src/lamp_py/ad_hoc/runner_001.py
@@ -1,9 +1,126 @@
+import os
+from datetime import date
+from datetime import timedelta
+
+import pyarrow.parquet as pq
+
 from lamp_py.runtime_utils.process_logger import ProcessLogger
+from lamp_py.postgres.postgres_utils import start_rds_writer_process
+from lamp_py.runtime_utils.remote_files import S3_ARCHIVE
+from lamp_py.runtime_utils.remote_files import LAMP
+from lamp_py.runtime_utils.remote_files import S3_SPRINGBOARD
+from lamp_py.aws.s3 import file_list_from_s3
+from lamp_py.aws.s3 import download_file
+from lamp_py.ingestion.convert_gtfs_rt import GtfsRtConverter
+from lamp_py.ingestion.converter import ConfigType
+
+
+# pylint: disable=R0801
+class AdHocConverter(GtfsRtConverter):
+    """Custom ad-hoc Converter Class"""
+
+    def convert(self) -> None:
+        """
+        ad-hoc Convert process to add revenue field to parquet files
+
+        will read from Archive bucket and not move any files after processing
+        """
+        process_logger = ProcessLogger(
+            "ad_hoc_converter",
+            config_type=str(self.config_type),
+            file_count=len(self.files),
+        )
+        process_logger.log_start()
+
+        table_count = 0
+        try:
+            for table in self.process_files():
+                if table.num_rows == 0:
+                    continue
+
+                self.continuous_pq_update(table)
+                table_count += 1
+                process_logger.add_metadata(table_count=table_count)
+
+        except Exception as exception:
+            process_logger.log_failure(exception)
+        else:
+            process_logger.log_complete()
+        finally:
+            self.clean_local_folders()
+
+    def sync_with_s3(self, local_path: str) -> bool:
+        """
+        sync local_path with S3 object if s3 file contains vehicle.trip.revenue columns
+        otherwise, ignore and create new parquet file for upload to S3
+
+        :param local_path: local tmp path file to sync
+
+        :return bool: True if local_path is available, else False
+        """
+        if os.path.exists(local_path):
+            return True
+
+        local_folder = local_path.replace(os.path.basename(local_path), "")
+        os.makedirs(local_folder, exist_ok=True)
+
+        s3_files = file_list_from_s3(
+            S3_SPRINGBOARD,
+            file_prefix=local_path.replace(f"{self.tmp_folder}/", ""),
+        )
+        if len(s3_files) == 1:
+            s3_path = s3_files[0]
+            pq_columns = pq.read_metadata(s3_path).schema.names
+            if "vehicle.trip.revenue" in pq_columns:
+                download_file(s3_path, local_path)
+                return True
+
+        return False
+
+
+# pylint: enable=R0801
 
 
 def runner() -> None:
-    """Test ad-hoc runner"""
-    logger = ProcessLogger("ad_hoc_runner")
-    logger.log_start()
-    logger.add_metadata(check_ran=True)
-    logger.log_complete()
+    """
+    add 'revenue' column to RT_VEHCILE_POSITIONf files in springboard bucket
+    starting from December 20,2023 to now.
+    """
+    ad_hoc_logger = ProcessLogger(process_name="ad_hoc_runner")
+    ad_hoc_logger.log_start()
+    prefix_date = date(2023, 12, 20)
+    # start rds writer process
+    # this will create only one rds engine while app is running
+    metadata_queue, rds_process = start_rds_writer_process()
+
+    while prefix_date <= date.today():
+        prefix = (
+            os.path.join(
+                LAMP,
+                "delta",
+                prefix_date.strftime("%Y"),
+                prefix_date.strftime("%m"),
+                prefix_date.strftime("%d"),
+            )
+            + "/"
+        )
+
+        vp_file_list = file_list_from_s3(
+            S3_ARCHIVE,
+            prefix,
+            in_filter="mbta.com_realtime_VehiclePositions_enhanced.json.gz",
+        )
+
+        converter = AdHocConverter(
+            config_type=ConfigType.from_filename(vp_file_list[0]),
+            metadata_queue=metadata_queue,
+        )
+        converter.add_files(vp_file_list)
+        converter.convert()
+
+        prefix_date += timedelta(days=1)
+
+    # stop writer process
+    metadata_queue.put(None)
+    rds_process.join()
+    ad_hoc_logger.log_complete()

--- a/src/lamp_py/ingestion/convert_gtfs_rt.py
+++ b/src/lamp_py/ingestion/convert_gtfs_rt.py
@@ -222,7 +222,7 @@ class GtfsRtConverter(Converter):
         process_logger.log_complete()
 
     def yield_check(
-        self, process_logger: ProcessLogger, min_rows: int = 5_000_000
+        self, process_logger: ProcessLogger, min_rows: int = 2_000_000
     ) -> Iterable[pyarrow.table]:
         """
         yield all tables in the data_parts map that have been sufficiently
@@ -244,8 +244,10 @@ class GtfsRtConverter(Converter):
                     number_of_rows=table.num_rows,
                 )
                 process_logger.log_complete()
-
-                process_logger.add_metadata(file_count=0, number_of_rows=0)
+                # reset process logger
+                process_logger.add_metadata(
+                    file_count=0, number_of_rows=0, print_log=False
+                )
                 process_logger.log_start()
 
                 yield table


### PR DESCRIPTION
This change creates and Ad-Hoc Runner script that will add a "vehicle.trip.revenue" column to RT_VEHICLE_POSITION springboard parquet files starting from December 20th, 2023. 

The Ad-Hoc runner will re-read GTFS-RT VehiclePosition input file, from the archive bucket, and produce new daily partitioned parquet files that include a "vehicle.trip.revenue" column. Existing parquet files that do not have a "vehicle.trip.revenue" column will be overwritten.

After the files have been created they are added to our metadata RDS table so that the performance manger application may re-ingest the files and add an accurate "revenue" values to the vehicle_event_trips table of the performance manger RDS. 

This process will run in parallel with LAMP's real-time performance pipeline so that customer data deliver will not be impacted. 

This process has already been testing on the dev environment, but will also be run on staging to confirm no adverse conditions are created. 

Asana Task: https://app.asana.com/0/1205827492903547/1208216161546522
Asana Task: https://app.asana.com/0/1205827492903547/1207556073650893
