### PR TITLE
(feat) implement additional required columns for bus performance manager

### DIFF
--- a/analysis/check_bus.py
+++ b/analysis/check_bus.py
@@ -67,7 +67,9 @@ tm = file_list_from_s3_date_range(
     bucket_name=bucket_name, file_prefix=file_prefix2, path_template=tm_template, end_date=date_end, start_date=date
 )
 
-bus_performance_metrics(service_date=date, gtfs_files=vp, tm_files=tm)
+df = bus_performance_metrics(service_date=date, gtfs_files=vp, tm_files=tm)
+
+print(df.height)
 
 # generate_tm_events(tm_files=['s3://mbta-ctd-dataplatform-staging-springboard/lamp/TM/STOP_CROSSING/120250502.parquet'])
 

--- a/runners/run_bus_recent_events.py
+++ b/runners/run_bus_recent_events.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+from datetime import datetime, timedelta
+from typing import List
+from lamp_py.bus_performance_manager.event_files import event_files_to_load
+from lamp_py.bus_performance_manager.events_metrics import bus_performance_metrics
+from lamp_py.bus_performance_manager.events_tm import generate_tm_events
+from lamp_py.bus_performance_manager.write_events import write_bus_metrics
+from lamp_py.runtime_utils.remote_files import S3_SPRINGBOARD, bus_events
+import pyarrow
+import pyarrow.parquet as pq
+import pyarrow.dataset as pd
+from pyarrow.fs import S3FileSystem
+from lamp_py.aws.s3 import file_list_from_s3, file_list_from_s3_date_range
+import polars as pl
+
+from lamp_py.tableau.conversions.convert_bus_performance_data import apply_bus_analysis_conversions
+from lamp_py.tableau.jobs.bus_performance import bus_schema_recent
+
+# stage 1 - regenerate range
+##################
+# this is a good runner - 6/17/25
+end_date = datetime(year=2025, month=6, day=17)
+start_date = end_date - timedelta(days=3)
+write_bus_metrics(start_date, end_date, write_local_only=True)
+##################
+ss = pl.date_range(start_date, end_date, "1d", eager=True)
+
+# stage 2 - concatenate and apply transforms
+# def create_bus_parquet(job: HyperJob, num_files: Optional[int]) -> None:
+"""
+Join bus_events files into single parquet file for upload to Tableau
+"""
+ds_paths = [f"/tmp/{service_date.strftime('%Y%m%d')}.parquet" for service_date in ss]
+
+ds = pd.dataset(
+    ds_paths,
+    format="parquet",
+    filesystem=None,
+)
+
+with pq.ParquetWriter("/tmp/bus_recent.parquet", schema=bus_schema_recent) as writer:
+    for batch in ds.to_batches(batch_size=500_000, batch_readahead=1, fragment_readahead=0):
+        # this select() is here to make sure the order of the polars_df
+        # schema is the same as the bus_schema above.
+        # order of schema matters to the ParquetWriter
+
+        # if the bus_schema above is in the same order as the batch
+        # schema, then the select will do nothing - as expected
+
+        polars_df = pl.from_arrow(batch).select(bus_schema_recent.names)  # type: ignore[union-attr]
+
+        if not isinstance(polars_df, pl.DataFrame):
+            raise TypeError(f"Expected a Polars DataFrame or Series, but got {type(polars_df)}")
+
+        writer.write_table(apply_bus_analysis_conversions(polars_df))

