### PR TITLE
FEAT: Add TransitMaster fields to aid validation of GTFS vs Transitmaster bus data

### DIFF
--- a/Data_Dictionary.md
+++ b/Data_Dictionary.md
@@ -308,6 +308,9 @@ Bus has additional data source: TransitMaster. Buses have TransitMaster devices 
 | dwell_time_seconds | int64 | seconds the vehicle spent stopped at `stop_id` of trip-stop pair | LAMP Calculated |
 | route_direction_headway_seconds	| int64 | seconds between consecutive vehicles departing `stop_id` on trips with same `route_id` and `direction_id` | LAMP Calculated |
 | direction_destination_headway_seconds	| int64 | seconds between consecutive vehicles departing `stop_id` on trips with same `direction_destination` | LAMP Calculated |
+| scheduled_time	| int64 | seconds after midnight measured from TransitMaster service_date (Eastern time zone) - FOR VALIDATION ONLY - DO NOT USE - see `service_date`  | TransitMaster |
+| actual_arrival_time	| int64 | seconds after midnight measured from TransitMaster service_date (Eastern time zone) - FOR VALIDATION ONLY - DO NOT USE - see `stop_arrival_dt` | TransitMaster |
+| actual_departure_time	| int64 | seconds after midnight measured from TransitMaster service_date (Eastern time zone) - FOR VALIDATION ONLY == DO NOT USE - see `stop_departure_dt` | TransitMaster |
 
 [gtfs-rt-alert]: https://gtfs.org/realtime/reference/#message-alert
 [mbta-enhanced]: https://github.com/mbta/gtfs-documentation/blob/master/reference/gtfs-realtime.md#enhanced-fields

--- a/Data_Dictionary.md
+++ b/Data_Dictionary.md
@@ -267,7 +267,7 @@ In generating this dataset, translation string fields contain only the English t
 
 LAMP_ALL_Bus_Events & LAMP_RECENT_Bus_Events have the same data dictionary.\
 Each row represents a unique `trip_id`-`stop_id` pair for each `service_date` of bus service.\
-Bus has additional data source: TransitMaster. Buses have TransitMaster devices to keep track of their location.
+The bus data incorporates an additional data source: TransitMaster. Buses have TransitMaster devices to keep track of their location.
 
 | field name | type | description | source |
 | ----------- | --------- | ----------- | ------------ |
