### PR TITLE
Reveal (and address) mypy errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ pretty = true
 python_version = "3.12"
 warn_unreachable = true
 warn_unused_ignores = true
-exclude = ["investigation/", "runners", "analysis/", "src/lamp_py/tableau/spare/"]
+exclude = ["investigation/", "runners", "analysis/", "tests/bus_performance_manager/validate_schedule.py"]
 
 [tool.pytest]
 log_cli = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ target-version = ['py310']
 [tool.mypy]
 disallow_untyped_defs = true
 ignore_missing_imports = true
+disable_error_code = ["union-attr"]
 plugins = ["sqlalchemy.ext.mypy.plugin"]
 pretty = true
 python_version = "3.12"

--- a/src/lamp_py/bus_performance_manager/events_tm_schedule.py
+++ b/src/lamp_py/bus_performance_manager/events_tm_schedule.py
@@ -18,16 +18,16 @@ class TransitMasterSchedule:
     Class holding collection of TM schedule inputs and the resultant tm_schedule for joining with GTFS
     """
 
-    tm_geo_nodes: pl.DataFrame | pl.LazyFrame
-    tm_routes: pl.DataFrame | pl.LazyFrame
-    tm_vehicles: pl.DataFrame | pl.LazyFrame
-    tm_time_points: pl.DataFrame | pl.LazyFrame
-    tm_pattern_geo_node_xref: pl.DataFrame | pl.LazyFrame  # to get actual timepoints (non_null)
-    tm_pattern_geo_node_xref_full: pl.DataFrame | pl.LazyFrame  # to get all stop sequence (including non-timepoint)
-    tm_trip_geo_tp: pl.DataFrame | pl.LazyFrame  # derived
-    tm_trip_geo_tp_full: pl.DataFrame | pl.LazyFrame  # derived
-    tm_sequences: pl.DataFrame | pl.LazyFrame  # derived
-    tm_schedule: pl.DataFrame | pl.LazyFrame
+    tm_geo_nodes: pl.LazyFrame
+    tm_routes: pl.LazyFrame
+    tm_vehicles: pl.LazyFrame
+    tm_time_points: pl.LazyFrame
+    tm_pattern_geo_node_xref: pl.LazyFrame  # to get actual timepoints (non_null)
+    tm_pattern_geo_node_xref_full: pl.LazyFrame  # to get all stop sequence (including non-timepoint)
+    tm_trip_geo_tp: pl.LazyFrame  # derived
+    tm_trip_geo_tp_full: pl.LazyFrame  # derived
+    tm_sequences: pl.LazyFrame  # derived
+    tm_schedule: pl.LazyFrame
 
 
 def generate_tm_schedule() -> TransitMasterSchedule:

--- a/src/lamp_py/ingestion/utils.py
+++ b/src/lamp_py/ingestion/utils.py
@@ -262,8 +262,8 @@ def hash_gtfs_rt_parquet(path: str) -> None:
             for batch in ds.iter_batches(batch_size=512 * 1024):
                 batch = pl.from_arrow(batch)
                 batch = (
-                    batch.with_columns(  # type: ignore
-                        batch.select(hash_columns)  # type: ignore
+                    batch.with_columns(
+                        batch.select(hash_columns)
                         .map_rows(hash_gtfs_rt_row, return_dtype=pl.Binary)
                         .to_series(0)
                         .alias(GTFS_RT_HASH_COL)

--- a/src/lamp_py/migrations/env.py
+++ b/src/lamp_py/migrations/env.py
@@ -85,10 +85,10 @@ def run_migrations_online() -> None:
     db_name = db_name_env.rsplit("_", 1)[0]
     connectable = db_details[db_name]["engine"]
 
-    with connectable.connect() as connection:
+    with connectable.connect() as connection:  # type: ignore[attr-defined]
         context.configure(
             connection=connection,
-            target_metadata=db_details[db_name]["target_metadata"],
+            target_metadata=db_details[db_name]["target_metadata"],  # type: ignore[arg-type]
         )
 
         with context.begin_transaction():

--- a/src/lamp_py/mssql/mssql_utils.py
+++ b/src/lamp_py/mssql/mssql_utils.py
@@ -99,14 +99,18 @@ class MSSQLManager:
 
         return result
 
-    def select_as_dataframe(self, select_query: sa.sql.selectable.Select) -> pandas.DataFrame:
+    def select_as_dataframe(
+        self, select_query: Union[sa.sql.expression.Select, sa.sql.expression.TextClause]
+    ) -> pandas.DataFrame:
         """
         select data from db table and return pandas dataframe
         """
         with self.session.begin() as cursor:
             return pandas.DataFrame([row._asdict() for row in cursor.execute(select_query)])
 
-    def select_as_list(self, select_query: sa.sql.selectable.Select) -> Union[List[Any], List[Dict[str, Any]]]:
+    def select_as_list(
+        self, select_query: Union[sa.sql.expression.Select, sa.sql.expression.TextClause]
+    ) -> Union[List[Any], List[Dict[str, Any]]]:
         """
         select data from db table and return list
         """
@@ -115,7 +119,7 @@ class MSSQLManager:
 
     def write_to_parquet(
         self,
-        select_query: sa.sql.selectable.Select,
+        select_query: Union[sa.sql.expression.Select, sa.sql.expression.TextClause],
         write_path: str,
         schema: pyarrow.schema,
         batch_size: int = 1024 * 1024,

--- a/src/lamp_py/performance_manager/l0_gtfs_static_load.py
+++ b/src/lamp_py/performance_manager/l0_gtfs_static_load.py
@@ -53,7 +53,7 @@ class StaticTableDetails:
 
     table_name: str
     insert_table: sa.sql.schema.Table
-    static_version_key_column: sa.sql.schema.Column
+    static_version_key_column: sa.sql.expression.SQLColumnExpression
     column_info: StaticTableColumns
     data_table: pandas.DataFrame = field(default_factory=pandas.DataFrame)
     allow_empty_dataframe: bool = False

--- a/src/lamp_py/performance_manager/pipeline.py
+++ b/src/lamp_py/performance_manager/pipeline.py
@@ -133,7 +133,7 @@ def start() -> None:
     )
 
     # run rail performance manager rds migrations
-    alembic_upgrade_to_head(db_name=os.getenv("ALEMBIC_RPM_DB_NAME"))
+    alembic_upgrade_to_head(db_name=os.getenv("ALEMBIC_RPM_DB_NAME"))  # type: ignore[arg-type]
 
     # run one time actions at every application deployment
     run_on_app_start()

--- a/src/lamp_py/postgres/postgres_utils.py
+++ b/src/lamp_py/postgres/postgres_utils.py
@@ -386,7 +386,9 @@ class DatabaseManager:
         with self.session.begin() as cursor:
             return pandas.DataFrame([row._asdict() for row in cursor.execute(select_query)])
 
-    def select_as_list(self, select_query: sa.sql.selectable.Select) -> Union[List[Any], List[Dict[str, Any]]]:
+    def select_as_list(
+        self, select_query: Union[sa.sql.expression.Select, sa.sql.expression.TextClause]
+    ) -> Union[List[Any], List[Dict[str, Any]]]:
         """
         select data from db table and return list
         """
@@ -395,7 +397,7 @@ class DatabaseManager:
 
     def write_to_parquet(
         self,
-        select_query: sa.sql.selectable.Select,
+        select_query: Union[sa.sql.expression.Select, sa.sql.expression.TextClause],
         write_path: str,
         schema: pyarrow.schema,
         batch_size: int = 1024 * 1024,

--- a/src/lamp_py/runtime_utils/env_validation.py
+++ b/src/lamp_py/runtime_utils/env_validation.py
@@ -49,6 +49,7 @@ def validate_environment(
         # do not log private variables
         if key in private_variables:
             value = "**********"
+        assert isinstance(value, str)  # assert value is not none for type safety
         metadata[key] = value
 
     # for optional variables, access ones that exist and add them to logs.

--- a/src/lamp_py/runtime_utils/process_logger.py
+++ b/src/lamp_py/runtime_utils/process_logger.py
@@ -4,11 +4,12 @@ import time
 import traceback
 import uuid
 import shutil
-from typing import Any, Dict, Union, Optional
+from datetime import date
+from typing import Any, Dict, Union, Optional, List
 
 import psutil
 
-MdValues = Optional[Union[str, int, float, bool]]
+MdValues = Optional[Union[str, int, float, bool, date, BaseException, List[str]]]
 
 
 class ProcessLogger:

--- a/src/lamp_py/tableau/hyper.py
+++ b/src/lamp_py/tableau/hyper.py
@@ -70,13 +70,13 @@ class HyperJob(ABC):  # pylint: disable=R0902
         """
 
     @abstractmethod
