### PR TITLE
FIX: Bump dataset versions to load back-filled revenue data

### DIFF
--- a/src/lamp_py/performance_manager/flat_file.py
+++ b/src/lamp_py/performance_manager/flat_file.py
@@ -43,7 +43,7 @@ class S3Archive:
     RAIL_PERFORMANCE_PREFIX = os.path.join(LAMP, "subway-on-time-performance-v1")
     INDEX_FILENAME = "index.csv"
     VERSION_KEY = "rpm_version"
-    RPM_VERSION = "1.1.0"
+    RPM_VERSION = "1.2.0"
 
 
 def dates_to_update(db_manager: DatabaseManager) -> Set[datetime]:

--- a/src/lamp_py/tableau/jobs/rt_rail.py
+++ b/src/lamp_py/tableau/jobs/rt_rail.py
@@ -22,7 +22,7 @@ class HyperRtRail(HyperJob):
             self,
             hyper_file_name="LAMP_ALL_RT_fields.hyper",
             remote_parquet_path=f"{tableau_rail.s3_uri}/LAMP_ALL_RT_fields.parquet",
-            lamp_version="1.1.4",
+            lamp_version="1.2.0",
         )
         self.table_query = (
             "SELECT"


### PR DESCRIPTION
This change bumps the datasets versions for "subway-on-time-performance-v1" and "LAMP_ALL_RT_fields" so they will incorporate the historical revenue data that has been backfilled by our ad-hoc task. 

These changes will force a re-generation of these datasets, so they should wait to be deployed at the end of a business day. 

Asana Task: https://app.asana.com/0/1205827492903547/1208510809443305
