### PR TITLE
FIX: Run migration with sa.text

### DIFF
--- a/src/lamp_py/migrations/versions/performance_manager_prod/007_da8f80a3dd90_upgrade_sequence.py
+++ b/src/lamp_py/migrations/versions/performance_manager_prod/007_da8f80a3dd90_upgrade_sequence.py
@@ -26,15 +26,6 @@ depends_on = None
 
 
 def upgrade() -> None:
-    # Create pgstattubple extension to monitor index health
-    try:
-        log = ProcessLogger("create_pgstattuple_extension")
-        log.log_start()
-        op.execute("CREATE EXTENSION pgstattuple;")
-        log.log_complete()
-    except Exception as e:
-        log.log_failure(e)
-
     # REINDEX all tables
     tables = [
         "vehicle_events",
@@ -53,7 +44,7 @@ def upgrade() -> None:
         try:
             log = ProcessLogger(f"reindex_{table}")
             log.log_start()
-            op.execute(f"REINDEX TABLE {table};")
+            op.execute(sa.text(f"REINDEX TABLE {table};"))
             log.log_complete()
         except Exception as e:
             log.log_failure(e)


### PR DESCRIPTION
db user does not have permission to create extension, so dropped that.

Run REINDEX inside of sa.text.  