--- a/src/lamp_py/bus_performance_manager/events_gtfs_rt.py
+++ b/src/lamp_py/bus_performance_manager/events_gtfs_rt.py
@@ -28,6 +28,7 @@ def _read_with_polars(service_date: date, gtfs_rt_files: List[str], bus_routes: 
             & pl.col("vehicle.vehicle.id").is_not_null()
             & pl.col("vehicle.timestamp").is_not_null()
             & pl.col("vehicle.trip.start_time").is_not_null()
+            # & (pl.col("vehicle.trip.revenue") == True)
         )
         .select(
             pl.col("vehicle.trip.route_id").cast(pl.String).alias("route_id"),
@@ -42,6 +43,8 @@ def _read_with_polars(service_date: date, gtfs_rt_files: List[str], bus_routes: 
             pl.col("vehicle.current_status").cast(pl.String).alias("current_status"),
             pl.col("vehicle.position.latitude").cast(pl.Float64).alias("latitude"),
             pl.col("vehicle.position.longitude").cast(pl.Float64).alias("longitude"),
+            pl.col("vehicle.trip.revenue").cast(pl.Boolean).alias("trip_revenue"),
+            pl.col("vehicle.revenue").cast(pl.Boolean).alias("revenue"),
             pl.from_epoch("vehicle.timestamp").alias("vehicle_timestamp"),
         )
         # We only care if the bus is IN_TRANSIT_TO or STOPPED_AT, wso we're replacing the INCOMING_TO enum from this column
@@ -82,6 +85,7 @@ def _read_with_pyarrow(service_date: date, gtfs_rt_files: List[str], bus_routes:
         "vehicle.timestamp",
         "vehicle.position.latitude",
         "vehicle.position.longitude",
+        "vehicle.trip.revenue",
     ]
     # pyarrow_exp filter expression is used to limit memory usage during read operation
     pyarrow_exp = pc.field("vehicle.trip.route_id").isin(bus_routes)
@@ -101,6 +105,7 @@ def _read_with_pyarrow(service_date: date, gtfs_rt_files: List[str], bus_routes:
             & pl.col("vehicle.vehicle.id").is_not_null()
             & pl.col("vehicle.timestamp").is_not_null()
             & pl.col("vehicle.trip.start_time").is_not_null()
+            # & (pl.col("vehicle.trip.revenue") == True)
         )
         .select(
             pl.col("vehicle.trip.route_id").cast(pl.String).alias("route_id"),
@@ -115,6 +120,8 @@ def _read_with_pyarrow(service_date: date, gtfs_rt_files: List[str], bus_routes:
             pl.col("vehicle.current_status").cast(pl.String).alias("current_status"),
             pl.col("vehicle.position.latitude").cast(pl.Float64).alias("latitude"),
             pl.col("vehicle.position.longitude").cast(pl.Float64).alias("longitude"),
+            pl.col("vehicle.trip.revenue").cast(pl.Boolean).alias("trip_revenue"),
+            pl.col("vehicle.trip.revenue").cast(pl.Boolean).alias("revenue"),
             pl.from_epoch("vehicle.timestamp").alias("vehicle_timestamp"),
         )
         # We only care if the bus is IN_TRANSIT_TO or STOPPED_AT, wso we're replacing the INCOMING_TO enum from this column
@@ -259,6 +266,7 @@ def positions_to_events(vehicle_positions: pl.DataFrame) -> pl.DataFrame:
                 "gtfs_arrival_dt",
                 "latitude",
                 "longitude",
+                # "revenue"
             ]
         )
     )

--- a/src/lamp_py/bus_performance_manager/events_gtfs_rt.py
+++ b/src/lamp_py/bus_performance_manager/events_gtfs_rt.py
@@ -224,14 +224,14 @@ def positions_to_events(vehicle_positions: pl.DataFrame) -> pl.DataFrame:
             on="trip_id",
             how="left",
         )
