### PR TITLE
FIX: Upgrade pm_event_id coumns to BIGINT Type

### DIFF
--- a/src/lamp_py/migrations/versions/performance_manager_dev/009_36e7a7aee148_upgrade_sequence.py
+++ b/src/lamp_py/migrations/versions/performance_manager_dev/009_36e7a7aee148_upgrade_sequence.py
@@ -1,0 +1,62 @@
+"""upgrade sequence
+
+Revision ID: 36e7a7aee148
+Revises: 32ba735d080c
+Create Date: 2025-01-07 13:57:50.433896
+
+This change upgrades the pm_event_id sequence type to bigint to avoid running out of keys
+
+Details
+* upgrade -> drop opmi view, upgrade sequence, update sequence storage columns
+
+* downgrade -> not possible, can't go from bigint to int
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+from lamp_py.migrations.versions.performance_manager_prod.sql_strings.strings_001 import view_opmi_all_rt_fields_joined
+
+# revision identifiers, used by Alembic.
+revision = "36e7a7aee148"
+down_revision = "32ba735d080c"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Upgrade sequence to BIGINT
+    op.execute("ALTER SEQUENCE vehicle_events_pm_event_id_seq as bigint MAXVALUE 9223372036854775807;")
+    # DROP VIEW before upgrading columns
+    drop_opmi_all_rt_fields_joined = "DROP VIEW IF EXISTS opmi_all_rt_fields_joined;"
+    op.execute(drop_opmi_all_rt_fields_joined)
+    # Upgrade event_id columns to BIGINT
+    op.alter_column(
+        "vehicle_events",
+        "pm_event_id",
+        existing_type=sa.INTEGER(),
+        type_=sa.BigInteger(),
+        existing_nullable=False,
+        autoincrement=True,
+    )
+    op.alter_column(
+        "vehicle_events",
+        "previous_trip_stop_pm_event_id",
+        existing_type=sa.INTEGER(),
+        type_=sa.BigInteger(),
+        existing_nullable=True,
+    )
+    op.alter_column(
+        "vehicle_events",
+        "next_trip_stop_pm_event_id",
+        existing_type=sa.INTEGER(),
+        type_=sa.BigInteger(),
+        existing_nullable=True,
+    )
+    op.execute(view_opmi_all_rt_fields_joined)
+
+
+def downgrade() -> None:
+    # Can not migrate from INT to BIGINT without losing data.
+    pass

--- a/src/lamp_py/migrations/versions/performance_manager_prod/006_36e7a7aee148_upgrade_sequence.py
+++ b/src/lamp_py/migrations/versions/performance_manager_prod/006_36e7a7aee148_upgrade_sequence.py
@@ -12,14 +12,15 @@ Details
 * downgrade -> not possible, can't go from bigint to int
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 
 from lamp_py.migrations.versions.performance_manager_prod.sql_strings.strings_001 import view_opmi_all_rt_fields_joined
 
 # revision identifiers, used by Alembic.
-revision = '36e7a7aee148'
-down_revision = '32ba735d080c'
+revision = "36e7a7aee148"
+down_revision = "32ba735d080c"
 branch_labels = None
 depends_on = None
 
@@ -31,19 +32,28 @@ def upgrade() -> None:
     drop_opmi_all_rt_fields_joined = "DROP VIEW IF EXISTS opmi_all_rt_fields_joined;"
     op.execute(drop_opmi_all_rt_fields_joined)
     # Upgrade event_id columns to BIGINT
-    op.alter_column('vehicle_events', 'pm_event_id',
-               existing_type=sa.INTEGER(),
-               type_=sa.BigInteger(),
-               existing_nullable=False,
-               autoincrement=True)
-    op.alter_column('vehicle_events', 'previous_trip_stop_pm_event_id',
-               existing_type=sa.INTEGER(),
-               type_=sa.BigInteger(),
-               existing_nullable=True)
-    op.alter_column('vehicle_events', 'next_trip_stop_pm_event_id',
-               existing_type=sa.INTEGER(),
-               type_=sa.BigInteger(),
-               existing_nullable=True)
+    op.alter_column(
+        "vehicle_events",
+        "pm_event_id",
+        existing_type=sa.INTEGER(),
+        type_=sa.BigInteger(),
+        existing_nullable=False,
+        autoincrement=True,
+    )
+    op.alter_column(
+        "vehicle_events",
+        "previous_trip_stop_pm_event_id",
+        existing_type=sa.INTEGER(),
+        type_=sa.BigInteger(),
+        existing_nullable=True,
+    )
+    op.alter_column(
+        "vehicle_events",
+        "next_trip_stop_pm_event_id",
+        existing_type=sa.INTEGER(),
+        type_=sa.BigInteger(),
+        existing_nullable=True,
+    )
     op.execute(view_opmi_all_rt_fields_joined)
 
 

--- a/src/lamp_py/migrations/versions/performance_manager_prod/006_36e7a7aee148_upgrade_sequence.py
+++ b/src/lamp_py/migrations/versions/performance_manager_prod/006_36e7a7aee148_upgrade_sequence.py
@@ -1,0 +1,52 @@
+"""upgrade sequence
+
+Revision ID: 36e7a7aee148
+Revises: 32ba735d080c
+Create Date: 2025-01-07 13:57:50.433896
+
+This change upgrades the pm_event_id sequence type to bigint to avoid running out of keys
+
+Details
+* upgrade -> drop opmi view, upgrade sequence, update sequence storage columns
+
+* downgrade -> not possible, can't go from bigint to int
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+from lamp_py.migrations.versions.performance_manager_prod.sql_strings.strings_001 import view_opmi_all_rt_fields_joined
+
+# revision identifiers, used by Alembic.
+revision = '36e7a7aee148'
+down_revision = '32ba735d080c'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Upgrade sequence to BIGINT
+    op.execute("ALTER SEQUENCE vehicle_events_pm_event_id_seq as bigint MAXVALUE 9223372036854775807;")
+    # DROP VIEW before upgrading columns
+    drop_opmi_all_rt_fields_joined = "DROP VIEW IF EXISTS opmi_all_rt_fields_joined;"
+    op.execute(drop_opmi_all_rt_fields_joined)
+    # Upgrade event_id columns to BIGINT
+    op.alter_column('vehicle_events', 'pm_event_id',
+               existing_type=sa.INTEGER(),
+               type_=sa.BigInteger(),
+               existing_nullable=False,
+               autoincrement=True)
+    op.alter_column('vehicle_events', 'previous_trip_stop_pm_event_id',
+               existing_type=sa.INTEGER(),
+               type_=sa.BigInteger(),
+               existing_nullable=True)
+    op.alter_column('vehicle_events', 'next_trip_stop_pm_event_id',
+               existing_type=sa.INTEGER(),
+               type_=sa.BigInteger(),
+               existing_nullable=True)
+    op.execute(view_opmi_all_rt_fields_joined)
+
+
+def downgrade() -> None:
+    # Can not migrate from INT to BIGINT without losing data.
+    pass

