### PR TITLE
(fix) update polars types to match database types for vehicle_trips 

### DIFF
--- a/src/lamp_py/performance_manager/l0_gtfs_rt_events.py
+++ b/src/lamp_py/performance_manager/l0_gtfs_rt_events.py
@@ -282,10 +282,7 @@ def build_temp_events(events: pandas.DataFrame, db_manager: DatabaseManager) -> 
 
     # truncate temp_event_compare table and insert all event records
     db_manager.truncate_table(TempEventCompare, restart_identity=True)
-    db_manager.execute_with_data(
-        sa.insert(TempEventCompare.__table__),
-        events,
-    )
+    db_manager.execute_with_data(sa.insert(TempEventCompare.__table__), events, disable_trip_tigger=False)
 
     # make sure vehicle_trips has trips for all events in temp_event_compare
     load_new_trip_data(db_manager=db_manager)

--- a/src/lamp_py/performance_manager/l1_cte_statements.py
+++ b/src/lamp_py/performance_manager/l1_cte_statements.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import os
 import sqlalchemy as sa
 import polars as pl
 from sqlalchemy.sql.functions import rank
@@ -12,13 +13,21 @@ from lamp_py.postgres.rail_performance_manager_schema import (
     StaticRoutes,
 )
 
+GTFS_ARCHIVE = "s3://mbta-performance/lamp/gtfs_archive"
+
 
 def static_trips_subquery_pl(service_date: int) -> pl.DataFrame:
     """
+    input:
+        service_date: int - YYYYMMDD format service_date e.g. 20250410
+
+    output:
+        static_trips_subquery: pl.DataFrame of the joined result. column dtype match RDS db dtypes
+
     Polars implementation of static_trips_subquery in backup_rt_static_trip_match
     """
     service_year = str(service_date)[:4]
-    static_prefix = f"s3://mbta-performance/lamp/gtfs_archive/{service_year}"
+    static_prefix = os.path.join(GTFS_ARCHIVE, service_year)
 
     service_dt = datetime.strptime(str(service_date), "%Y%m%d")
     days = ["monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"]