-        .with_columns(
-            pl.coalesce(["latitude_STOPPED_AT", "latitude_IN_TRANSIT_TO"]).alias("latitude"),
-            pl.coalesce(["longitude_STOPPED_AT", "longitude_IN_TRANSIT_TO"]).alias("longitude"),
-        )
         .rename(
             {
                 "vehicle_timestamp_STOPPED_AT": "gtfs_arrival_dt",
                 "vehicle_timestamp_IN_TRANSIT_TO": "gtfs_travel_to_dt",
+                # only grab the IN_TRANSIT_TO rows because they seem to better
+                # align to actual trips than STOPPED_AT does
+                "latitude_IN_TRANSIT_TO": "latitude",
+                "longitude_IN_TRANSIT_TO": "longitude",
             }
         )
         .with_columns(

--- a/src/lamp_py/bus_performance_manager/events_gtfs_rt.py
+++ b/src/lamp_py/bus_performance_manager/events_gtfs_rt.py
@@ -44,7 +44,7 @@ def _read_with_polars(service_date: date, gtfs_rt_files: List[str], bus_routes: 
             pl.col("vehicle.position.latitude").cast(pl.Float64).alias("latitude"),
             pl.col("vehicle.position.longitude").cast(pl.Float64).alias("longitude"),
             pl.col("vehicle.trip.revenue").cast(pl.Boolean).alias("trip_revenue"),
-            pl.col("vehicle.revenue").cast(pl.Boolean).alias("revenue"),
+            # pl.col("vehicle.revenue").cast(pl.Boolean).alias("revenue"), # only in BusLoc/Swiftly VP files
             pl.from_epoch("vehicle.timestamp").alias("vehicle_timestamp"),
         )
         # We only care if the bus is IN_TRANSIT_TO or STOPPED_AT, wso we're replacing the INCOMING_TO enum from this column
@@ -121,7 +121,7 @@ def _read_with_pyarrow(service_date: date, gtfs_rt_files: List[str], bus_routes:
             pl.col("vehicle.position.latitude").cast(pl.Float64).alias("latitude"),
             pl.col("vehicle.position.longitude").cast(pl.Float64).alias("longitude"),
             pl.col("vehicle.trip.revenue").cast(pl.Boolean).alias("trip_revenue"),
-            pl.col("vehicle.trip.revenue").cast(pl.Boolean).alias("revenue"),
+            # pl.col("vehicle.trip.revenue").cast(pl.Boolean).alias("revenue"), # only in BusLoc/Swiftly VP files
             pl.from_epoch("vehicle.timestamp").alias("vehicle_timestamp"),
         )
         # We only care if the bus is IN_TRANSIT_TO or STOPPED_AT, wso we're replacing the INCOMING_TO enum from this column
@@ -169,11 +169,12 @@ def read_vehicle_positions(service_date: date, gtfs_rt_files: List[str]) -> pl.D
     logger.log_start()
     bus_routes = bus_route_ids_for_service_date(service_date)
 
-    try:
-        vehicle_positions = _read_with_polars(service_date, gtfs_rt_files, bus_routes)
-    except Exception as _:
-        logger.add_metadata(reader_engine="pyarrow")
-        vehicle_positions = _read_with_pyarrow(service_date, gtfs_rt_files, bus_routes)
+    # try:
+    #     vehicle_positions = _read_with_polars(service_date, gtfs_rt_files, bus_routes)
+    # except Exception as _:
+    # why is this so slow now? local machine?
+    logger.add_metadata(reader_engine="pyarrow")
+    vehicle_positions = _read_with_pyarrow(service_date, gtfs_rt_files, bus_routes)
 
     logger.log_complete()
     return vehicle_positions

--- a/src/lamp_py/bus_performance_manager/events_gtfs_schedule.py
+++ b/src/lamp_py/bus_performance_manager/events_gtfs_schedule.py
@@ -189,6 +189,7 @@ def stop_events_for_date(service_date: date) -> pl.DataFrame:
         "checkpoint_id",
     )
 
+    checkpoints = gtfs_from_parquet("checkpoints", service_date).select("checkpoint_id", "checkpoint_name")
     stop_count = stop_times.group_by("trip_id").len("plan_stop_count")
     trip_start = stop_times.group_by("trip_id").agg(pl.col("arrival_time").min().alias("plan_start_time"))
 
@@ -220,6 +221,11 @@ def stop_events_for_date(service_date: date) -> pl.DataFrame:
         .join(
             trip_start,
             on="trip_id",
+            how="left",
+        )
+        .join(
+            checkpoints,
+            on="checkpoint_id",
             how="left",
         )
         # .join(

