### PR TITLE
(feat/mem) set batch_readahead and fragment_readahead for all intensive to_batches() calls

### DIFF
--- a/src/lamp_py/tableau/jobs/bus_performance.py
+++ b/src/lamp_py/tableau/jobs/bus_performance.py
@@ -87,7 +87,7 @@ def create_bus_parquet(job: HyperJob, num_files: Optional[int]) -> None:
     )
 
     with pq.ParquetWriter(job.local_parquet_path, schema=job.parquet_schema) as writer:
-        for batch in ds.to_batches(batch_size=500_000):
+        for batch in ds.to_batches(batch_size=500_000, batch_readahead=1, fragment_readahead=0):
             # this select() is here to make sure the order of the polars_df
             # schema is the same as the bus_schema above.
             # order of schema matters to the ParquetWriter

--- a/src/lamp_py/tableau/jobs/gtfs_rail.py
+++ b/src/lamp_py/tableau/jobs/gtfs_rail.py
@@ -98,7 +98,11 @@ class HyperGTFS(HyperJob):
         combine_batches = pd.dataset(
             [old_ds, new_ds],
             schema=self.parquet_schema,
-        ).to_batches(batch_size=self.ds_batch_size)
+        ).to_batches(
+            batch_size=self.ds_batch_size,
+            batch_readahead=1,
+            fragment_readahead=0,
+        )
 
         with pq.ParquetWriter(combine_parquet_path, schema=self.parquet_schema) as writer:
             for batch in combine_batches:

--- a/src/lamp_py/tableau/jobs/rt_rail.py
+++ b/src/lamp_py/tableau/jobs/rt_rail.py
@@ -225,7 +225,12 @@ class HyperRtRail(HyperJob):
 
         # update downloaded parquet file with filtered service_date
         old_filter = pc.field("service_date") < max_start_date
-        old_batches = pd.dataset(self.local_parquet_path).to_batches(filter=old_filter, batch_size=self.ds_batch_size)
+        old_batches = pd.dataset(self.local_parquet_path).to_batches(
+            filter=old_filter,
+            batch_size=self.ds_batch_size,
+            batch_readahead=1,
+            fragment_readahead=0,
+        )
         filter_path = "/tmp/filter_local.parquet"
 
         old_batch_count = 0
@@ -255,7 +260,11 @@ class HyperRtRail(HyperJob):
         combine_batches = pd.dataset(
             joined_dataset,
             schema=self.parquet_schema,
-        ).to_batches(batch_size=self.ds_batch_size)
+        ).to_batches(
+            batch_size=self.ds_batch_size,
+            batch_readahead=1,
+            fragment_readahead=0,
+        )
 
         combine_batch_count = 0
         combine_batch_rows = 0


### PR DESCRIPTION
Rail Performance Manager was dangerously close to OOM, and fell over once in the time window I was observing. Setting these params reduce memory pressure significantly. 