--- a/src/lamp_py/performance_manager/l1_cte_statements.py
+++ b/src/lamp_py/performance_manager/l1_cte_statements.py
@@ -118,7 +118,7 @@ def static_trips_subquery_pl(service_date: int) -> pl.DataFrame:
         .group_by(["static_trip_id", "t_route_id", "direction_id"])
         .agg(
             pl.len().alias("static_stop_count"),
-            pl.min("arrival_time").alias("static_start_time"),
+            pl.min("arrival_time").cast(pl.Int32).alias("static_start_time"),
             pl.map_groups(["t_route_id", "stop_id"], function=apply_branch_route_id, returns_scalar=True).alias(
                 "route_id"
             ),

--- a/src/lamp_py/performance_manager/l1_cte_statements.py
+++ b/src/lamp_py/performance_manager/l1_cte_statements.py
@@ -108,6 +108,15 @@ def static_trips_subquery_pl(service_date: int) -> pl.DataFrame:
             return get_red_branch(set(series_list[1]))
         return series_list[0][0]
 
+    # developer note: the casts are not necessary.
+    #
+    # static_trips columns are set to the same datatypes/schema as the database
+    # representation for these columns this is not strictly necessary, as the call
+    # to execute_with_data_pl() calls polars.to_dicts(), which converts everything
+    # to native python types (Int16, Int32 --> Int) before updating the database.
+    # We choose to maintain the correct types here to ensure overflows or other
+    # dtype issues can be discovered in the python processing
+
     static_trips = (
         stop_times_lf.join(
             trips_lf.select("trip_id", "route_id", "service_id", "direction_id"),

--- a/src/lamp_py/performance_manager/l1_cte_statements.py
+++ b/src/lamp_py/performance_manager/l1_cte_statements.py
@@ -118,7 +118,7 @@ def static_trips_subquery_pl(service_date: int) -> pl.DataFrame:
         .group_by(["static_trip_id", "t_route_id", "direction_id"])
         .agg(
             pl.len().alias("static_stop_count"),
-            pl.min("arrival_time").cast(pl.Int32).alias("static_start_time"),
+            pl.min("arrival_time").alias("static_start_time"),
             pl.map_groups(["t_route_id", "stop_id"], function=apply_branch_route_id, returns_scalar=True).alias(
                 "route_id"
             ),
@@ -137,6 +137,7 @@ def static_trips_subquery_pl(service_date: int) -> pl.DataFrame:
     static_trips = static_trips.with_columns(
         pl.duration(hours=pl.col("hour"), minutes=pl.col("minute"), seconds=pl.col("second"))
         .dt.total_seconds()
+        .cast(pl.Int32)
         .alias("static_start_time")
     ).drop(["hour", "minute", "second"])
 

--- a/src/lamp_py/performance_manager/l1_cte_statements.py
+++ b/src/lamp_py/performance_manager/l1_cte_statements.py
@@ -139,8 +139,7 @@ def static_trips_subquery_pl(service_date: int) -> pl.DataFrame:
         .dt.total_seconds()
         .cast(pl.Int32)
         .alias("static_start_time"),
-        pl.col("static_stop_count")
-        .cast(pl.Int16)
+        pl.col("static_stop_count").cast(pl.Int16),
     ).drop(["hour", "minute", "second"])
 
     return static_trips

--- a/src/lamp_py/performance_manager/l1_cte_statements.py
+++ b/src/lamp_py/performance_manager/l1_cte_statements.py
@@ -138,7 +138,9 @@ def static_trips_subquery_pl(service_date: int) -> pl.DataFrame:
         pl.duration(hours=pl.col("hour"), minutes=pl.col("minute"), seconds=pl.col("second"))
         .dt.total_seconds()
         .cast(pl.Int32)
-        .alias("static_start_time")
+        .alias("static_start_time"),
+        pl.col("static_stop_count")
+        .cast(pl.Int16)
     ).drop(["hour", "minute", "second"])
 
     return static_trips

--- a/src/lamp_py/performance_manager/l1_rt_trips.py
+++ b/src/lamp_py/performance_manager/l1_rt_trips.py
@@ -1014,7 +1014,7 @@ def backup_rt_static_trip_match(
     logger.add_metadata(
         backup_trips_match_df_schema=backup_trips_match_df.schema,
         backup_trips_match_df_n_rows=backup_trips_match_df.height,
-        backup_trips_match_df_row_0=str(backup_trips_match_df.head(0).to_dict()),
+        backup_trips_match_df_row_0=str(backup_trips_match_df.head(1).to_dict()),
     )
 
     update_query = (
@@ -1028,7 +1028,7 @@ def backup_rt_static_trip_match(
         )
     )
 
-    db_manager.execute_with_data(
+    db_manager.execute_with_data_pl(
         update_query,
         backup_trips_match_df,  # we'll have to clean up the execute_with_data method
         disable_trip_tigger=True,

--- a/src/lamp_py/performance_manager/l1_rt_trips.py
+++ b/src/lamp_py/performance_manager/l1_rt_trips.py
@@ -323,7 +323,6 @@ def update_start_times(db_manager: DatabaseManager) -> None:
         db_manager.execute_with_data(
             start_times_update_query,
             unscheduled_start_times,
-            disable_trip_tigger=True,
         )
 
 
@@ -454,11 +453,7 @@ def update_branch_trunk_route_id(db_manager: DatabaseManager) -> None:
         )
     )
 
-    db_manager.execute_with_data(
-        start_times_update_query,
-        trips_df,
-        disable_trip_tigger=True,
-    )
+    db_manager.execute_with_data(start_times_update_query, trips_df)
     process_logger.log_complete()
 
 
@@ -960,7 +955,6 @@ def backup_rt_static_trip_match(
 
     logger = ProcessLogger("backup_rt_static_trip_match_pl")
     logger.log_start()
-
     static_trips_df = static_trips_subquery_pl(seed_service_date)
     logger.add_metadata(static_trips_df_schema=static_trips_df.schema, static_trips_df_n_rows=static_trips_df.height)
     # pull RT trips records that are candidates for backup matching to static trips
@@ -1028,11 +1022,7 @@ def backup_rt_static_trip_match(
         )
     )
 
-    db_manager.execute_with_data_pl(
-        update_query,
-        backup_trips_match_df,  # we'll have to clean up the execute_with_data method
-        disable_trip_tigger=True,
-    )
+    db_manager.execute_with_data_pl(update_query, backup_trips_match_df)
     logger.log_complete()
 
 

--- a/src/lamp_py/performance_manager/l1_rt_trips.py
+++ b/src/lamp_py/performance_manager/l1_rt_trips.py
@@ -956,7 +956,6 @@ def backup_rt_static_trip_match(
     logger = ProcessLogger("backup_rt_static_trip_match_pl")
     logger.log_start()
     static_trips_df = static_trips_subquery_pl(seed_service_date)
-    logger.add_metadata(static_trips_df_schema=static_trips_df.schema, static_trips_df_n_rows=static_trips_df.height)
     # pull RT trips records that are candidates for backup matching to static trips
     temp_trips = (
         sa.select(
@@ -995,9 +994,6 @@ def backup_rt_static_trip_match(
     }
 
     rt_trips_summary_df = pl.DataFrame(db_manager.select_as_list(rt_trips_summary), schema=rt_schema)
-    logger.add_metadata(
-        rt_trips_summary_df_schema=rt_trips_summary_df.schema, rt_trips_summary_df_n_rows=rt_trips_summary_df.height
-    )
 
     # backup matching logic, should match all remaining RT trips to static trips,
     # assuming that the route_id exists in the static schedule data
@@ -1005,12 +1001,6 @@ def backup_rt_static_trip_match(
         return
 
     backup_trips_match_df = backup_trips_match_pl(rt_trips_summary_df, static_trips_df).rename(rt_rename_dict)
-
-    logger.add_metadata(
-        backup_trips_match_df_schema=backup_trips_match_df.schema,
-        backup_trips_match_df_n_rows=backup_trips_match_df.height,
-        backup_trips_match_df_row_0=str(backup_trips_match_df.head(1).to_dicts()),
-    )
 
     update_query = (
         sa.update(VehicleTrips.__table__)

--- a/src/lamp_py/performance_manager/l1_rt_trips.py
+++ b/src/lamp_py/performance_manager/l1_rt_trips.py
@@ -1014,6 +1014,7 @@ def backup_rt_static_trip_match(
     logger.add_metadata(
         backup_trips_match_df_schema=backup_trips_match_df.schema,
         backup_trips_match_df_n_rows=backup_trips_match_df.height,
+        backup_trips_match_df_row_0=str(backup_trips_match_df.head(0).to_dict()),
     )
 
     update_query = (
@@ -1029,7 +1030,7 @@ def backup_rt_static_trip_match(
 
     db_manager.execute_with_data(
         update_query,
-        backup_trips_match_df.to_pandas(),  # we'll have to clean up the execute_with_data method
+        backup_trips_match_df,  # we'll have to clean up the execute_with_data method
         disable_trip_tigger=True,
     )
     logger.log_complete()

--- a/src/lamp_py/performance_manager/l1_rt_trips.py
+++ b/src/lamp_py/performance_manager/l1_rt_trips.py
@@ -1005,10 +1005,11 @@ def backup_rt_static_trip_match(
         return
 
     backup_trips_match_df = backup_trips_match_pl(rt_trips_summary_df, static_trips_df).rename(rt_rename_dict)
+
     logger.add_metadata(
         backup_trips_match_df_schema=backup_trips_match_df.schema,
         backup_trips_match_df_n_rows=backup_trips_match_df.height,
-        backup_trips_match_df_row_0=str(backup_trips_match_df.head(1).to_dict()),
+        backup_trips_match_df_row_0=str(backup_trips_match_df.head(1).to_dicts()),
     )
 
     update_query = (

--- a/src/lamp_py/postgres/postgres_utils.py
+++ b/src/lamp_py/postgres/postgres_utils.py
@@ -322,10 +322,10 @@ class DatabaseManager:
             sa.sql.dml.Insert,
         ],
         data: pl.DataFrame,
-        disable_trip_tigger: bool = False,
+        disable_trip_tigger: bool = True,
     ) -> sa.engine.CursorResult:
         """
-        execute db action WITH data as pandas dataframe
+        execute db action WITH data as polars dataframe
 
         :param disable_trip_trigger if True, will disable rt_trips_update_branch_trunk TRIGGER on vehicle_trips table
         """
@@ -349,7 +349,7 @@ class DatabaseManager:
             sa.sql.dml.Insert,
         ],
         data: pandas.DataFrame,
-        disable_trip_tigger: bool = False,
+        disable_trip_tigger: bool = True,
     ) -> sa.engine.CursorResult:
         """
         execute db action WITH data as pandas dataframe

--- a/src/lamp_py/postgres/postgres_utils.py
+++ b/src/lamp_py/postgres/postgres_utils.py
@@ -321,7 +321,7 @@ class DatabaseManager:
             sa.sql.dml.Delete,
             sa.sql.dml.Insert,
         ],
-        data: pandas.DataFrame | pl.DataFrame = pandas.Dataframe,
+        data: pandas.DataFrame | pl.DataFrame = pandas.DataFrame,
         disable_trip_tigger: bool = False,
     ) -> sa.engine.CursorResult:
         """

--- a/src/lamp_py/postgres/postgres_utils.py
+++ b/src/lamp_py/postgres/postgres_utils.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union, Callable
 import boto3
 import pandas
 import sqlalchemy as sa
+import polars as pl
 from sqlalchemy.sql.functions import now
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.orm import sessionmaker
@@ -320,7 +321,7 @@ class DatabaseManager:
             sa.sql.dml.Delete,
             sa.sql.dml.Insert,
         ],
-        data: pandas.DataFrame,
+        data: pandas.DataFrame | pl.DataFrame = pandas.Dataframe,
         disable_trip_tigger: bool = False,
     ) -> sa.engine.CursorResult:
         """
@@ -332,7 +333,7 @@ class DatabaseManager:
             self._disable_trip_trigger()
 
         with self.session.begin() as cursor:
-            result = cursor.execute(statement, data.to_dict(orient="records"))
+            result = cursor.execute(statement, data.to_dict(orient="records"))  # type: ignore
 
         if disable_trip_tigger:
             self._enable_trip_trigger()

--- a/tests/performance_manager/test_backup_trips_match.py
+++ b/tests/performance_manager/test_backup_trips_match.py
@@ -1,10 +1,13 @@
 import pytest
 import polars as pl
+from unittest.mock import patch
 from lamp_py.performance_manager.l1_cte_statements import static_trips_subquery_pl
 from lamp_py.performance_manager.l1_rt_trips import backup_trips_match_pl
 
 
-@pytest.mark.skip(reason="Temporarily disabled: PR #500")
+@patch(
+    "lamp_py.performance_manager.l1_cte_statements.GTFS_ARCHIVE", "https://performancedata.mbta.com/lamp/gtfs_archive"
+)
 def test_backup_trips_match() -> None:
     """
     test backup_trips_match
@@ -18,47 +21,10 @@ def test_backup_trips_match() -> None:
         "tests/test_files/replace_perf_mgr_query_test_data/20250415_rt_trips_for_backup_match_subquery.csv",
         infer_schema=False,
     )
-    # static_trips = pl.read_csv('tests/test_files/replace_perf_mgr_query_test_data/20250415_static_trips_subquery.csv', infer_schema=False)
     rt_trips = rt_trips_raw.with_columns(
         pl.when(pl.col("direction_id") == "f").then(pl.lit(False)).otherwise(pl.lit(True)).alias("direction_id"),
-        pl.col("start_time").cast(pl.Int64).alias("start_time"),
+        pl.col("start_time").cast(pl.Int32).alias("start_time"),
     )
-    # rt_trips = rt_trips.with_columns(
-    #     (pl.col("start_time_int") / (60 * 60)).floor().cast(pl.Int64).alias("hh"),
-    #     (pl.col("start_time_int").mod(3600) / 60).floor().cast(pl.Int64).alias("mm"),
-    #     (pl.col("start_time_int").mod(3600).mod(60)).floor().cast(pl.Int64).alias("ss"),
-    # )
-    # # breakpoint()
-    # rt_trips = rt_trips.with_columns(
-    #     pl.duration(hours=pl.col("hh"), minutes=pl.col("mm"), seconds=pl.col("ss")).alias("start_time")
-    # )
-    # breakpoint()
-    # rt_trips = rt_trips.with_columns()
-    # rt_trips = rt_trips.with_columns((pl.col("start_time_int")/(60*60)).floor().cast(pl.Int64).cast(pl.String).alias("hh"))
-    # rt_trips2 = rt_trips.with_columns((pl.col("start_time_int").mod(3600)/60).floor().cast(pl.Int64).cast(pl.String).alias("mm"))
-    # rt_trips3 = rt_trips2.with_columns((pl.col("start_time_int").mod(3600).mod(60)).floor().cast(pl.Int64).cast(pl.String).alias("ss"))
-
-    #  ((pl.col("start_time_int").mod(3600)/60).floor().cast(pl.Int64).cast(pl.String).alias("mm")),
-    #                             (((pl.col("start_time_int").mod(3600)/60).mod(60)).floor().cast(pl.Int64).cast(pl.String).alias("ss"))
 
     static_trips = static_trips_subquery_pl(20250415)
-    # breakpoint()
     backup_matched_trips = backup_trips_match_pl(rt_trips, static_trips)
-
-    # breakpoint()
-    print(backup_matched_trips)
-    # is it going to be strings IRL? What is the datatype of this stuff when it comes back
-
-
-# update_query = (
-#     sa.update(VehicleTrips.__table__)
-#     .where(
-#         VehicleTrips.pm_trip_id == backup_trips_match.c.pm_trip_id,
-#     )
-#     .values(
-#         static_trip_id_guess=backup_trips_match.c.static_trip_id,
-#         static_start_time=backup_trips_match.c.static_start_time,
-#         static_stop_count=backup_trips_match.c.static_stop_count,
-#         first_last_station_match=backup_trips_match.c.first_last_station_match,
-#     )
-# )

--- a/tests/performance_manager/test_backup_trips_match.py
+++ b/tests/performance_manager/test_backup_trips_match.py
@@ -1,6 +1,5 @@
-import pytest
-import polars as pl
 from unittest.mock import patch
+import polars as pl
 from lamp_py.performance_manager.l1_cte_statements import static_trips_subquery_pl
 from lamp_py.performance_manager.l1_rt_trips import backup_trips_match_pl
 
@@ -28,3 +27,5 @@ def test_backup_trips_match() -> None:
 
     static_trips = static_trips_subquery_pl(20250415)
     backup_matched_trips = backup_trips_match_pl(rt_trips, static_trips)
+
+    assert backup_matched_trips.height == 1299

--- a/tests/performance_manager/test_backup_trips_match.py
+++ b/tests/performance_manager/test_backup_trips_match.py
@@ -1,62 +1,63 @@
-# import polars as pl
-# from lamp_py.performance_manager.l1_cte_statements import static_trips_subquery_pl
-# from lamp_py.performance_manager.l1_rt_trips import backup_trips_match_pl
+import pytest
+import polars as pl
+from lamp_py.performance_manager.l1_cte_statements import static_trips_subquery_pl
+from lamp_py.performance_manager.l1_rt_trips import backup_trips_match_pl
+
+@pytest.mark.skip(reason="Temporarily disabled: PR #500")
+def test_backup_trips_match() -> None:
+    """
+    test backup_trips_match
+    """
+    # ┌─────────────────────────┬──────────────┬───────────────────┬───────────────────┬────────────────┐
+    # │ static_trip_id          ┆ direction_id ┆ static_stop_count ┆ static_start_time ┆ route_id       │
+    # │ ---                     ┆ ---          ┆ ---               ┆ ---               ┆ ---            │
+    # │ str                     ┆ i64          ┆ u32               ┆ str               ┆ str            │
+    # ╞═════════════════════════╪══════════════╪═══════════════════╪═══════════════════╪════════════════╡
+    rt_trips_raw = pl.read_csv(
+        "tests/test_files/replace_perf_mgr_query_test_data/20250415_rt_trips_for_backup_match_subquery.csv",
+        infer_schema=False,
+    )
+    # static_trips = pl.read_csv('tests/test_files/replace_perf_mgr_query_test_data/20250415_static_trips_subquery.csv', infer_schema=False)
+    rt_trips = rt_trips_raw.with_columns(
+        pl.when(pl.col("direction_id") == "f").then(pl.lit(False)).otherwise(pl.lit(True)).alias("direction_id"),
+        pl.col("start_time").cast(pl.Int64).alias("start_time"),
+    )
+    # rt_trips = rt_trips.with_columns(
+    #     (pl.col("start_time_int") / (60 * 60)).floor().cast(pl.Int64).alias("hh"),
+    #     (pl.col("start_time_int").mod(3600) / 60).floor().cast(pl.Int64).alias("mm"),
+    #     (pl.col("start_time_int").mod(3600).mod(60)).floor().cast(pl.Int64).alias("ss"),
+    # )
+    # # breakpoint()
+    # rt_trips = rt_trips.with_columns(
+    #     pl.duration(hours=pl.col("hh"), minutes=pl.col("mm"), seconds=pl.col("ss")).alias("start_time")
+    # )
+    # breakpoint()
+    # rt_trips = rt_trips.with_columns()
+    # rt_trips = rt_trips.with_columns((pl.col("start_time_int")/(60*60)).floor().cast(pl.Int64).cast(pl.String).alias("hh"))
+    # rt_trips2 = rt_trips.with_columns((pl.col("start_time_int").mod(3600)/60).floor().cast(pl.Int64).cast(pl.String).alias("mm"))
+    # rt_trips3 = rt_trips2.with_columns((pl.col("start_time_int").mod(3600).mod(60)).floor().cast(pl.Int64).cast(pl.String).alias("ss"))
+
+    #  ((pl.col("start_time_int").mod(3600)/60).floor().cast(pl.Int64).cast(pl.String).alias("mm")),
+    #                             (((pl.col("start_time_int").mod(3600)/60).mod(60)).floor().cast(pl.Int64).cast(pl.String).alias("ss"))
+
+    static_trips = static_trips_subquery_pl(20250415)
+    # breakpoint()
+    backup_matched_trips = backup_trips_match_pl(rt_trips, static_trips)
+
+    # breakpoint()
+    print(backup_matched_trips)
+    # is it going to be strings IRL? What is the datatype of this stuff when it comes back
 
 
-# def test_backup_trips_match() -> None:
-#     """
-#     test backup_trips_match
-#     """
-#     # ┌─────────────────────────┬──────────────┬───────────────────┬───────────────────┬────────────────┐
-#     # │ static_trip_id          ┆ direction_id ┆ static_stop_count ┆ static_start_time ┆ route_id       │
-#     # │ ---                     ┆ ---          ┆ ---               ┆ ---               ┆ ---            │
-#     # │ str                     ┆ i64          ┆ u32               ┆ str               ┆ str            │
-#     # ╞═════════════════════════╪══════════════╪═══════════════════╪═══════════════════╪════════════════╡
-#     rt_trips_raw = pl.read_csv(
-#         "tests/test_files/replace_perf_mgr_query_test_data/20250415_rt_trips_for_backup_match_subquery.csv",
-#         infer_schema=False,
+# update_query = (
+#     sa.update(VehicleTrips.__table__)
+#     .where(
+#         VehicleTrips.pm_trip_id == backup_trips_match.c.pm_trip_id,
 #     )
-#     # static_trips = pl.read_csv('tests/test_files/replace_perf_mgr_query_test_data/20250415_static_trips_subquery.csv', infer_schema=False)
-#     rt_trips = rt_trips_raw.with_columns(
-#         pl.when(pl.col("direction_id") == "f").then(pl.lit(False)).otherwise(pl.lit(True)).alias("direction_id"),
-#         pl.col("start_time").cast(pl.Int64).alias("start_time"),
+#     .values(
+#         static_trip_id_guess=backup_trips_match.c.static_trip_id,
+#         static_start_time=backup_trips_match.c.static_start_time,
+#         static_stop_count=backup_trips_match.c.static_stop_count,
+#         first_last_station_match=backup_trips_match.c.first_last_station_match,
 #     )
-#     # rt_trips = rt_trips.with_columns(
-#     #     (pl.col("start_time_int") / (60 * 60)).floor().cast(pl.Int64).alias("hh"),
-#     #     (pl.col("start_time_int").mod(3600) / 60).floor().cast(pl.Int64).alias("mm"),
-#     #     (pl.col("start_time_int").mod(3600).mod(60)).floor().cast(pl.Int64).alias("ss"),
-#     # )
-#     # # breakpoint()
-#     # rt_trips = rt_trips.with_columns(
-#     #     pl.duration(hours=pl.col("hh"), minutes=pl.col("mm"), seconds=pl.col("ss")).alias("start_time")
-#     # )
-#     # breakpoint()
-#     # rt_trips = rt_trips.with_columns()
-#     # rt_trips = rt_trips.with_columns((pl.col("start_time_int")/(60*60)).floor().cast(pl.Int64).cast(pl.String).alias("hh"))
-#     # rt_trips2 = rt_trips.with_columns((pl.col("start_time_int").mod(3600)/60).floor().cast(pl.Int64).cast(pl.String).alias("mm"))
-#     # rt_trips3 = rt_trips2.with_columns((pl.col("start_time_int").mod(3600).mod(60)).floor().cast(pl.Int64).cast(pl.String).alias("ss"))
-
-#     #  ((pl.col("start_time_int").mod(3600)/60).floor().cast(pl.Int64).cast(pl.String).alias("mm")),
-#     #                             (((pl.col("start_time_int").mod(3600)/60).mod(60)).floor().cast(pl.Int64).cast(pl.String).alias("ss"))
-
-#     static_trips = static_trips_subquery_pl(20250415)
-#     # breakpoint()
-#     backup_matched_trips = backup_trips_match_pl(rt_trips, static_trips)
-
-#     # breakpoint()
-#     print(backup_matched_trips)
-#     # is it going to be strings IRL? What is the datatype of this stuff when it comes back
-
-
-# # update_query = (
-# #     sa.update(VehicleTrips.__table__)
-# #     .where(
-# #         VehicleTrips.pm_trip_id == backup_trips_match.c.pm_trip_id,
-# #     )
-# #     .values(
-# #         static_trip_id_guess=backup_trips_match.c.static_trip_id,
-# #         static_start_time=backup_trips_match.c.static_start_time,
-# #         static_stop_count=backup_trips_match.c.static_stop_count,
-# #         first_last_station_match=backup_trips_match.c.first_last_station_match,
-# #     )
-# # )
+# )

--- a/tests/performance_manager/test_backup_trips_match.py
+++ b/tests/performance_manager/test_backup_trips_match.py
@@ -3,6 +3,7 @@ import polars as pl
 from lamp_py.performance_manager.l1_cte_statements import static_trips_subquery_pl
 from lamp_py.performance_manager.l1_rt_trips import backup_trips_match_pl
 
+
 @pytest.mark.skip(reason="Temporarily disabled: PR #500")
 def test_backup_trips_match() -> None:
     """

--- a/tests/performance_manager/test_performance_manager.py
+++ b/tests/performance_manager/test_performance_manager.py
@@ -11,12 +11,14 @@ from typing import (
     List,
     Optional,
 )
+from unittest.mock import patch
 
 import pandas
 import pyarrow
 import pytest
 import sqlalchemy as sa
 from _pytest.monkeypatch import MonkeyPatch
+
 
 from lamp_py.performance_manager.flat_file import write_flat_files, S3Archive
 from lamp_py.performance_manager.l0_gtfs_static_load import (
@@ -601,6 +603,9 @@ def test_gtfs_rt_processing(
 
 
 @pytest.mark.skip(reason="Temporarily disabled: PR #500")
+@patch(
+    "lamp_py.performance_manager.l1_cte_statements.GTFS_ARCHIVE", "https://performancedata.mbta.com/lamp/gtfs_archive"
+)
 def test_vp_only(
     rpm_db_manager: DatabaseManager,
     md_db_manager: DatabaseManager,
@@ -624,6 +629,9 @@ def test_vp_only(
 
 
 @pytest.mark.skip(reason="Temporarily disabled: PR #500")
+@patch(
+    "lamp_py.performance_manager.l1_cte_statements.GTFS_ARCHIVE", "https://performancedata.mbta.com/lamp/gtfs_archive"
+)
 def test_tu_only(
     rpm_db_manager: DatabaseManager,
     md_db_manager: DatabaseManager,
@@ -647,6 +655,9 @@ def test_tu_only(
 
 
 @pytest.mark.skip(reason="Temporarily disabled: PR #500")
+@patch(
+    "lamp_py.performance_manager.l1_cte_statements.GTFS_ARCHIVE", "https://performancedata.mbta.com/lamp/gtfs_archive"
+)
 def test_vp_and_tu(
     rpm_db_manager: DatabaseManager,
     md_db_manager: DatabaseManager,
@@ -670,6 +681,9 @@ def test_vp_and_tu(
 
 
 @pytest.mark.skip(reason="Temporarily disabled: PR #500")
+@patch(
+    "lamp_py.performance_manager.l1_cte_statements.GTFS_ARCHIVE", "https://performancedata.mbta.com/lamp/gtfs_archive"
+)
 def test_missing_start_time(
     rpm_db_manager: DatabaseManager,
     md_db_manager: DatabaseManager,

--- a/tests/performance_manager/test_performance_manager.py
+++ b/tests/performance_manager/test_performance_manager.py
@@ -602,7 +602,6 @@ def test_gtfs_rt_processing(
 # pylint: enable=R0915
 
 
-@pytest.mark.skip(reason="Temporarily disabled: PR #500")
 @patch(
     "lamp_py.performance_manager.l1_cte_statements.GTFS_ARCHIVE", "https://performancedata.mbta.com/lamp/gtfs_archive"
 )
@@ -628,7 +627,6 @@ def test_vp_only(
     check_logs(caplog)
 
 
-@pytest.mark.skip(reason="Temporarily disabled: PR #500")
 @patch(
     "lamp_py.performance_manager.l1_cte_statements.GTFS_ARCHIVE", "https://performancedata.mbta.com/lamp/gtfs_archive"
 )
@@ -654,7 +652,6 @@ def test_tu_only(
     check_logs(caplog)
 
 
-@pytest.mark.skip(reason="Temporarily disabled: PR #500")
 @patch(
     "lamp_py.performance_manager.l1_cte_statements.GTFS_ARCHIVE", "https://performancedata.mbta.com/lamp/gtfs_archive"
 )
@@ -680,7 +677,6 @@ def test_vp_and_tu(
     check_logs(caplog)
 
 
-@pytest.mark.skip(reason="Temporarily disabled: PR #500")
 @patch(
     "lamp_py.performance_manager.l1_cte_statements.GTFS_ARCHIVE", "https://performancedata.mbta.com/lamp/gtfs_archive"
 )

--- a/tests/performance_manager/test_static_trips_subquery.py
+++ b/tests/performance_manager/test_static_trips_subquery.py
@@ -1,27 +1,19 @@
 import pytest
 import polars as pl
+from unittest.mock import patch
 from polars.testing import assert_frame_equal
 from lamp_py.performance_manager.l1_cte_statements import static_trips_subquery_pl
 
 
-# look at bus performance to get a monkeypatch/thing to read from bucket from ci/cd
-@pytest.mark.skip(reason="Temporarily disabled: PR #500")
+@patch(
+    "lamp_py.performance_manager.l1_cte_statements.GTFS_ARCHIVE", "https://performancedata.mbta.com/lamp/gtfs_archive"
+)
 def test_static_trips_subquery_pl() -> None:
     """
     Passing unit test for static_trips_subquery implementation in polars/parquet
     """
-    # ┌─────────────────────────┬──────────────┬───────────────────┬───────────────────┬────────────────┐
-    # │ static_trip_id          ┆ direction_id ┆ static_stop_count ┆ static_start_time ┆ route_id       │
-    # │ ---                     ┆ ---          ┆ ---               ┆ ---               ┆ ---            │
-    # │ str                     ┆ bool         ┆ u32               ┆ i64               ┆ str            │
-    # ╞═════════════════════════╪══════════════╪═══════════════════╪═══════════════════╪════════════════╡
-    static_trips_pl = static_trips_subquery_pl(20250410).sort(by="static_trip_id")
 
-    # ┌─────────────────────────┬────────────────┬──────────────┬───────────────────┬───────────────────┐
-    # │ static_trip_id          ┆ route_id       ┆ direction_id ┆ static_start_time ┆ static_stop_count │
-    # │ ---                     ┆ ---            ┆ ---          ┆ ---               ┆ ---               │
-    # │ str                     ┆ str            ┆ str          ┆ str               ┆ str               │
-    # ╞═════════════════════════╪════════════════╪══════════════╪═══════════════════╪═══════════════════╡
+    static_trips_pl = static_trips_subquery_pl(20250410).sort(by="static_trip_id")
 
     compare_sql = pl.read_csv(
         "tests/test_files/replace_perf_mgr_query_test_data/staging_test_summary_sub.csv", infer_schema=False
@@ -29,7 +21,7 @@ def test_static_trips_subquery_pl() -> None:
 
     # need to do a few things because the csv output doesn't do types well
     static_trips_sql = compare_sql.with_columns(
-        pl.col("static_stop_count").cast(pl.UInt32),
+        pl.col("static_stop_count").cast(pl.Int16),
         pl.col("static_start_time").cast(pl.Int32),
         pl.when(pl.col("direction_id") == "f").then(pl.lit(False)).otherwise(pl.lit(True)).alias("direction_id"),
     )

--- a/tests/performance_manager/test_static_trips_subquery.py
+++ b/tests/performance_manager/test_static_trips_subquery.py
@@ -1,6 +1,5 @@
-import pytest
-import polars as pl
 from unittest.mock import patch
+import polars as pl
 from polars.testing import assert_frame_equal
 from lamp_py.performance_manager.l1_cte_statements import static_trips_subquery_pl
 

--- a/tests/performance_manager/test_static_trips_subquery.py
+++ b/tests/performance_manager/test_static_trips_subquery.py
@@ -1,75 +1,40 @@
-# from lamp_py. l1_cte_statements import (
-#     static_trips_subquery,
-# )
-# import polars as pl
-# from polars.testing import assert_frame_equal, assert_series_equal
-# from lamp_py.performance_manager.l1_cte_statements import static_trips_subquery_pl
+import pytest
+import polars as pl
+from polars.testing import assert_frame_equal
+from lamp_py.performance_manager.l1_cte_statements import static_trips_subquery_pl
 
 # look at bus performance to get a monkeypatch/thing to read from bucket from ci/cd
-# def test_static_trips_subquery_pl() -> None:
-#     """
-#     Passing unit test for static_trips_subquery implementation in polars/parquet
-#     """
-#     # ┌─────────────────────────┬──────────────┬───────────────────┬───────────────────┬────────────────┐
-#     # │ static_trip_id          ┆ direction_id ┆ static_stop_count ┆ static_start_time ┆ route_id       │
-#     # │ ---                     ┆ ---          ┆ ---               ┆ ---               ┆ ---            │
-#     # │ str                     ┆ bool         ┆ u32               ┆ i64               ┆ str            │
-#     # ╞═════════════════════════╪══════════════╪═══════════════════╪═══════════════════╪════════════════╡
-#     static_trips_sub_res = static_trips_subquery_pl(20250410).sort(by="static_trip_id")
+@pytest.mark.skip(reason="Temporarily disabled: PR #500")
+def test_static_trips_subquery_pl() -> None:
+    """
+    Passing unit test for static_trips_subquery implementation in polars/parquet
+    """
+    # ┌─────────────────────────┬──────────────┬───────────────────┬───────────────────┬────────────────┐
+    # │ static_trip_id          ┆ direction_id ┆ static_stop_count ┆ static_start_time ┆ route_id       │
+    # │ ---                     ┆ ---          ┆ ---               ┆ ---               ┆ ---            │
+    # │ str                     ┆ bool         ┆ u32               ┆ i64               ┆ str            │
+    # ╞═════════════════════════╪══════════════╪═══════════════════╪═══════════════════╪════════════════╡
+    static_trips_pl = static_trips_subquery_pl(20250410).sort(by="static_trip_id")
 
-#     # ┌─────────────────────────┬────────────────┬──────────────┬───────────────────┬───────────────────┐
-#     # │ static_trip_id          ┆ route_id       ┆ direction_id ┆ static_start_time ┆ static_stop_count │
-#     # │ ---                     ┆ ---            ┆ ---          ┆ ---               ┆ ---               │
-#     # │ str                     ┆ str            ┆ str          ┆ str               ┆ str               │
-#     # ╞═════════════════════════╪════════════════╪══════════════╪═══════════════════╪═══════════════════╡
+    # ┌─────────────────────────┬────────────────┬──────────────┬───────────────────┬───────────────────┐
+    # │ static_trip_id          ┆ route_id       ┆ direction_id ┆ static_start_time ┆ static_stop_count │
+    # │ ---                     ┆ ---            ┆ ---          ┆ ---               ┆ ---               │
+    # │ str                     ┆ str            ┆ str          ┆ str               ┆ str               │
+    # ╞═════════════════════════╪════════════════╪══════════════╪═══════════════════╪═══════════════════╡
 
-#     compare_sql = pl.read_csv(
-#         "tests/test_files/replace_perf_mgr_query_test_data/staging_test_summary_sub.csv", infer_schema=False
-#     )
+    compare_sql = pl.read_csv(
+        "tests/test_files/replace_perf_mgr_query_test_data/staging_test_summary_sub.csv", infer_schema=False
+    )
 
-#     # line up the types - convert the 24+ hour timestamp to math-able values
-#     static_trips_pl = static_trips_sub_res.with_columns(
-#         pl.col("static_start_time")
-#         .str.splitn(":", 3)
-#         .struct.rename_fields(["hour", "minute", "second"])
-#         .alias("fields")
-#     ).unnest("fields")
-#     breakpoint()
+    # need to do a few things because the csv output doesn't do types well
+    static_trips_sql = compare_sql.with_columns(
+        pl.col("static_stop_count").cast(pl.UInt32),
+        pl.col("static_start_time").cast(pl.Int32),
+        pl.when(pl.col("direction_id") == "f")
+        .then(pl.lit(False))
+        .otherwise(pl.lit(True))
+        .alias("direction_id")
+    )
 
-#     static_trips_sql = compare_sql.with_columns(
-#         pl.col("static_stop_count").cast(pl.UInt32),
-#         pl.col("static_start_time").cast(pl.Int32),
-#         pl.when(pl.col("direction_id") == "f")
-#         .then(pl.lit(False))
-#         .otherwise(pl.lit(True))
-#         .alias("direction_id")
-#     )
-
-#     breakpoint()
-#     # assert against test csv for all rows
-#     # all the easy ones
-#     assert_frame_equal(
-#         static_trips_pl.select(["static_trip_id", "direction_id", "static_stop_count", "route_id"]),
-#         static_trips_sql.select(["static_trip_id", "direction_id", "static_stop_count", "route_id"]),
-#     )
-
-#     # now the timestamp...
-#     tmp = static_trips_pl.select(["hour", "minute", "second"]).cast(pl.Int32)
-#     assert_series_equal(
-#         tmp["hour"] * 60 * 60 + tmp["minute"] * 60 + tmp["second"],
-#         static_trips_sql["static_start_time"],
-#         check_names=False,
-#     )
-
-
-# # def insert_dataframe(self, dataframe: pandas.DataFrame, insert_table: Any) -> None:
-# # """
-# # insert data into db table from pandas dataframe
-# # """
-# # insert_as = self._get_schema_table(insert_table)
-
-# # with self.session.begin() as cursor:
-# #     cursor.execute(
-# #         sa.insert(insert_as),
-# #         dataframe.to_dict(orient="records"),
-# #     )
+    # assert against test csv for all rows
+    assert_frame_equal(static_trips_pl, static_trips_sql, check_column_order=False)

--- a/tests/performance_manager/test_static_trips_subquery.py
+++ b/tests/performance_manager/test_static_trips_subquery.py
@@ -3,6 +3,7 @@ import polars as pl
 from polars.testing import assert_frame_equal
 from lamp_py.performance_manager.l1_cte_statements import static_trips_subquery_pl
 
+
 # look at bus performance to get a monkeypatch/thing to read from bucket from ci/cd
 @pytest.mark.skip(reason="Temporarily disabled: PR #500")
 def test_static_trips_subquery_pl() -> None:
@@ -30,10 +31,7 @@ def test_static_trips_subquery_pl() -> None:
     static_trips_sql = compare_sql.with_columns(
         pl.col("static_stop_count").cast(pl.UInt32),
         pl.col("static_start_time").cast(pl.Int32),
-        pl.when(pl.col("direction_id") == "f")
-        .then(pl.lit(False))
-        .otherwise(pl.lit(True))
-        .alias("direction_id")
+        pl.when(pl.col("direction_id") == "f").then(pl.lit(False)).otherwise(pl.lit(True)).alias("direction_id"),
     )
 
     # assert against test csv for all rows


### PR DESCRIPTION
Cleanup and fixes for the polars reimplementation of database queries for `backup_rt_static_trip_match`

We were unable to test these changes until getting the previous PR to staging. These changes fix the remaining issues found. 

Mostly datatype issues, one was an issue with polars -> pandas converting a column to float. 