@@ -302,8 +302,8 @@ Bus has additional data source: TransitMaster. Buses have TransitMaster devices 
 | stop_arrival_dt | datetime | earliest "STOPPED_AT" status `timestamp` for a trip-stop pair from GTFS-RT [VehiclePosition](https://gtfs.org/realtime/reference/#message-vehicleposition) | GTFS-RT
 | stop_departure_dt | datetime | equivalent to `gtfs_travel_to_dt` for next stop on trip | GTFS-RT
 | gtfs_travel_to_seconds | int64 | `gtfs_travel_to_dt` as seconds after midnight | LAMP Calculated
-| stop_arrival_seconds | int64 | `stop_arrival_datetime` as seconds after midnight | LAMP Calculated |
-| stop_departure_seconds | int64 | `stop_departure_datetime` as seconds after midnight | LAMP Calculated |
+| stop_arrival_seconds | int64 | `stop_arrival_dt` as seconds after midnight | LAMP Calculated |
+| stop_departure_seconds | int64 | `stop_departure_dt` as seconds after midnight | LAMP Calculated |
 | travel_time_seconds | int64 | seconds the vehicle spent traveling to the `stop_id` of trip-stop pair from previous `stop_id` on trip | LAMP Calculated |
 | dwell_time_seconds | int64 | seconds the vehicle spent stopped at `stop_id` of trip-stop pair | LAMP Calculated |
 | route_direction_headway_seconds	| int64 | seconds between consecutive vehicles departing `stop_id` on trips with same `route_id` and `direction_id` | LAMP Calculated |

--- a/Data_Dictionary.md
+++ b/Data_Dictionary.md
@@ -308,9 +308,9 @@ The bus data incorporates an additional data source: TransitMaster. Buses have T
 | dwell_time_seconds | int64 | seconds the vehicle spent stopped at `stop_id` of trip-stop pair | LAMP Calculated |
 | route_direction_headway_seconds	| int64 | seconds between consecutive vehicles departing `stop_id` on trips with same `route_id` and `direction_id` | LAMP Calculated |
 | direction_destination_headway_seconds	| int64 | seconds between consecutive vehicles departing `stop_id` on trips with same `direction_destination` | LAMP Calculated |
-| scheduled_time	| int64 | seconds after midnight measured from TransitMaster service_date (Eastern time zone) - FOR VALIDATION ONLY - DO NOT USE - see `service_date`  | TransitMaster |
-| actual_arrival_time	| int64 | seconds after midnight measured from TransitMaster service_date (Eastern time zone) - FOR VALIDATION ONLY - DO NOT USE - see `stop_arrival_dt` | TransitMaster |
-| actual_departure_time	| int64 | seconds after midnight measured from TransitMaster service_date (Eastern time zone) - FOR VALIDATION ONLY == DO NOT USE - see `stop_departure_dt` | TransitMaster |
+| tm_scheduled_time_dt	| Datetime | Date calculated from seconds after midnight measured from TransitMaster service_date (Eastern time zone) - FOR VALIDATION ONLY - DO NOT USE - see `service_date`  | TransitMaster |
+| tm_actual_arrival_dt	| Datetime | Date calculated from seconds after midnight measured from TransitMaster service_date (Eastern time zone) - FOR VALIDATION ONLY - DO NOT USE - see `stop_arrival_dt` | TransitMaster |
+| tm_actual_departure_dt	| Datetime | Date calculated from seconds after midnight measured from TransitMaster service_date (Eastern time zone) - FOR VALIDATION ONLY == DO NOT USE - see `stop_departure_dt` | TransitMaster |
 
 [gtfs-rt-alert]: https://gtfs.org/realtime/reference/#message-alert
 [mbta-enhanced]: https://github.com/mbta/gtfs-documentation/blob/master/reference/gtfs-realtime.md#enhanced-fields

--- a/Data_Dictionary.md
+++ b/Data_Dictionary.md
@@ -311,6 +311,9 @@ The bus data incorporates an additional data source: TransitMaster. Buses have T
 | tm_scheduled_time_dt	| Datetime | Date calculated from seconds after midnight measured from TransitMaster service_date (Eastern time zone) - FOR VALIDATION ONLY - DO NOT USE - see `service_date`  | TransitMaster |
 | tm_actual_arrival_dt	| Datetime | Date calculated from seconds after midnight measured from TransitMaster service_date (Eastern time zone) - FOR VALIDATION ONLY - DO NOT USE - see `stop_arrival_dt` | TransitMaster |
 | tm_actual_departure_dt	| Datetime | Date calculated from seconds after midnight measured from TransitMaster service_date (Eastern time zone) - FOR VALIDATION ONLY == DO NOT USE - see `stop_departure_dt` | TransitMaster |
+| tm_scheduled_time_sam	| Int64 | seconds after midnight measured from TransitMaster service_date (Eastern time zone) - FOR VALIDATION ONLY - DO NOT USE - see `service_date`  | TransitMaster |
+| tm_actual_arrival_time_sam	| Datetime | seconds after midnight measured from TransitMaster service_date (Eastern time zone) - FOR VALIDATION ONLY - DO NOT USE - see `stop_arrival_dt` | TransitMaster |
+| tm_actual_departure_time_sam	| Datetime | seconds after midnight measured from TransitMaster service_date (Eastern time zone) - FOR VALIDATION ONLY == DO NOT USE - see `stop_departure_dt` | TransitMaster |
 
 [gtfs-rt-alert]: https://gtfs.org/realtime/reference/#message-alert
 [mbta-enhanced]: https://github.com/mbta/gtfs-documentation/blob/master/reference/gtfs-realtime.md#enhanced-fields

--- a/src/lamp_py/bus_performance_manager/events_gtfs_rt.py
+++ b/src/lamp_py/bus_performance_manager/events_gtfs_rt.py
@@ -42,6 +42,8 @@ def _read_with_polars(service_date: date, gtfs_rt_files: List[str], bus_routes: 
             pl.col("vehicle.current_status").cast(pl.String).alias("current_status"),
             pl.from_epoch("vehicle.timestamp").alias("vehicle_timestamp"),
         )
+        # We only care if the bus is IN_TRANSIT_TO or STOPPED_AT, wso we're replacing the INCOMING_TO enum from this column
+        # https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/reference.md?plain=1#L270        
         .with_columns(
             pl.when(pl.col("current_status") == "INCOMING_AT")
             .then(pl.lit("IN_TRANSIT_TO"))
@@ -109,6 +111,8 @@ def _read_with_pyarrow(service_date: date, gtfs_rt_files: List[str], bus_routes:
             pl.col("vehicle.current_status").cast(pl.String).alias("current_status"),
             pl.from_epoch("vehicle.timestamp").alias("vehicle_timestamp"),
         )
+        # We only care if the bus is IN_TRANSIT_TO or STOPPED_AT, wso we're replacing the INCOMING_TO enum from this column
+        # https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/reference.md?plain=1#L270
         .with_columns(
             pl.when(pl.col("current_status") == "INCOMING_AT")
             .then(pl.lit("IN_TRANSIT_TO"))

--- a/src/lamp_py/bus_performance_manager/events_gtfs_rt.py
+++ b/src/lamp_py/bus_performance_manager/events_gtfs_rt.py
@@ -43,7 +43,7 @@ def _read_with_polars(service_date: date, gtfs_rt_files: List[str], bus_routes: 
             pl.from_epoch("vehicle.timestamp").alias("vehicle_timestamp"),
         )
         # We only care if the bus is IN_TRANSIT_TO or STOPPED_AT, wso we're replacing the INCOMING_TO enum from this column
-        # https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/reference.md?plain=1#L270        
+        # https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/reference.md?plain=1#L270
         .with_columns(
             pl.when(pl.col("current_status") == "INCOMING_AT")
             .then(pl.lit("IN_TRANSIT_TO"))

--- a/src/lamp_py/bus_performance_manager/events_joined.py
+++ b/src/lamp_py/bus_performance_manager/events_joined.py
@@ -217,8 +217,12 @@ def join_tm_to_rt(gtfs: pl.DataFrame, tm: pl.DataFrame) -> pl.DataFrame:
     Join gtfs-rt and transit master (tm) event dataframes
 
     :return added-columns:
+        tm_scheduled_time_dt -> Datetime
         tm_actual_arrival_dt -> Datetime
         tm_actual_departure_dt -> Datetime
+        tm_scheduled_time_sam -> Int64
+        tm_actual_arrival_time_sam -> Int64
+        tm_actual_departure_time_sam -> Int64
     """
 
     # join gtfs and tm datasets using "asof" strategy for stop_sequence columns

--- a/src/lamp_py/bus_performance_manager/events_joined.py
+++ b/src/lamp_py/bus_performance_manager/events_joined.py
@@ -217,8 +217,8 @@ def join_tm_to_rt(gtfs: pl.DataFrame, tm: pl.DataFrame) -> pl.DataFrame:
     Join gtfs-rt and transit master (tm) event dataframes
 
     :return added-columns:
-        tm_arrival_dt -> Datetime
-        tm_departure_dt -> Datetime
+        tm_actual_arrival_dt -> Datetime
+        tm_actual_departure_dt -> Datetime
     """
 
     # join gtfs and tm datasets using "asof" strategy for stop_sequence columns

--- a/src/lamp_py/bus_performance_manager/events_metrics.py
+++ b/src/lamp_py/bus_performance_manager/events_metrics.py
@@ -135,9 +135,6 @@ def bus_performance_metrics(service_date: date, gtfs_files: List[str], tm_files:
             [
                 "gtfs_departure_dt",
                 "gtfs_arrival_dt",
-                "tm_actual_arrival_time_sam",
-                "tm_actual_departure_time_sam",
-                "tm_scheduled_time_sam",
                 "gtfs_sort_dt",
             ]
         )

--- a/src/lamp_py/bus_performance_manager/events_metrics.py
+++ b/src/lamp_py/bus_performance_manager/events_metrics.py
@@ -66,8 +66,7 @@ def bus_performance_metrics(service_date: date, gtfs_files: List[str], tm_files:
     bus_df = join_schedule_to_rt(join_tm_to_rt(gtfs_df, tm_df))
 
     bus_df = (
-        bus_df.with_columns(pl.coalesce(["gtfs_travel_to_dt", "gtfs_arrival_dt"]).alias("gtfs_sort_dt"))
-        .with_columns(
+        bus_df.with_columns(pl.coalesce(["gtfs_travel_to_dt", "gtfs_arrival_dt"]).alias("gtfs_sort_dt")).with_columns(
             (
                 pl.col("gtfs_travel_to_dt")
                 .shift(-1)
@@ -131,7 +130,7 @@ def bus_performance_metrics(service_date: date, gtfs_files: List[str], tm_files:
         )
         # sort to reduce parquet file size
         .sort(["route_id", "vehicle_label", "gtfs_sort_dt"])
-        # drop temp fields and dev validation fields 
+        # drop temp fields and dev validation fields
         .drop(
             [
                 "gtfs_departure_dt",

--- a/src/lamp_py/bus_performance_manager/events_metrics.py
+++ b/src/lamp_py/bus_performance_manager/events_metrics.py
@@ -38,6 +38,9 @@ def bus_performance_metrics(service_date: date, gtfs_files: List[str], tm_files:
         tm_scheduled_time_dt -> Datetime
         tm_actual_departure_dt -> Datetime
         tm_actual_arrival_dt -> Datetime
+        tm_scheduled_time_sam -> Int64
+        tm_actual_departure_time_sam -> Int64
+        tm_actual_arrival_time_sam -> Int64
         plan_trip_id -> String
         exact_plan_trip_match -> Bool
         block_id -> String

--- a/src/lamp_py/bus_performance_manager/events_tm.py
+++ b/src/lamp_py/bus_performance_manager/events_tm.py
@@ -49,9 +49,13 @@ def generate_tm_events(tm_files: List[str]) -> pl.DataFrame:
         trip_id -> String
         stop_id -> String
         tm_stop_sequence -> Int64
-        tm_scheduled_time_dt -> Datetime(time_unit='us', time_zone=None) as UTC
-        tm_actual_arrival_dt -> Datetime(time_unit='us', time_zone=None) as UTC
-        tm_actual_departure_dt -> Datetime(time_unit='us', time_zone=None) as UTC
+        tm_scheduled_time_dt -> Datetime(time_unit='us', time_zone=None) as EST
+        tm_actual_arrival_dt -> Datetime(time_unit='us', time_zone=None) as EST
+        tm_actual_departure_dt -> Datetime(time_unit='us', time_zone=None) as EST
+        tm_scheduled_time_sam -> Int64
+        tm_actual_arrival_time_sam -> Int64
+        tm_actual_departure_time_sam -> Int64
+
     """
     logger = ProcessLogger("generate_tm_events", tm_files=tm_files)
     logger.log_start()
@@ -121,7 +125,6 @@ def generate_tm_events(tm_files: List[str]) -> pl.DataFrame:
                 & pl.col("GEO_NODE_ID").is_not_null()
                 & pl.col("TRIP_ID").is_not_null()
                 & pl.col("VEHICLE_ID").is_not_null()
-                & pl.col("SCHEDULED_TIME").is_not_null()
                 & ((pl.col("ACT_ARRIVAL_TIME").is_not_null()) | (pl.col("ACT_DEPARTURE_TIME").is_not_null()))
             )
             .join(

--- a/src/lamp_py/bus_performance_manager/events_tm.py
+++ b/src/lamp_py/bus_performance_manager/events_tm.py
@@ -25,12 +25,13 @@ def _empty_stop_crossing() -> pl.DataFrame:
         "trip_id": pl.String,
         "stop_id": pl.String,
         "tm_stop_sequence": pl.Int64,
-        "tm_arrival_dt": pl.Datetime,
-        "tm_departure_dt": pl.Datetime,
-        "scheduled_time": pl.Int64,
-        "actual_departure_time": pl.Int64,
-        "actual_arrival_time": pl.Int64,
-    }
+        "tm_scheduled_time_dt": pl.Datetime,
+        "tm_actual_arrival_dt": pl.Datetime,
+        "tm_actual_departure_dt": pl.Datetime,
+        "tm_scheduled_time_sam": pl.Int64,
+        "tm_actual_departure_time_sam": pl.Int64,
+        "tm_actual_arrival_time_sam": pl.Int64,
+            }
     return pl.DataFrame(schema=schema)
 
 
@@ -48,11 +49,9 @@ def generate_tm_events(tm_files: List[str]) -> pl.DataFrame:
         trip_id -> String
         stop_id -> String
         tm_stop_sequence -> Int64
-        tm_arrival_dt -> Datetime(time_unit='us', time_zone=None) as UTC
-        tm_departure_dt -> Datetime(time_unit='us', time_zone=None) as UTC
-        scheduled_time -> Int64 (seconds after service_date midnight)
-        actual_departure_time -> Int64 (seconds after service_date midnight)
-        actual_arrival_time -> Int64 (seconds after service_date midnight)
+        tm_scheduled_time_dt -> Datetime(time_unit='us', time_zone=None) as UTC
+        tm_actual_arrival_dt -> Datetime(time_unit='us', time_zone=None) as UTC
+        tm_actual_departure_dt -> Datetime(time_unit='us', time_zone=None) as UTC
     """
     logger = ProcessLogger("generate_tm_events", tm_files=tm_files)
     logger.log_start()
@@ -165,22 +164,24 @@ def generate_tm_events(tm_files: List[str]) -> pl.DataFrame:
                 pl.col("PATTERN_GEO_NODE_SEQ").cast(pl.Int64).alias("tm_stop_sequence"),
                 pl.col("PROPERTY_TAG").cast(pl.String).alias("vehicle_label"),
                 (
-                    (pl.col("service_date") + pl.duration(seconds="ACT_ARRIVAL_TIME"))
-                    .dt.replace_time_zone("America/New_York", ambiguous="earliest")
-                    .dt.convert_time_zone("UTC")
+                    (pl.col("service_date") + pl.duration(seconds="SCHEDULED_TIME"))
                     .dt.replace_time_zone(None)
-                    .alias("tm_arrival_dt")
+                    .alias("tm_scheduled_time_dt")
+                ),
+                (
+                    (pl.col("service_date") + pl.duration(seconds="ACT_ARRIVAL_TIME"))
+                    .dt.replace_time_zone(None)
+                    .alias("tm_actual_arrival_dt")
                 ),
                 (
                     (pl.col("service_date") + pl.duration(seconds="ACT_DEPARTURE_TIME"))
-                    .dt.replace_time_zone("America/New_York", ambiguous="earliest")
-                    .dt.convert_time_zone("UTC")
                     .dt.replace_time_zone(None)
-                    .alias("tm_departure_dt")
-                ),
-                pl.col("SCHEDULED_TIME").cast(pl.Int64).alias("scheduled_time"),
-                pl.col("ACT_ARRIVAL_TIME").cast(pl.Int64).alias("actual_arrival_time"),
-                pl.col("ACT_DEPARTURE_TIME").cast(pl.Int64).alias("actual_departure_time"),
+                    .alias("tm_actual_departure_dt")
+                ), 
+                pl.col("SCHEDULED_TIME").cast(pl.Int64).alias("tm_scheduled_time_sam"),
+                pl.col("ACT_ARRIVAL_TIME").cast(pl.Int64).alias("tm_actual_arrival_time_sam"),
+                pl.col("ACT_DEPARTURE_TIME").cast(pl.Int64).alias("tm_actual_departure_time_sam"),
+
             )
             .collect()
         )

--- a/src/lamp_py/bus_performance_manager/events_tm.py
+++ b/src/lamp_py/bus_performance_manager/events_tm.py
@@ -31,7 +31,7 @@ def _empty_stop_crossing() -> pl.DataFrame:
         "tm_scheduled_time_sam": pl.Int64,
         "tm_actual_departure_time_sam": pl.Int64,
         "tm_actual_arrival_time_sam": pl.Int64,
-            }
+    }
     return pl.DataFrame(schema=schema)
 
 
@@ -177,11 +177,10 @@ def generate_tm_events(tm_files: List[str]) -> pl.DataFrame:
                     (pl.col("service_date") + pl.duration(seconds="ACT_DEPARTURE_TIME"))
                     .dt.replace_time_zone(None)
                     .alias("tm_actual_departure_dt")
-                ), 
+                ),
                 pl.col("SCHEDULED_TIME").cast(pl.Int64).alias("tm_scheduled_time_sam"),
                 pl.col("ACT_ARRIVAL_TIME").cast(pl.Int64).alias("tm_actual_arrival_time_sam"),
                 pl.col("ACT_DEPARTURE_TIME").cast(pl.Int64).alias("tm_actual_departure_time_sam"),
-
             )
             .collect()
         )

--- a/src/lamp_py/bus_performance_manager/events_tm.py
+++ b/src/lamp_py/bus_performance_manager/events_tm.py
@@ -30,7 +30,6 @@ def _empty_stop_crossing() -> pl.DataFrame:
         "scheduled_time": pl.Int64,
         "actual_departure_time": pl.Int64,
         "actual_arrival_time": pl.Int64,
-
     }
     return pl.DataFrame(schema=schema)
 
@@ -182,7 +181,7 @@ def generate_tm_events(tm_files: List[str]) -> pl.DataFrame:
                 pl.col("SCHEDULED_TIME").cast(pl.Int64).alias("scheduled_time"),
                 pl.col("ACT_ARRIVAL_TIME").cast(pl.Int64).alias("actual_arrival_time"),
                 pl.col("ACT_DEPARTURE_TIME").cast(pl.Int64).alias("actual_departure_time"),
-            )            
+            )
             .collect()
         )
 

