### PR TITLE
(fix/temp) limit BUS_ALL to 1 year temporarily

### DIFF
--- a/src/lamp_py/tableau/jobs/bus_performance.py
+++ b/src/lamp_py/tableau/jobs/bus_performance.py
@@ -18,6 +18,9 @@ from lamp_py.aws.s3 import file_list_from_s3
 from lamp_py.aws.s3 import file_list_from_s3_with_details
 from lamp_py.aws.s3 import object_exists
 
+# temporary - ticket in backlog to implement this split as per-rating instead
+DAYS_YEAR = 365
+DAYS_WEEK = 7
 # this schema and the order of this schema SHOULD match what comes out
 # of the polars version from bus_performance_manager.
 # see select() comment below..
@@ -136,7 +139,7 @@ class HyperBusPerformanceAll(HyperJob):
             if now_utc.day == last_mod.day or now_utc.hour < 11:
                 return False
 
-        create_bus_parquet(self, None)
+        create_bus_parquet(self, days_in_year)
         return True
 
 

--- a/src/lamp_py/tableau/jobs/bus_performance.py
+++ b/src/lamp_py/tableau/jobs/bus_performance.py
@@ -139,7 +139,7 @@ class HyperBusPerformanceAll(HyperJob):
             if now_utc.day == last_mod.day or now_utc.hour < 11:
                 return False
 
-        create_bus_parquet(self, days_in_year)
+        create_bus_parquet(self, DAYS_YEAR)
         return True
 
 
@@ -162,5 +162,5 @@ class HyperBusPerformanceRecent(HyperJob):
         self.update_parquet(None)
 
     def update_parquet(self, _: None) -> bool:
-        create_bus_parquet(self, 7)
+        create_bus_parquet(self, DAYS_WEEK)
         return True


### PR DESCRIPTION
Temporary/Bus all needs to be split up as it is becoming unwieldy to query in Tableau uncompressed. 

Lowering limit to 1 year temporarily while we are still in development of the Bus Performance Manager metrics. 

Will be implemented in this [ticket](https://app.asana.com/1/15492006741476/project/1189492770004753/task/1210469663680236?focus=true)

Undo task: change YEAR for bus all to ALL (split up files)