### PR TITLE
(feat) Misc quick fixes: Adjust tableau upload rate for GTFS-RT - LR 7 day - Bus Fields

### DIFF
--- a/runners/run_gtfs_rt_parquet_converter.py
+++ b/runners/run_gtfs_rt_parquet_converter.py
@@ -28,7 +28,7 @@ from lamp_py.runtime_utils.remote_files import (
     tableau_rt_trip_updates_heavyrail_30_day,
     tableau_devgreen_rt_vehicle_positions_lightrail_60_day,
     tableau_devgreen_rt_trip_updates_lightrail_60_day,
-    tableau_rt_vehicle_positions_all_light_rail_7_day
+    tableau_rt_vehicle_positions_all_light_rail_7_day,
 )
 
 from lamp_py.utils.filter_bank import FilterBankRtTripUpdates, FilterBankRtVehiclePositions
@@ -155,7 +155,7 @@ if __name__ == "__main__":
         HyperDevGreenGtfsRtTripUpdates,
         HyperGtfsRtVehiclePositionsHeavyRail,
         HyperGtfsRtTripUpdatesHeavyRail,
-        HyperGtfsRtVehiclePositionsAllLightRail
+        HyperGtfsRtVehiclePositionsAllLightRail,
     ]
 
     for job in parquet_update_jobs:

--- a/runners/run_gtfs_rt_parquet_converter.py
+++ b/runners/run_gtfs_rt_parquet_converter.py
@@ -28,6 +28,7 @@ from lamp_py.runtime_utils.remote_files import (
     tableau_rt_trip_updates_heavyrail_30_day,
     tableau_devgreen_rt_vehicle_positions_lightrail_60_day,
     tableau_devgreen_rt_trip_updates_lightrail_60_day,
+    tableau_rt_vehicle_positions_all_light_rail_7_day
 )
 
 from lamp_py.utils.filter_bank import FilterBankRtTripUpdates, FilterBankRtVehiclePositions
@@ -137,6 +138,16 @@ if __name__ == "__main__":
         tableau_project_name=GTFS_RT_TABLEAU_PROJECT,
     )
 
+    HyperGtfsRtVehiclePositionsAllLightRail = FilteredHyperJob(
+        remote_input_location=springboard_rt_vehicle_positions,
+        remote_output_location=tableau_rt_vehicle_positions_all_light_rail_7_day,
+        rollup_num_days=7,
+        processed_schema=convert_gtfs_rt_vehicle_position.schema(),
+        dataframe_filter=convert_gtfs_rt_vehicle_position.apply_gtfs_rt_vehicle_positions_timezone_conversions,
+        parquet_filter=FilterBankRtVehiclePositions.ParquetFilter.light_rail,
+        tableau_project_name=GTFS_RT_TABLEAU_PROJECT,
+    )
+
     parquet_update_jobs: List[HyperJob] = [
         HyperGtfsRtVehiclePositions,
         HyperGtfsRtTripUpdates,
@@ -144,6 +155,7 @@ if __name__ == "__main__":
         HyperDevGreenGtfsRtTripUpdates,
         HyperGtfsRtVehiclePositionsHeavyRail,
         HyperGtfsRtTripUpdatesHeavyRail,
+        HyperGtfsRtVehiclePositionsAllLightRail
     ]
 
     for job in parquet_update_jobs:

--- a/src/lamp_py/bus_performance_manager/events_metrics.py
+++ b/src/lamp_py/bus_performance_manager/events_metrics.py
@@ -134,13 +134,16 @@ def bus_performance_metrics(service_date: date, gtfs_files: List[str], tm_files:
         )
         # sort to reduce parquet file size
         .sort(["route_id", "vehicle_label", "gtfs_sort_dt"])
+        # TODO: re-evaluate dropping these at the conclusing of Bus data QA.
+        # commenting out for now to aid QA and validation
+        #
         # drop temp fields and dev validation fields
-        .drop(
-            [
-                "gtfs_departure_dt",
-                "gtfs_arrival_dt",
-                "gtfs_sort_dt",
-            ]
-        )
+        # .drop(
+        #     [
+        #         "gtfs_departure_dt",
+        #         "gtfs_arrival_dt",
+        #         "gtfs_sort_dt",
+        #     ]
+        # )
     )
     return bus_df

--- a/src/lamp_py/runtime_utils/remote_files.py
+++ b/src/lamp_py/runtime_utils/remote_files.py
@@ -172,6 +172,11 @@ tableau_rt_trip_updates_heavyrail_30_day = S3Location(
     bucket=S3_PUBLIC, prefix=os.path.join(TABLEAU, "gtfs-rt", "LAMP_RT_TripUpdates_HR_30_day.parquet")
 )
 