--- a/src/lamp_py/bus_performance_manager/events_tm.py
+++ b/src/lamp_py/bus_performance_manager/events_tm.py
@@ -29,8 +29,8 @@ def _empty_stop_crossing() -> pl.DataFrame:
         "tm_actual_arrival_dt": pl.Datetime,
         "tm_actual_departure_dt": pl.Datetime,
         "tm_scheduled_time_sam": pl.Int64,
-        "tm_actual_departure_time_sam": pl.Int64,
         "tm_actual_arrival_time_sam": pl.Int64,
+        "tm_actual_departure_time_sam": pl.Int64,
     }
     return pl.DataFrame(schema=schema)
 

--- a/src/lamp_py/runtime_utils/remote_files.py
+++ b/src/lamp_py/runtime_utils/remote_files.py
@@ -106,11 +106,7 @@ tm_work_piece_file = S3Location(
 )
 
 # published by LAMP
-bus_events = S3Location(
-    bucket=S3_PUBLIC,
-    prefix=os.path.join(LAMP, "bus_vehicle_events"),
-    version="1.1"
-)
+bus_events = S3Location(bucket=S3_PUBLIC, prefix=os.path.join(LAMP, "bus_vehicle_events"), version="1.1")
 public_alerts_file = S3Location(
     bucket=S3_PUBLIC,
     prefix=os.path.join(TABLEAU, "alerts", "LAMP_RT_ALERTS.parquet"),

--- a/src/lamp_py/runtime_utils/remote_files.py
+++ b/src/lamp_py/runtime_utils/remote_files.py
@@ -109,6 +109,7 @@ tm_work_piece_file = S3Location(
 bus_events = S3Location(
     bucket=S3_PUBLIC,
     prefix=os.path.join(LAMP, "bus_vehicle_events"),
+    version="1.1"
 )
 public_alerts_file = S3Location(
     bucket=S3_PUBLIC,

--- a/src/lamp_py/tableau/jobs/bus_performance.py
+++ b/src/lamp_py/tableau/jobs/bus_performance.py
@@ -56,6 +56,12 @@ bus_schema = pyarrow.schema(
         ("dwell_time_seconds", pyarrow.int64()),
         ("route_direction_headway_seconds", pyarrow.int64()),
         ("direction_destination_headway_seconds", pyarrow.int64()),
+        ("tm_scheduled_time_dt", pyarrow.timestamp("us")),
+        ("tm_actual_arrival_dt", pyarrow.timestamp("us")),
+        ("tm_actual_departure_dt", pyarrow.timestamp("us")),
+        ("tm_scheduled_time_sam", pyarrow.int64()),
+        ("tm_actual_arrival_time_sam", pyarrow.int64()),
+        ("tm_actual_departure_time_sam", pyarrow.int64()),
     ]
 )
 

--- a/tests/bus_performance_manager/test_tm_ingestion.py
+++ b/tests/bus_performance_manager/test_tm_ingestion.py
@@ -86,9 +86,9 @@ def check_stop_crossings(stop_crossings_filepath: str) -> None:
 
     # check that all scheduled, arrival and departure timestamps happen after the start of the service date
     assert bus_events.filter(
-        (pl.col("tm_actual_arrival_dt") < service_date) | 
-        (pl.col("tm_actual_departure_dt") < service_date) | 
-        (pl.col("tm_scheduled_time_dt") < service_date)
+        (pl.col("tm_actual_arrival_dt") < service_date)
+        | (pl.col("tm_actual_departure_dt") < service_date)
+        | (pl.col("tm_scheduled_time_dt") < service_date)
     ).is_empty()
 
     # check that all departure times are after the arrival times
@@ -112,10 +112,25 @@ def check_stop_crossings(stop_crossings_filepath: str) -> None:
     assert not bus_events["tm_scheduled_time_sam"].has_nulls()
     assert not bus_events["tm_actual_arrival_time_sam"].has_nulls()
     assert not bus_events["tm_actual_departure_time_sam"].has_nulls()
-    assert bus_events.select(pl.col("tm_actual_departure_time_sam").ge(pl.col("tm_actual_arrival_time_sam"))).filter(False).is_empty()
+    assert (
+        bus_events.select(pl.col("tm_actual_departure_time_sam").ge(pl.col("tm_actual_arrival_time_sam")))
+        .filter(False)
+        .is_empty()
+    )
 
     # check that scheduled/departure/arrival dt are equal to the seconds after midnight representation
     # this also checks that all the Datetimes are in the same timezone as service_date e.g. EST
-    assert ((bus_events['tm_actual_departure_dt'] - service_date).dt.total_seconds() - bus_events['tm_actual_departure_time_sam'] == 0).all()
-    assert ((bus_events['tm_actual_arrival_dt'] - service_date).dt.total_seconds() - bus_events['tm_actual_arrival_time_sam'] == 0).all()
-    assert ((bus_events['tm_scheduled_time_dt'] - service_date).dt.total_seconds() - bus_events['tm_scheduled_time_sam'] == 0).all()
+    assert (
+        (bus_events["tm_actual_departure_dt"] - service_date).dt.total_seconds()
+        - bus_events["tm_actual_departure_time_sam"]
+        == 0
+    ).all()
+    assert (
+        (bus_events["tm_actual_arrival_dt"] - service_date).dt.total_seconds()
+        - bus_events["tm_actual_arrival_time_sam"]
+        == 0
+    ).all()
+    assert (
+        (bus_events["tm_scheduled_time_dt"] - service_date).dt.total_seconds() - bus_events["tm_scheduled_time_sam"]
+        == 0
+    ).all()

--- a/tests/bus_performance_manager/test_tm_ingestion.py
+++ b/tests/bus_performance_manager/test_tm_ingestion.py
@@ -98,3 +98,16 @@ def check_stop_crossings(stop_crossings_filepath: str) -> None:
         | pl.col("trip_id").str.starts_with("0")
         | pl.col("stop_id").str.starts_with("0")
     ).is_empty()
+
+    # scheduled_time, actual_arrival_time, actual_departure_time - these are unprocessed straight from TM. 
+    # intended for comparison/data validation - use tm_arrival_dt or tm_departure_dt instead
+
+    # e.g.
+    # tm_departure_dt 2024-06-01 13:13:47 UTC - seconds after midnight = 47627
+    # actual_departure_time - 33227
+    # 47627-33227 = 14400 / 60 / 60 = 4 hrs - (UTC -> EDT (UTC-04:00))
+
+    assert not bus_events['scheduled_time'].has_nulls()
+    assert not bus_events['actual_arrival_time'].has_nulls()
+    assert not bus_events['actual_departure_time'].has_nulls()
+    assert(bus_events.select(pl.col("actual_departure_time").ge(pl.col("actual_arrival_time"))).filter(False).is_empty())

--- a/tests/bus_performance_manager/test_tm_ingestion.py
+++ b/tests/bus_performance_manager/test_tm_ingestion.py
@@ -49,11 +49,11 @@ def check_stop_crossings(stop_crossings_filepath: str) -> None:
     run checks on the dataframes produced by running generate_tm_events on
     transit master stop crossing files.
     """
+    print(f"processing: {stop_crossings_filepath}")
     # Remove the .parquet extension and get the date
     filename = os.path.basename(stop_crossings_filepath)
     date_str = filename.replace(".parquet", "")[1:]
     service_date = datetime.strptime(date_str, "%Y%m%d").date()
-
     # this is the df of all useful records from the stop crossings files
     raw_stop_crossings = (
         pl.scan_parquet(stop_crossings_filepath)
@@ -84,13 +84,15 @@ def check_stop_crossings(stop_crossings_filepath: str) -> None:
     non_trip_events = bus_events.filter(pl.col("trip_id").is_null())
     assert set(non_trip_events["stop_id"]).issubset(bus_garages)
 
-    # check that all arrival and departure timestamps happen after the start of the service date
+    # check that all scheduled, arrival and departure timestamps happen after the start of the service date
     assert bus_events.filter(
-        (pl.col("tm_arrival_dt") < service_date) | (pl.col("tm_departure_dt") < service_date)
+        (pl.col("tm_actual_arrival_dt") < service_date) | 
+        (pl.col("tm_actual_departure_dt") < service_date) | 
+        (pl.col("tm_scheduled_time_dt") < service_date)
     ).is_empty()
 
     # check that all departure times are after the arrival times
-    assert bus_events.filter(pl.col("tm_arrival_dt") > pl.col("tm_departure_dt")).is_empty()
+    assert bus_events.filter(pl.col("tm_actual_arrival_dt") > pl.col("tm_actual_departure_dt")).is_empty()
 
     # check that there are no leading zeros on route ids
     assert bus_events.filter(
@@ -99,15 +101,21 @@ def check_stop_crossings(stop_crossings_filepath: str) -> None:
         | pl.col("stop_id").str.starts_with("0")
     ).is_empty()
 
-    # scheduled_time, actual_arrival_time, actual_departure_time - these are unprocessed straight from TM.
+    # scheduled_time_sam, actual_arrival_time_sam, actual_departure_time_sam - these are unprocessed straight from TM.
+    # sam = seconds after midnight
     # intended for comparison/data validation
 
     # e.g.
-    # tm_departure_dt 2024-06-01 13:13:47 UTC - seconds after midnight = 47627
+    # tm_actual_departure_dt 2024-06-01 13:13:47 UTC - seconds after midnight = 47627
     # actual_departure_time - 33227
     # 47627-33227 = 14400 / 60 / 60 = 4 hrs - (UTC -> EDT (UTC-04:00))
+    assert not bus_events["tm_scheduled_time_sam"].has_nulls()
+    assert not bus_events["tm_actual_arrival_time_sam"].has_nulls()
+    assert not bus_events["tm_actual_departure_time_sam"].has_nulls()
+    assert bus_events.select(pl.col("tm_actual_departure_time_sam").ge(pl.col("tm_actual_arrival_time_sam"))).filter(False).is_empty()
 
-    assert not bus_events["scheduled_time"].has_nulls()
-    assert not bus_events["actual_arrival_time"].has_nulls()
-    assert not bus_events["actual_departure_time"].has_nulls()
-    assert bus_events.select(pl.col("actual_departure_time").ge(pl.col("actual_arrival_time"))).filter(False).is_empty()
+    # check that scheduled/departure/arrival dt are equal to the seconds after midnight representation
+    # this also checks that all the Datetimes are in the same timezone as service_date e.g. EST
+    assert ((bus_events['tm_actual_departure_dt'] - service_date).dt.total_seconds() - bus_events['tm_actual_departure_time_sam'] == 0).all()
+    assert ((bus_events['tm_actual_arrival_dt'] - service_date).dt.total_seconds() - bus_events['tm_actual_arrival_time_sam'] == 0).all()
+    assert ((bus_events['tm_scheduled_time_dt'] - service_date).dt.total_seconds() - bus_events['tm_scheduled_time_sam'] == 0).all()

--- a/tests/bus_performance_manager/test_tm_ingestion.py
+++ b/tests/bus_performance_manager/test_tm_ingestion.py
@@ -100,7 +100,7 @@ def check_stop_crossings(stop_crossings_filepath: str) -> None:
     ).is_empty()
 
     # scheduled_time, actual_arrival_time, actual_departure_time - these are unprocessed straight from TM. 
-    # intended for comparison/data validation - use tm_arrival_dt or tm_departure_dt instead
+    # intended for comparison/data validation
 
     # e.g.
     # tm_departure_dt 2024-06-01 13:13:47 UTC - seconds after midnight = 47627

--- a/tests/bus_performance_manager/test_tm_ingestion.py
+++ b/tests/bus_performance_manager/test_tm_ingestion.py
@@ -99,7 +99,7 @@ def check_stop_crossings(stop_crossings_filepath: str) -> None:
         | pl.col("stop_id").str.starts_with("0")
     ).is_empty()
 
-    # scheduled_time, actual_arrival_time, actual_departure_time - these are unprocessed straight from TM. 
+    # scheduled_time, actual_arrival_time, actual_departure_time - these are unprocessed straight from TM.
     # intended for comparison/data validation
 
     # e.g.
@@ -107,7 +107,7 @@ def check_stop_crossings(stop_crossings_filepath: str) -> None:
     # actual_departure_time - 33227
     # 47627-33227 = 14400 / 60 / 60 = 4 hrs - (UTC -> EDT (UTC-04:00))
 
-    assert not bus_events['scheduled_time'].has_nulls()
-    assert not bus_events['actual_arrival_time'].has_nulls()
-    assert not bus_events['actual_departure_time'].has_nulls()
-    assert(bus_events.select(pl.col("actual_departure_time").ge(pl.col("actual_arrival_time"))).filter(False).is_empty())
+    assert not bus_events["scheduled_time"].has_nulls()
+    assert not bus_events["actual_arrival_time"].has_nulls()
+    assert not bus_events["actual_departure_time"].has_nulls()
+    assert bus_events.select(pl.col("actual_departure_time").ge(pl.col("actual_arrival_time"))).filter(False).is_empty()


### PR DESCRIPTION
 [Asana Task](https://app.asana.com/0/1189492770004753/1209391790454623)

Save off actual_departure_time, actual_arrival_time, and scheduled_time.

Trigger a regeneration of the whole bus_events datasets by bumping the version.