-    def create_parquet(self, db_manager: DatabaseManager | None) -> None:
+    def create_parquet(self, db_manager) -> None:  # type: ignore[no-untyped-def]
         """
         Business logic to create new Job parquet file
         """
 
     @abstractmethod
-    def update_parquet(self, db_manager: DatabaseManager | None) -> bool:
+    def update_parquet(self, db_manager) -> bool:  # type: ignore[no-untyped-def]
         """
         Business logic to update existing Job parquet file
 

--- a/src/lamp_py/tableau/hyper.py
+++ b/src/lamp_py/tableau/hyper.py
@@ -1,8 +1,9 @@
 import os
 from abc import ABC
 from abc import abstractmethod
+from datetime import date
 from itertools import chain
-from typing import Dict
+from typing import Dict, Union
 
 import pyarrow
 from pyarrow import fs
@@ -120,7 +121,7 @@ class HyperJob(ABC):  # pylint: disable=R0902
 
         return SqlType.text()
 
-    def max_stats_of_parquet(self) -> Dict[str, str]:
+    def max_stats_of_parquet(self) -> Dict[str, Union[str, date]]:
         """
         Create dictionary of maximum value for each column of locally saved
         parquet file

--- a/src/lamp_py/tableau/hyper.py
+++ b/src/lamp_py/tableau/hyper.py
@@ -70,13 +70,13 @@ class HyperJob(ABC):  # pylint: disable=R0902
         """
 
     @abstractmethod
-    def create_parquet(self, db_manager) -> None:  # type: ignore[no-untyped-def]
+    def create_parquet(self, db_manager: DatabaseManager | None) -> None:
         """
         Business logic to create new Job parquet file
         """
 
     @abstractmethod
-    def update_parquet(self, db_manager) -> bool:  # type: ignore[no-untyped-def]
+    def update_parquet(self, db_manager: DatabaseManager | None) -> bool:
         """
         Business logic to update existing Job parquet file
 