--- a/src/lamp_py/bus_performance_manager/events_gtfs_schedule.py
+++ b/src/lamp_py/bus_performance_manager/events_gtfs_schedule.py
@@ -186,6 +186,7 @@ def stop_events_for_date(service_date: date) -> pl.DataFrame:
         "departure_time",
         "stop_id",
         "stop_sequence",
+        "checkpoint_id",
     )
 
     stop_count = stop_times.group_by("trip_id").len("plan_stop_count")

--- a/src/lamp_py/bus_performance_manager/events_joined.py
+++ b/src/lamp_py/bus_performance_manager/events_joined.py
@@ -158,10 +158,28 @@ def join_schedule_to_rt(gtfs: pl.DataFrame) -> pl.DataFrame:
 
     schedule = bus_gtfs_events_for_date(service_date)
 
+    # point type requires the schedule to be known, so likely handling it here after
+    # join_schedule_to_rt
+    # bus_df = bus_df.with_columns(
+    #     pl.coalesce(
+    #         pl.when(pl.col("tm_stop_sequence") == pl.col("tm_stop_sequence").min()).then(0),
+    #         pl.when(pl.col("tm_stop_sequence") == pl.col("tm_stop_sequence").max()).then(2),
+    #         pl.lit(1),
+    #     )
+    #     .over("trip_id", "route_id", "vehicle_label")
+    #     .alias("tm_point_type")
+    # )
+
+    # if for any group over, does not have a 0 and a 2 for point_type,
+    # valid trip is false
+    # rename valid trip to something better.
+
+    matched_plan_trips = match_plan_trips(gtfs, schedule)
+
     # get a plan_trip_id from the schedule for every rt trip_id
-    gtfs = gtfs.join(
-        match_plan_trips(gtfs, schedule), on="trip_id", how="left", coalesce=True, validate="m:1"
-    ).with_columns(pl.col("trip_id").eq(pl.col("plan_trip_id")).alias("exact_plan_trip_match"))
+    gtfs = gtfs.join(matched_plan_trips, on="trip_id", how="left", coalesce=True, validate="m:1").with_columns(
+        pl.col("trip_id").eq(pl.col("plan_trip_id")).alias("exact_plan_trip_match")
+    )
 
     # join plan scheudle trip data to rt gtfs
     gtfs = gtfs.join(

--- a/src/lamp_py/bus_performance_manager/events_joined.py
+++ b/src/lamp_py/bus_performance_manager/events_joined.py
@@ -202,16 +202,11 @@ def join_schedule_to_rt(gtfs: pl.DataFrame) -> pl.DataFrame:
         coalesce=True,
         validate="m:1",
     ).join(
-        (
-            schedule.select(
-                "stop_id",
-                "stop_name",
-            ).unique()
-        ),
+        (schedule.select("stop_id", "stop_name", "checkpoint_id", "checkpoint_name").unique()),
         on="stop_id",
         how="left",
         coalesce=True,
-        validate="m:1",
+        # validate="m:1",
     )
 
     # join plan schedule evenat data to rt gtfs

--- a/src/lamp_py/bus_performance_manager/events_tm.py
+++ b/src/lamp_py/bus_performance_manager/events_tm.py
@@ -92,6 +92,7 @@ def generate_tm_events(tm_files: List[str]) -> pl.DataFrame:
             "TRIP_ID",
             "TRIP_SERIAL_NUMBER",
         )
+        .rename({"Pattern_ID": "PATTERN_ID"})
         .filter(pl.col("TRIP_SERIAL_NUMBER").is_not_null())
         .unique()
     )
@@ -107,6 +108,49 @@ def generate_tm_events(tm_files: List[str]) -> pl.DataFrame:
         .filter(pl.col("PROPERTY_TAG").is_not_null())
         .unique()
     )
