### PR TITLE
FIX: Compressed GTFS Edge Case

### DIFF
--- a/src/lamp_py/ingestion/compress_gtfs/schedule_details.py
+++ b/src/lamp_py/ingestion/compress_gtfs/schedule_details.py
@@ -208,6 +208,9 @@ def schedules_to_compress(tmp_folder: str) -> pl.DataFrame:
         reverse=True,
     )
 
+    # Insert extra year in case schedule is issued on last day of year
+    feed_years.insert(0, str(int(feed_years[0]) + 1))
+
     for year in feed_years:
         if not os.path.exists(os.path.join(tmp_folder, year)):
             os.makedirs(os.path.join(tmp_folder, year))


### PR DESCRIPTION
I believe we ran into an edge case because for the GTFS Compression process because a new schedule was issued on new years eve.

This change creates a local year folder for 1 extra year in the future to resolve this issue. 