--- a/src/lamp_py/tableau/jobs/bus_performance.py
+++ b/src/lamp_py/tableau/jobs/bus_performance.py
@@ -9,6 +9,7 @@ from pyarrow.fs import S3FileSystem
 import polars as pl
 
 from lamp_py.tableau.hyper import HyperJob
+from lamp_py.postgres.postgres_utils import DatabaseManager
 from lamp_py.tableau.conversions.convert_bus_performance_data import apply_bus_analysis_conversions
 
 from lamp_py.runtime_utils.remote_files import bus_events
@@ -125,10 +126,10 @@ class HyperBusPerformanceAll(HyperJob):
     def output_processed_schema(self) -> pyarrow.schema:
         return bus_schema
 
-    def create_parquet(self, _: None) -> None:
+    def create_parquet(self, _: DatabaseManager | None) -> None:
         self.update_parquet(None)
 
-    def update_parquet(self, _: None) -> bool:
+    def update_parquet(self, _: DatabaseManager | None) -> bool:
         # only run once per day after 11AM UTC
         if object_exists(tableau_bus_all.s3_uri):
             now_utc = datetime.now(tz=timezone.utc)
@@ -159,9 +160,9 @@ class HyperBusPerformanceRecent(HyperJob):
     def output_processed_schema(self) -> pyarrow.schema:
         return bus_schema
 
-    def create_parquet(self, _: None) -> None:
+    def create_parquet(self, _: DatabaseManager | None) -> None:
         self.update_parquet(None)
 
-    def update_parquet(self, _: None) -> bool:
+    def update_parquet(self, _: DatabaseManager | None) -> bool:
         create_bus_parquet(self, BUS_RECENT_NDAYS)
         return True

--- a/src/lamp_py/tableau/jobs/bus_performance.py
+++ b/src/lamp_py/tableau/jobs/bus_performance.py
@@ -102,7 +102,7 @@ def create_bus_parquet(job: HyperJob, num_files: Optional[int]) -> None:
             # if the bus_schema above is in the same order as the batch
             # schema, then the select will do nothing - as expected
 
-            polars_df = pl.from_arrow(batch).select(job.output_processed_schema.names)  # type: ignore[union-attr]
+            polars_df = pl.from_arrow(batch).select(job.output_processed_schema.names)
 
             if not isinstance(polars_df, pl.DataFrame):
                 raise TypeError(f"Expected a Polars DataFrame or Series, but got {type(polars_df)}")