+
+    tm_time_points = pl.scan_parquet(tm_time_point_file.s3_uri).select(
+        "TIME_POINT_ID",
+        "TIME_POINT_ABBR",
+        "TIME_PT_NAME",
+    )
+
+    tm_pattern_geo_node_xref = pl.scan_parquet(tm_pattern_geo_node_xref_file.s3_uri).select(
+        "PATTERN_ID", "PATTERN_GEO_NODE_SEQ", "TIME_POINT_ID", "GEO_NODE_ID"
+    )
+
+    # this is the truth to reference and compare STOP_CROSSING records with to determine timepoint_order
+    tm_trip_xref = (
+        tm_trips.join(
+            tm_pattern_geo_node_xref,
+            on="PATTERN_ID",
+            how="left",
+            coalesce=True,
+        )
+        .join(tm_geo_nodes, on="GEO_NODE_ID", how="left", coalesce=True)
+        .join(tm_time_points, on="TIME_POINT_ID", how="left", coalesce=True)
+    ).sort(by=["TRIP_SERIAL_NUMBER", "PATTERN_ID", "PATTERN_GEO_NODE_SEQ"])
+
+    # TRIP_ID or [TRIP_SERIAL_NUMBER, PATTERN_ID] uniquely identify a TM "Trip".
+    # TRIP_SERIAL_NUMBER is the publicly facing number (and gets aliased to "TRIP_ID" below)
+    tm_sequences = tm_trip_xref.group_by(["TRIP_ID"]).agg(
+        pl.col("PATTERN_GEO_NODE_SEQ").max().alias("tm_planned_sequence_end"),
+        pl.col("PATTERN_GEO_NODE_SEQ").min().alias("tm_planned_sequence_start"),
+    )
+
+    # select tr.TRIP_SERIAL_NUMBER as trip_id
+    #         ,geo.GEO_NODE_ABBR as stop_id
+    #         ,geo.GEO_NODE_NAME as stop_name
+    #         ,timept.TIME_POINT_ABBR as tp_name
+    #         ,xref.PATTERN_GEO_NODE_SEQ as tm_sequence
+    #     from TMViewport..TMMain_Trip tr =============== - STOP_CROSSING - TRIP
+    #     join TMViewport..TMMain_PATTERN_GEO_NODE_XREF xref
+    #         on tr.PATTERN_ID=xref.PATTERN_ID =============== - STOP_CROSSING - default
+    #     join TMViewport.dbo.TMMain_GEO_NODE geo
+    #         on xref.GEO_NODE_ID = geo.GEO_NODE_ID =============== - STOP_CROSSING - default
+    #     left join TMViewport.dbo.TMDataMart_TIME_POINT timept
+    #         on xref.TIME_POINT_ID = timept.TIME_POINT_ID =============== - NEW
+    #     order by xref.PATTERN_GEO_NODE_SEQ
 
     # pull stop crossing information for a given service date and join it with
     # other dataframes using the transit master keys.
@@ -166,6 +210,10 @@ def generate_tm_events(tm_files: List[str]) -> pl.DataFrame:
                 pl.col("GEO_NODE_ABBR").cast(pl.String).alias("stop_id"),
                 pl.col("PATTERN_GEO_NODE_SEQ").cast(pl.Int64).alias("tm_stop_sequence"),
                 pl.col("PROPERTY_TAG").cast(pl.String).alias("vehicle_label"),
+                pl.col("TIME_POINT_ID").cast(pl.Int64).alias("timepoint_id"),
+                pl.col("TIME_POINT_ABBR").cast(pl.String).alias("timepoint_abbr"),
+                pl.col("TIME_PT_NAME").cast(pl.String).alias("timepoint_name"),
+                pl.col("PATTERN_ID").cast(pl.Int64).alias("pattern_id"),
                 (
                     (pl.col("service_date") + pl.duration(seconds="SCHEDULED_TIME"))
                     .dt.replace_time_zone("America/New_York", ambiguous="earliest")

--- a/src/lamp_py/bus_performance_manager/events_tm.py
+++ b/src/lamp_py/bus_performance_manager/events_tm.py
@@ -191,21 +191,14 @@ def generate_tm_events(tm_files: List[str]) -> pl.DataFrame:
             .collect()
         )
 
