### PR TITLE
(fix/tableau) change end date to the current day

### DIFF
--- a/src/lamp_py/tableau/jobs/filtered_hyper.py
+++ b/src/lamp_py/tableau/jobs/filtered_hyper.py
@@ -60,7 +60,12 @@ class FilteredHyperJob(HyperJob):
         Join files into single parquet file for upload to Tableau. apply filter and conversions as necessary
         """
 
-        end_date = datetime.now() - timedelta(days=1)
+        # limitation of filtered hyper only does whole days.
+        # update to allow start/end set by hour, to get the entire
+        # previous days uploads working
+        # need to implement new input daily_upload_hour as well
+        # this will currently update hourly. will monitor
+        end_date = datetime.now()
         start_date = end_date - timedelta(days=num_days)  # type: ignore
         bucket_filter_template = "year={yy}/month={mm}/day={dd}/"
         # self.remote_input_location.bucket = 'mbta-ctd-dataplatform-staging-springboard'


### PR DESCRIPTION
Change the end date to today so the FilteredHyperJob updates tableau hourly including today. In support of Recent 7 day LR Vehicle positions for OPMI

Results in some minor contention with ingestion writing - will reevaluate in a future task. [task](https://app.asana.com/1/15492006741476/project/1189492770004753/task/1210680469623771?focus=true)