--- a/src/lamp_py/tableau/jobs/filtered_hyper.py
+++ b/src/lamp_py/tableau/jobs/filtered_hyper.py
@@ -10,7 +10,7 @@ import polars as pl
 
 from lamp_py.runtime_utils.process_logger import ProcessLogger
 from lamp_py.tableau.hyper import HyperJob
-
+from lamp_py.postgres.postgres_utils import DatabaseManager
 from lamp_py.runtime_utils.remote_files import S3Location
 
 from lamp_py.aws.s3 import file_list_from_s3, file_list_from_s3_date_range
@@ -51,10 +51,10 @@ class FilteredHyperJob(HyperJob):
     def output_processed_schema(self) -> pyarrow.schema:
         return self.processed_schema
 
-    def create_parquet(self, _: None) -> None:
+    def create_parquet(self, _: DatabaseManager | None) -> None:
         self.update_parquet(None)
 
-    def update_parquet(self, _: None) -> bool:
+    def update_parquet(self, _: DatabaseManager | None) -> bool:
         return self.create_tableau_parquet(num_days=self.rollup_num_days)
 
     # pylint: disable=R0914, R0912

--- a/src/lamp_py/tableau/jobs/filtered_hyper.py
+++ b/src/lamp_py/tableau/jobs/filtered_hyper.py
@@ -27,7 +27,7 @@ class FilteredHyperJob(HyperJob):
         remote_output_location: S3Location,
         processed_schema: pyarrow.schema,
         tableau_project_name: str,
-        rollup_num_days: int = 7,  # default this to a week of data
+        rollup_num_days: Optional[int] = 7,  # default this to a week of data
         parquet_preprocess: Callable[[pyarrow.Table], pyarrow.Table] | None = None,
         parquet_filter: pc.Expression | None = None,
         dataframe_filter: Callable[[pl.DataFrame], pl.DataFrame] | None = None,

--- a/src/lamp_py/tableau/jobs/glides.py
+++ b/src/lamp_py/tableau/jobs/glides.py
@@ -8,6 +8,7 @@ from pyarrow.fs import S3FileSystem
 import polars as pl
 
 from lamp_py.tableau.hyper import HyperJob