--- a/src/lamp_py/migrations/versions/performance_manager_staging/010_36e7a7aee148_upgrade_sequence.py
+++ b/src/lamp_py/migrations/versions/performance_manager_staging/010_36e7a7aee148_upgrade_sequence.py
@@ -16,7 +16,9 @@ Details
 from alembic import op
 import sqlalchemy as sa
 
-from lamp_py.migrations.versions.performance_manager_staging.sql_strings.strings_001 import view_opmi_all_rt_fields_joined
+from lamp_py.migrations.versions.performance_manager_staging.sql_strings.strings_001 import (
+    view_opmi_all_rt_fields_joined,
+)
 
 # revision identifiers, used by Alembic.
 revision = "36e7a7aee148"

--- a/src/lamp_py/migrations/versions/performance_manager_staging/010_36e7a7aee148_upgrade_sequence.py
+++ b/src/lamp_py/migrations/versions/performance_manager_staging/010_36e7a7aee148_upgrade_sequence.py
@@ -1,0 +1,62 @@
+"""upgrade sequence
+
+Revision ID: 36e7a7aee148
+Revises: 32ba735d080c
+Create Date: 2025-01-07 13:57:50.433896
+
+This change upgrades the pm_event_id sequence type to bigint to avoid running out of keys
+
+Details
+* upgrade -> drop opmi view, upgrade sequence, update sequence storage columns
+
+* downgrade -> not possible, can't go from bigint to int
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+from lamp_py.migrations.versions.performance_manager_staging.sql_strings.strings_001 import view_opmi_all_rt_fields_joined
+
+# revision identifiers, used by Alembic.
+revision = "36e7a7aee148"
+down_revision = "32ba735d080c"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Upgrade sequence to BIGINT
+    op.execute("ALTER SEQUENCE vehicle_events_pm_event_id_seq as bigint MAXVALUE 9223372036854775807;")
+    # DROP VIEW before upgrading columns
+    drop_opmi_all_rt_fields_joined = "DROP VIEW IF EXISTS opmi_all_rt_fields_joined;"
+    op.execute(drop_opmi_all_rt_fields_joined)
+    # Upgrade event_id columns to BIGINT
+    op.alter_column(
+        "vehicle_events",
+        "pm_event_id",
+        existing_type=sa.INTEGER(),
+        type_=sa.BigInteger(),
+        existing_nullable=False,
+        autoincrement=True,
+    )
+    op.alter_column(
+        "vehicle_events",
+        "previous_trip_stop_pm_event_id",
+        existing_type=sa.INTEGER(),
+        type_=sa.BigInteger(),
+        existing_nullable=True,
+    )
+    op.alter_column(
+        "vehicle_events",
+        "next_trip_stop_pm_event_id",
+        existing_type=sa.INTEGER(),
+        type_=sa.BigInteger(),
+        existing_nullable=True,
+    )
+    op.execute(view_opmi_all_rt_fields_joined)
+
+
+def downgrade() -> None:
+    # Can not migrate from INT to BIGINT without losing data.
+    pass

--- a/src/lamp_py/postgres/rail_performance_manager_schema.py
+++ b/src/lamp_py/postgres/rail_performance_manager_schema.py
@@ -19,7 +19,7 @@ class VehicleEvents(RpmSqlBase):  # pylint: disable=too-few-public-methods
 
     __tablename__ = "vehicle_events"
 
-    pm_event_id = sa.Column(sa.Integer, primary_key=True)
+    pm_event_id = sa.Column(sa.BigInteger, primary_key=True)
 
     # trip identifiers
     service_date = sa.Column(sa.Integer, nullable=False)
@@ -33,8 +33,8 @@ class VehicleEvents(RpmSqlBase):  # pylint: disable=too-few-public-methods
     parent_station = sa.Column(sa.String(60), nullable=False)
 
     # stop link fields
-    previous_trip_stop_pm_event_id = sa.Column(sa.Integer, nullable=True)
-    next_trip_stop_pm_event_id = sa.Column(sa.Integer, nullable=True)
+    previous_trip_stop_pm_event_id = sa.Column(sa.BigInteger, nullable=True)
+    next_trip_stop_pm_event_id = sa.Column(sa.BigInteger, nullable=True)
 
     # event timestamps used for metrics
     vp_move_timestamp = sa.Column(sa.Integer, nullable=True)


### PR DESCRIPTION
Staging started throwing errors because the pm_event_id column ran out of integer numbers.

This change updates the pm_event_id columns from int to bigint so we don't run out of keys. 