### PR TITLE
FIX: TempEventCompare max primary key error

### DIFF
--- a/src/lamp_py/performance_manager/l0_gtfs_rt_events.py
+++ b/src/lamp_py/performance_manager/l0_gtfs_rt_events.py
@@ -281,7 +281,7 @@ def build_temp_events(events: pandas.DataFrame, db_manager: DatabaseManager) -> 
     events = events.fillna(numpy.nan).replace([numpy.nan], [None])
 
     # truncate temp_event_compare table and insert all event records
-    db_manager.truncate_table(TempEventCompare)
+    db_manager.truncate_table(TempEventCompare, restart_identity=True)
     db_manager.execute_with_data(
         sa.insert(TempEventCompare.__table__),
         events,


### PR DESCRIPTION
Staging environment is showing errors because of an sql ERROR:
```nextval: reached maximum value of sequence "temp_event_compare_pk_id_seq" (2147483647)```

This change restarts the identity on the TempEventCompare table to avoid a "maximum value of sequence" error. 