+from lamp_py.postgres.postgres_utils import DatabaseManager
 from lamp_py.runtime_utils.remote_files import (
     glides_trips_updated,
     glides_operator_signed_in,
@@ -184,10 +185,10 @@ class HyperGlidesTripUpdates(HyperJob):
     def output_processed_schema(self) -> pyarrow.schema:
         return glides_trips_updated_schema
 
-    def create_parquet(self, _: None) -> None:
+    def create_parquet(self, _: DatabaseManager | None) -> None:
         self.update_parquet(None)
 
-    def update_parquet(self, _: None) -> bool:
+    def update_parquet(self, _: DatabaseManager | None) -> bool:
 
         create_trips_updated_glides_parquet(self, None)
         return True
@@ -209,10 +210,10 @@ class HyperGlidesOperatorSignIns(HyperJob):
     def output_processed_schema(self) -> pyarrow.schema:
         return glides_operator_signed_in_schema
 
-    def create_parquet(self, _: None) -> None:
+    def create_parquet(self, _: DatabaseManager | None) -> None:
         self.update_parquet(None)
 
-    def update_parquet(self, _: None) -> bool:
+    def update_parquet(self, _: DatabaseManager | None) -> bool:
 
         create_operator_signed_in_glides_parquet(self, None)
         return True

--- a/src/lamp_py/tableau/jobs/gtfs_rail.py
+++ b/src/lamp_py/tableau/jobs/gtfs_rail.py
@@ -47,10 +47,11 @@ class HyperGTFS(HyperJob):
     def output_processed_schema(self) -> pyarrow.schema:
         """Define GTFS Table Schema"""
 
-    def create_parquet(self, db_manager: DatabaseManager) -> None:
+    def create_parquet(self, db_manager: DatabaseManager | None) -> None:
         if os.path.exists(self.local_parquet_path):
             os.remove(self.local_parquet_path)
 
+        assert isinstance(db_manager, DatabaseManager)
         db_manager.write_to_parquet(
             select_query=sa.text(self.create_query),
             write_path=self.local_parquet_path,
@@ -58,7 +59,7 @@ class HyperGTFS(HyperJob):
             batch_size=self.ds_batch_size,
         )
 
-    def update_parquet(self, db_manager: DatabaseManager) -> bool:
+    def update_parquet(self, db_manager: DatabaseManager | None) -> bool:
         download_file(
             object_path=self.remote_parquet_path,
             file_name=self.local_parquet_path,
@@ -70,6 +71,7 @@ class HyperGTFS(HyperJob):
 
         max_key_query = f"SELECT MAX(static_version_key) FROM {self.gtfs_table_name};"
 
+        assert isinstance(db_manager, DatabaseManager)
         max_db_key = db_manager.select_as_list(sa.text(max_key_query))[0]["max"]
 
         # no update needed

--- a/src/lamp_py/tableau/jobs/rt_alerts.py
+++ b/src/lamp_py/tableau/jobs/rt_alerts.py
@@ -21,10 +21,10 @@ class HyperRtAlerts(HyperJob):
     def output_processed_schema(self) -> pyarrow.schema:
         return AlertsS3Info.parquet_schema
 
-    def create_parquet(self, _: DatabaseManager) -> None:
+    def create_parquet(self, _: DatabaseManager | None) -> None:
         raise NotImplementedError("Alerts Hyper Job does not create parquet file")
 
-    def update_parquet(self, _: DatabaseManager) -> bool:
+    def update_parquet(self, _: DatabaseManager | None) -> bool:
         download_file(
             object_path=self.remote_parquet_path,
             file_name=self.local_parquet_path,

--- a/src/lamp_py/tableau/jobs/rt_rail.py
+++ b/src/lamp_py/tableau/jobs/rt_rail.py
@@ -199,7 +199,7 @@ class HyperRtRail(HyperJob):
 
         max_stats = self.max_stats_of_parquet()
 
-        max_start_date: datetime.date = max_stats["service_date"]
+        max_start_date: datetime.date = max_stats["service_date"]  # type: ignore[assignment]
         # subtract additional day incase of early spurious service_date record
         max_start_date -= datetime.timedelta(days=1)
 

--- a/src/lamp_py/tableau/jobs/rt_rail.py
+++ b/src/lamp_py/tableau/jobs/rt_rail.py
@@ -172,12 +172,12 @@ class HyperRtRail(HyperJob):
             ]
         )
 
-    def create_parquet(self, db_manager: DatabaseManager) -> None:
+    def create_parquet(self, db_manager: DatabaseManager | None) -> None:
         create_query = self.table_query % ""
 
         if os.path.exists(self.local_parquet_path):
             os.remove(self.local_parquet_path)
-
+        assert isinstance(db_manager, DatabaseManager)
         db_manager.write_to_parquet(
             select_query=sa.text(create_query),
             write_path=self.local_parquet_path,
@@ -188,7 +188,7 @@ class HyperRtRail(HyperJob):
     # pylint: disable=R0914
     # there are a lot of vars in here used for logging and it pushes the total
     # method variables past the threshold.
-    def update_parquet(self, db_manager: DatabaseManager) -> bool:
+    def update_parquet(self, db_manager: DatabaseManager | None) -> bool:
         process_logger = ProcessLogger("update_rt_rail_parquet")
         process_logger.log_start()
 
@@ -205,6 +205,7 @@ class HyperRtRail(HyperJob):
 
         update_query = self.table_query % (f" AND vt.service_date >= {max_start_date.strftime('%Y%m%d')} ",)
 
+        assert isinstance(db_manager, DatabaseManager)
         db_manager.write_to_parquet(
             select_query=sa.text(update_query),
             write_path=self.db_parquet_path,

--- a/src/lamp_py/tableau/jobs/spare_jobs.py
+++ b/src/lamp_py/tableau/jobs/spare_jobs.py
@@ -1,4 +1,4 @@
-from lamp_py.tableau.spare.default_converter import convert_to_tableau_flat_schema, default_converter_from_s3
+from lamp_py.tableau.spare.default_converter import PolarsDataFrameConverter, default_converter_from_s3
 from lamp_py.tableau.spare.autogen_01_schema_printer import spare_resources
 from lamp_py.tableau.jobs.filtered_hyper import FilteredHyperJob
 
@@ -18,7 +18,7 @@ for resource, (springboard_input, tableau_output) in spare_resources.items():
                 rollup_num_days=None,
                 processed_schema=default_converter_from_s3(springboard_input),
                 parquet_preprocess=None,
-                dataframe_filter=convert_to_tableau_flat_schema,
+                dataframe_filter=PolarsDataFrameConverter.convert_to_tableau_flat_schema,
                 parquet_filter=None,
                 tableau_project_name=SPARE_TABLEAU_PROJECT,
             )

--- a/src/lamp_py/tableau/spare/autogen_01_schema_printer.py
+++ b/src/lamp_py/tableau/spare/autogen_01_schema_printer.py
@@ -1,4 +1,3 @@
-# type: ignore
 # pylint: skip-file
 
 import os

--- a/src/lamp_py/tableau/spare/default_converter.py
+++ b/src/lamp_py/tableau/spare/default_converter.py
@@ -1,5 +1,3 @@
-# type: ignore
-
 import pyarrow
 import pyarrow.dataset as pd
 
@@ -7,15 +5,16 @@ import polars as pl
 
 from lamp_py.aws.s3 import file_list_from_s3
 from lamp_py.runtime_utils.remote_files import S3Location
+from typing import List
 
 
-def convert_to_tableau_flat_schema(self: pl.DataFrame, seperator="."):
+def convert_to_tableau_flat_schema(self: pl.DataFrame, seperator: str = ".") -> pl.DataFrame:
     """
     Polars does not have nested struct string expansion on their roadmap - this implementation is adapted
     from user legout's solution: https://github.com/pola-rs/polars/issues/9613#issuecomment-1658376392
     """
 
-    def _unnest_all(struct_columns):
+    def _unnest_all(struct_columns: List[str]) -> pl.DataFrame:
         return self.with_columns(
             [
                 pl.col(col).struct.rename_fields(
@@ -43,20 +42,20 @@ def convert_to_tableau_flat_schema(self: pl.DataFrame, seperator="."):
             for col in list_columns:
                 # self = self.explode(columns=col)
                 try:
-                    if isinstance(self[col].dtype.inner, pl.Categorical) | isinstance(self[col].dtype.inner, pl.String):
+                    if isinstance(self[col].dtype.inner, pl.Categorical) | isinstance(self[col].dtype.inner, pl.String):  # type: ignore[attr-defined]
                         self = self.with_columns(pl.col(col).cast(pl.List(pl.String)).list.join(","))
                         continue
-                    if isinstance(self[col].dtype.inner, pl.Struct):
+                    if isinstance(self[col].dtype.inner, pl.Struct):  # type: ignore[attr-defined]
                         self = self.with_columns(
                             pl.col(col).list.eval(pl.element().struct.json_encode()).list.join(",")
                         )
                         continue
-                    if isinstance(self[col].dtype.inner, pl.String):
+                    if isinstance(self[col].dtype.inner, pl.String):  # type: ignore[attr-defined]
                         self = self.with_columns(pl.col(col).cast(pl.List(pl.String)).list.join(","))
                 except Exception as e:
                     print(e)
                     print("oops")
-                print(self[list_columns[0].dtype])
+                print(self[list_columns[0]].dtype)
         if len(categorical_columns):
             self = self.with_columns(pl.col(categorical_columns).cast(pl.String))
         if len(u64_unsupported):

--- a/src/lamp_py/tableau/spare/default_converter.py
+++ b/src/lamp_py/tableau/spare/default_converter.py
@@ -8,69 +8,69 @@ from lamp_py.runtime_utils.remote_files import S3Location
 from typing import List
 
 
-def convert_to_tableau_flat_schema(self: pl.DataFrame, seperator: str = ".") -> pl.DataFrame:
-    """
-    Polars does not have nested struct string expansion on their roadmap - this implementation is adapted
-    from user legout's solution: https://github.com/pola-rs/polars/issues/9613#issuecomment-1658376392
-    """
+class PolarsDataFrameConverter(pl.DataFrame):
+    def convert_to_tableau_flat_schema(self: pl.DataFrame, seperator: str = ".") -> pl.DataFrame:
+        """
+        Polars does not have nested struct string expansion on their roadmap - this implementation is adapted
+        from user legout's solution: https://github.com/pola-rs/polars/issues/9613#issuecomment-1658376392
+        """
 
-    def _unnest_all(struct_columns: List[str]) -> pl.DataFrame:
-        return self.with_columns(
-            [
-                pl.col(col).struct.rename_fields(
-                    [f"{col}{seperator}{field_name}" for field_name in self[col].struct.fields]
-                )
-                for col in struct_columns
-            ]
-        ).unnest(struct_columns)
-
-    struct_columns = [col for col in self.columns if isinstance(self[col].dtype, pl.Struct)]
-    list_columns = [col for col in self.columns if isinstance(self[col].dtype, pl.List)]
-    categorical_columns = [col for col in self.columns if isinstance(self[col].dtype, pl.Categorical)]
-    u64_unsupported = [col for col in self.columns if isinstance(self[col].dtype, pl.UInt64)]
-    # fold in the timezone stripping logic into here eventually...
-    # dt_With_timezone = [col for col in self.columns if isinstance(self[col].dtype, pl.Datetime) and self[col].dtype.time_zone is not None]
-
-    fully_flattened = not len(struct_columns) | len(list_columns) | len(categorical_columns) | len(u64_unsupported)
-    while not fully_flattened:
-        if len(struct_columns):
-            self = _unnest_all(struct_columns=struct_columns)
-        if len(list_columns):
-            # don't expand lists - leave it as a string repr for now.
-            # self = self.explode(list_columns).with_columns(pl.col(list_columns).cast(pl.String))
-            # self['roles'].dtype.inner
-            for col in list_columns:
-                # self = self.explode(columns=col)
-                try:
-                    if isinstance(self[col].dtype.inner, pl.Categorical) | isinstance(self[col].dtype.inner, pl.String):  # type: ignore[attr-defined]
-                        self = self.with_columns(pl.col(col).cast(pl.List(pl.String)).list.join(","))
-                        continue
-                    if isinstance(self[col].dtype.inner, pl.Struct):  # type: ignore[attr-defined]
-                        self = self.with_columns(
-                            pl.col(col).list.eval(pl.element().struct.json_encode()).list.join(",")
-                        )
-                        continue
-                    if isinstance(self[col].dtype.inner, pl.String):  # type: ignore[attr-defined]
-                        self = self.with_columns(pl.col(col).cast(pl.List(pl.String)).list.join(","))
-                except Exception as e:
-                    print(e)
-                    print("oops")
-                print(self[list_columns[0]].dtype)
-        if len(categorical_columns):
-            self = self.with_columns(pl.col(categorical_columns).cast(pl.String))
-        if len(u64_unsupported):
-            self = self.with_columns(pl.col(u64_unsupported).cast(pl.Int64))
+        def _unnest_all(struct_columns: List[str]) -> pl.DataFrame:
+            return self.with_columns(
+                [
+                    pl.col(col).struct.rename_fields(
+                        [f"{col}{seperator}{field_name}" for field_name in self[col].struct.fields]
+                    )
+                    for col in struct_columns
+                ]
+            ).unnest(struct_columns)
 
         struct_columns = [col for col in self.columns if isinstance(self[col].dtype, pl.Struct)]
         list_columns = [col for col in self.columns if isinstance(self[col].dtype, pl.List)]
         categorical_columns = [col for col in self.columns if isinstance(self[col].dtype, pl.Categorical)]
         u64_unsupported = [col for col in self.columns if isinstance(self[col].dtype, pl.UInt64)]
+        # fold in the timezone stripping logic into here eventually...
+        # dt_With_timezone = [col for col in self.columns if isinstance(self[col].dtype, pl.Datetime) and self[col].dtype.time_zone is not None]
 
         fully_flattened = not len(struct_columns) | len(list_columns) | len(categorical_columns) | len(u64_unsupported)
-    return self
+        while not fully_flattened:
+            if len(struct_columns):
+                self = _unnest_all(struct_columns=struct_columns)
+            if len(list_columns):
+                # don't expand lists - leave it as a string repr for now.
+                # self = self.explode(list_columns).with_columns(pl.col(list_columns).cast(pl.String))
+                # self['roles'].dtype.inner
+                for col in list_columns:
+                    # self = self.explode(columns=col)
+                    try:
+                        if isinstance(self[col].dtype.inner, pl.Categorical) | isinstance(self[col].dtype.inner, pl.String):  # type: ignore[attr-defined]
+                            self = self.with_columns(pl.col(col).cast(pl.List(pl.String)).list.join(","))
+                            continue
+                        if isinstance(self[col].dtype.inner, pl.Struct):  # type: ignore[attr-defined]
+                            self = self.with_columns(
+                                pl.col(col).list.eval(pl.element().struct.json_encode()).list.join(",")
+                            )
+                            continue
+                        if isinstance(self[col].dtype.inner, pl.String):  # type: ignore[attr-defined]
+                            self = self.with_columns(pl.col(col).cast(pl.List(pl.String)).list.join(","))
+                    except Exception as e:
+                        print(e)
+                        print("oops")
+                    print(self[list_columns[0]].dtype)
+            if len(categorical_columns):
+                self = self.with_columns(pl.col(categorical_columns).cast(pl.String))
+            if len(u64_unsupported):
+                self = self.with_columns(pl.col(u64_unsupported).cast(pl.Int64))
 
+            struct_columns = [col for col in self.columns if isinstance(self[col].dtype, pl.Struct)]
+            list_columns = [col for col in self.columns if isinstance(self[col].dtype, pl.List)]
+            categorical_columns = [col for col in self.columns if isinstance(self[col].dtype, pl.Categorical)]
+            u64_unsupported = [col for col in self.columns if isinstance(self[col].dtype, pl.UInt64)]
 
-pl.DataFrame.convert_to_tableau_flat_schema = convert_to_tableau_flat_schema
+            fully_flattened = (
+                not len(struct_columns) | len(list_columns) | len(categorical_columns) | len(u64_unsupported)
+            )
+        return self
 
 
 def default_converter_from_s3(input_location: S3Location) -> pyarrow.Schema:

--- a/src/lamp_py/utils/date_range_builder.py
+++ b/src/lamp_py/utils/date_range_builder.py
@@ -1,8 +1,8 @@
-from datetime import datetime, timedelta
+from datetime import date, timedelta
 
 
 # Create a DataFrame with two date columns
-def build_data_range_paths(template_string: str, start_date: datetime, end_date: datetime) -> list[str]:
+def build_data_range_paths(template_string: str, start_date: date, end_date: date) -> list[str]:
     """
     Given an f-string template, fill in the {} in template with all the days between
     start_date and end_date (inclusive) and return the result as a list of strings

--- a/tests/performance_manager/test_performance_manager.py
+++ b/tests/performance_manager/test_performance_manager.py
@@ -454,7 +454,8 @@ def test_static_tables(
     with rpm_db_manager.session.begin() as session:
         for table, should_count in row_counts.items():
             actual_count = session.query(table).count()
-            tablename = table.__tablename__
+            # see sa.orm.decl_api.declared_attr for why to ignore the type error
+            tablename = table.__tablename__  # type: ignore[attr-defined]
             assert actual_count == should_count, f"Table {tablename} has incorrect row count"
 
     unprocessed_static_schedules = md_db_manager.select_as_list(

--- a/tests/tableau/test_convert_types.py
+++ b/tests/tableau/test_convert_types.py
@@ -2,7 +2,7 @@ import polars as pl
 import polars.testing as pt
 from io import StringIO
 
-from lamp_py.tableau.spare.default_converter import convert_to_tableau_flat_schema
+from lamp_py.tableau.spare.default_converter import PolarsDataFrameConverter
 
 
 def test_convert_to_tableau_flat_schema() -> None:
@@ -23,4 +23,4 @@ def test_convert_to_tableau_flat_schema() -> None:
 
     expected = pl.read_json("tests/tableau/test_convert_types_expected.json")
 
-    pt.assert_frame_equal(expected, convert_to_tableau_flat_schema(df1))
+    pt.assert_frame_equal(expected, PolarsDataFrameConverter.convert_to_tableau_flat_schema(df1))


### PR DESCRIPTION
Asana Task: https://app.asana.com/1/15492006741476/project/1189492770004753/task/1211291821750054

# Why do we need changes?

`mypy` silently ignores typing issues throughout the codebase. Once those errors are revealed, they need to be fixed. Also, #566 included a commit tree that I wanted to split into a different PR.


# What changes does this PR propose?

## Adds
1. `src/lamp_py/__init__.py`, allowing `mypy` to recognize `src/lamp_py` as a python module
2. `src/lamp_py/py.typing`, allowing `mypy` to recognize that it should type check `lamp_py` when it checks `tests/`

## Edits
1. `[tools.mypy]` in `pyproject.toml` to ignore `union-attr` errors because they are simply too numerous to deal with right now; these occur when any of the possible types in a union of types lacks the attribute or method referenced. For example, imagine an argument `x` typed `Optional[Union[float, str]]`: 
    - a reference to `x.str` will throw a `union-attr` error unless x is asserted to be one of `float` or `str`
    - a reference to `x.endswith` will throw a `union-attr` error unless `x` is asserted to be `str`

# How were these changes validated?

1. GitHub Actions + my local see that `mypy` has 0 errors


# What questions should reviewers consider?

1. Do any of these annotation changes raise flags?