### PR TITLE
(temp) light rail gps is failing ingestion. this is unused, disabling for now

### DIFF
--- a/src/lamp_py/ingestion/pipeline.py
+++ b/src/lamp_py/ingestion/pipeline.py
@@ -61,7 +61,7 @@ def main() -> None:
         process_logger.log_start()
         bucket_filter = LAMP
         check_for_sigterm(metadata_queue, rds_process)
-        ingest_light_rail_gps(bucket_filter=bucket_filter)
+        # ingest_light_rail_gps(bucket_filter=bucket_filter)
         ingest_gtfs(metadata_queue, bucket_filter=bucket_filter)
         ingest_glides_events(glides_reader, metadata_queue)
         check_for_sigterm(metadata_queue, rds_process)

--- a/src/lamp_py/ingestion/pipeline.py
+++ b/src/lamp_py/ingestion/pipeline.py
@@ -15,7 +15,8 @@ from lamp_py.runtime_utils.process_logger import ProcessLogger
 
 from lamp_py.ingestion.ingest_gtfs import ingest_gtfs
 from lamp_py.ingestion.glides import ingest_glides_events
-from lamp_py.ingestion.light_rail_gps import ingest_light_rail_gps
+
+# from lamp_py.ingestion.light_rail_gps import ingest_light_rail_gps
 from lamp_py.runtime_utils.remote_files import LAMP
 
 logging.getLogger().setLevel("INFO")


### PR DESCRIPTION
light rail gps is failing and crashing ingestion. temporary disable while we investigate and triage. 

nobody uses this yet, so it doesn't hurt anyone