-    # # add a new column tm_joined to keep track of whether the join to gtfs is successful or not
-    # # in the final output of this method:
-    # # tm_joined - true if join is successful
-    # # tm_joined - false if join not successful - tm row will be inserted via concat
-    # # tm_joined - null if this is a pure GTFS row with no TM fields
-
-    # tm_stop_crossings = tm_stop_crossings.with_columns(
-    #     (pl.col(["tm_stop_sequence"]).rank(method="dense").alias("timepoint_order")),
-    #     (pl.lit(True).alias("tm_joined")),
-    #     pl.coalesce(
-    #         pl.when(pl.col("tm_stop_sequence") == pl.col("tm_stop_sequence").min()).then(0),
-    #         pl.when(pl.col("tm_stop_sequence") == pl.col("tm_stop_sequence").max()).then(2),
-    #         pl.lit(1),
-    #     )
-    # )#.sort(by=["route_id", "trip_id", "vehicle_label", "stop_id", "tm_stop_sequence"])
+    tm_stop_crossings = tm_stop_crossings.with_columns(
+        (
+            pl.col(["tm_stop_sequence"])
+            .rank(method="dense")
+            .over(["trip_id", "pattern_id", "vehicle_label"])
+            .alias("timepoint_order")
+        )
+    )
 
     if tm_stop_crossings.shape[0] == 0:
         tm_stop_crossings = _empty_stop_crossing()

--- a/src/lamp_py/bus_performance_manager/events_tm.py
+++ b/src/lamp_py/bus_performance_manager/events_tm.py
@@ -191,6 +191,22 @@ def generate_tm_events(tm_files: List[str]) -> pl.DataFrame:
             .collect()
         )
 
+    # # add a new column tm_joined to keep track of whether the join to gtfs is successful or not
+    # # in the final output of this method:
+    # # tm_joined - true if join is successful
+    # # tm_joined - false if join not successful - tm row will be inserted via concat
+    # # tm_joined - null if this is a pure GTFS row with no TM fields
+
+    # tm_stop_crossings = tm_stop_crossings.with_columns(
+    #     (pl.col(["tm_stop_sequence"]).rank(method="dense").alias("timepoint_order")),
+    #     (pl.lit(True).alias("tm_joined")),
+    #     pl.coalesce(
+    #         pl.when(pl.col("tm_stop_sequence") == pl.col("tm_stop_sequence").min()).then(0),
+    #         pl.when(pl.col("tm_stop_sequence") == pl.col("tm_stop_sequence").max()).then(2),
+    #         pl.lit(1),
+    #     )
+    # )#.sort(by=["route_id", "trip_id", "vehicle_label", "stop_id", "tm_stop_sequence"])
+
     if tm_stop_crossings.shape[0] == 0:
         tm_stop_crossings = _empty_stop_crossing()
 


### PR DESCRIPTION
[tm_not_null](https://app.asana.com/1/15492006741476/project/1189492770004753/task/1210058693545805)
[timepoint_name](https://app.asana.com/1/15492006741476/project/1189492770004753/task/1209939711691455)
[point_type](https://app.asana.com/1/15492006741476/project/1189492770004753/task/1210092273140307)
[latlon](https://app.asana.com/1/15492006741476/project/1189492770004753/task/1210528708241232)
[timepoint_order](https://app.asana.com/1/15492006741476/project/1189492770004753/task/1209312681633186)

* timepoint_name/abbr
* timepoint_order
* latitude/longitude (only from IN_TRANSIT_TO events - STOPPED_AT has limitations due to vendor datasource)
* grab all TM rows regardless of whether they join to GTFS rows in dataset - to get all non-revenue/TM specific info
* point_type

Some WIP/development rows are being committed here that will not make it to the final dataset - keeping for now to track work
* checkpoint_id/name
* revenue