+# all light rail output file - to be converted to .hyper
+tableau_rt_vehicle_positions_all_light_rail_7_day = S3Location(
+    bucket=S3_PUBLIC, prefix=os.path.join(TABLEAU, "gtfs-rt", "LAMP_RT_VehiclePositions_ALL_LR_7_day.parquet")
+)
+
 # DEVGREEN
 tableau_devgreen_rt_vehicle_positions_lightrail_60_day = S3Location(
     bucket=S3_ARCHIVE,

--- a/src/lamp_py/tableau/jobs/filtered_hyper.py
+++ b/src/lamp_py/tableau/jobs/filtered_hyper.py
@@ -1,5 +1,5 @@
 from typing import Optional, Callable
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timedelta
 import pyarrow
 import pyarrow.parquet as pq
 import pyarrow.dataset as pd
@@ -13,10 +13,7 @@ from lamp_py.tableau.hyper import HyperJob
 
 from lamp_py.runtime_utils.remote_files import S3Location
 
-from lamp_py.aws.s3 import file_list_from_s3_with_details
 from lamp_py.aws.s3 import file_list_from_s3_date_range
-from lamp_py.aws.s3 import object_exists
-
 
 # pylint: disable=R0913,R0902
 # pylint too many local variables (more than 15)

--- a/src/lamp_py/tableau/jobs/filtered_hyper.py
+++ b/src/lamp_py/tableau/jobs/filtered_hyper.py
@@ -55,18 +55,6 @@ class FilteredHyperJob(HyperJob):
         self.update_parquet(None)
 
     def update_parquet(self, _: None) -> bool:
-
-        # only run once per day after 11AM UTC
-        if object_exists(self.remote_input_location.s3_uri):
-            now_utc = datetime.now(tz=timezone.utc)
-            last_mod: datetime = file_list_from_s3_with_details(
-                bucket_name=self.remote_input_location.bucket,
-                file_prefix=self.remote_input_location.prefix,
-            )[0]["last_modified"]
-
-            if now_utc.day == last_mod.day or now_utc.hour < 11:
-                return False
-
         return self.create_tableau_parquet(num_days=self.rollup_num_days)
 
     def create_tableau_parquet(self, num_days: Optional[int]) -> bool:

--- a/src/lamp_py/tableau/pipeline.py
+++ b/src/lamp_py/tableau/pipeline.py
@@ -37,6 +37,7 @@ from lamp_py.runtime_utils.remote_files import (
     tableau_rt_trip_updates_heavyrail_30_day,
     tableau_devgreen_rt_vehicle_positions_lightrail_60_day,
     tableau_devgreen_rt_trip_updates_lightrail_60_day,
+    tableau_rt_vehicle_positions_all_light_rail_7_day,
 )
 
 GTFS_RT_TABLEAU_PROJECT = "GTFS-RT"
@@ -78,6 +79,16 @@ HyperGtfsRtTripUpdatesHeavyRail = FilteredHyperJob(
     processed_schema=convert_gtfs_rt_trip_updates.schema(),
     dataframe_filter=convert_gtfs_rt_trip_updates.heavyrail,
     parquet_filter=FilterBankRtTripUpdates.ParquetFilter.heavy_rail,
+    tableau_project_name=GTFS_RT_TABLEAU_PROJECT,
+)
+
+HyperGtfsRtVehiclePositionsAllLightRail = FilteredHyperJob(
+    remote_input_location=springboard_rt_vehicle_positions,
+    remote_output_location=tableau_rt_vehicle_positions_all_light_rail_7_day,
+    rollup_num_days=7,
+    processed_schema=convert_gtfs_rt_vehicle_position.schema(),
+    dataframe_filter=convert_gtfs_rt_vehicle_position.apply_gtfs_rt_vehicle_positions_timezone_conversions,
+    parquet_filter=FilterBankRtVehiclePositions.ParquetFilter.light_rail,
     tableau_project_name=GTFS_RT_TABLEAU_PROJECT,
 )
 
@@ -148,6 +159,7 @@ def start_hyper_updates() -> None:
         HyperDevGreenGtfsRtTripUpdates,
         HyperGtfsRtVehiclePositionsHeavyRail,
         HyperGtfsRtTripUpdatesHeavyRail,
+        HyperGtfsRtVehiclePositionsAllLightRail,
     ]
 
     for job in hyper_jobs:
@@ -177,6 +189,7 @@ def start_parquet_updates(db_manager: DatabaseManager) -> None:
         HyperDevGreenGtfsRtTripUpdates,
         HyperGtfsRtVehiclePositionsHeavyRail,
         HyperGtfsRtTripUpdatesHeavyRail,
+        HyperGtfsRtVehiclePositionsAllLightRail,
     ]
 
     for job in parquet_update_jobs:


### PR DESCRIPTION
[Asana Task](https://app.asana.com/1/15492006741476/project/1189492770004753/task/1210404550176784?focus=true)
[Asana Task](https://app.asana.com/1/15492006741476/project/1189492770004753/task/1210404550176780?focus=true)

TransitData ask - increase rate of tableau uploads to dashboard

Implemented here:

* increase rate of all GTFS-RT uploads to once per hour
* Implement light rail vehicle positions tableau upload for recent 7 days (OPMI)
* Don't drop bus fields from parquet to aid in analysis
