### PR TITLE
FIX: Add parquet uint32 type to hyper file type mapping

### DIFF
--- a/src/lamp_py/tableau/hyper.py
+++ b/src/lamp_py/tableau/hyper.py
@@ -99,6 +99,7 @@ class HyperJob(ABC):  # pylint: disable=R0902
             "int8": SqlType.small_int(),
             "int16": SqlType.small_int(),
             "int32": SqlType.int(),
+            "uint32": SqlType.big_int(),
             "int64": SqlType.big_int(),
             "bool": SqlType.bool(),
             "float16": SqlType.double(),


### PR DESCRIPTION
Bus Performance Event parquet files utilize a new parquet type `unit32` that was not properly being converted to it's hyper file type equivalent. This change adds the correct type mapping. 