### PR TITLE
Make ProcessLogger harder to break

### DIFF
--- a/src/lamp_py/runtime_utils/process_logger.py
+++ b/src/lamp_py/runtime_utils/process_logger.py
@@ -46,7 +46,7 @@ class ProcessLogger:
 
         self.start_time = 0.0
 
-        self.add_metadata(**metadata)
+        self.add_metadata(**metadata, print_log=False)  # wait to start the logger
 
     def _get_log_string(self) -> str:
         """create logging string for log write"""
@@ -60,11 +60,12 @@ class ProcessLogger:
             logging_list.append(f"{key}={value}")
 
         # add metadata to log output
-        for key, value in self.metadata.items():
-            logging_list.append(f"{key}={value}")
+        if self.metadata:
+            for key, value in self.metadata.items():
+                logging_list.append(f"{key}={value}")
 
         return ", ".join(logging_list)
-    
+
     def _start_if_unstarted(self) -> None:
         try:
             self.default_data["uuid"]
@@ -77,7 +78,6 @@ class ProcessLogger:
 
         :param print_log: if True(default), print log after metadata is added
         """
-        self._start_if_unstarted()
         metadata.setdefault("print_log", True)
         print_log = bool(metadata.get("print_log"))
         for key, value in metadata.items():
@@ -88,6 +88,7 @@ class ProcessLogger:
             self.metadata[str(key)] = str(value)
 
         if self.default_data.get("status") is not None and print_log:
+            self._start_if_unstarted()
             self.default_data["status"] = "add_metadata"
             logging.info(self._get_log_string())
 
@@ -131,4 +132,5 @@ class ProcessLogger:
             logging.error(f"uuid={self.default_data["uuid"]}, {line.strip('\n')}")
 
         # Log Process Failure
-        logging.exception(self._get_log_string())
+        has_exception_info = bool(exception.__traceback__)
+        logging.exception(self._get_log_string(), exc_info=has_exception_info)

--- a/src/lamp_py/runtime_utils/process_logger.py
+++ b/src/lamp_py/runtime_utils/process_logger.py
@@ -64,6 +64,12 @@ class ProcessLogger:
             logging_list.append(f"{key}={value}")
 
         return ", ".join(logging_list)
+    
+    def _start_if_unstarted(self) -> None:
+        try:
+            self.default_data["uuid"]
+        except KeyError:
+            self.log_start()
 
     def add_metadata(self, **metadata: MdValues) -> None:
         """
@@ -71,6 +77,7 @@ class ProcessLogger:
 
         :param print_log: if True(default), print log after metadata is added
         """
+        self._start_if_unstarted()
         metadata.setdefault("print_log", True)
         print_log = bool(metadata.get("print_log"))
         for key, value in metadata.items():
@@ -106,6 +113,8 @@ class ProcessLogger:
 
     def log_failure(self, exception: Exception) -> None:
         """log the failure of a process with exception type"""
+        self._start_if_unstarted()
+
         duration = time.monotonic() - self.start_time
         self.default_data["status"] = "failed"
         self.default_data["duration"] = f"{duration:.2f}"

--- a/src/lamp_py/runtime_utils/process_logger.py
+++ b/src/lamp_py/runtime_utils/process_logger.py
@@ -60,9 +60,8 @@ class ProcessLogger:
             logging_list.append(f"{key}={value}")
 
         # add metadata to log output
-        if self.metadata:
-            for key, value in self.metadata.items():
-                logging_list.append(f"{key}={value}")
+        for key, value in self.metadata.items():
+            logging_list.append(f"{key}={value}")
 
         return ", ".join(logging_list)
 

--- a/tests/runtime_utils/test_process_logger.py
+++ b/tests/runtime_utils/test_process_logger.py
@@ -3,6 +3,7 @@ import pytest
 
 from lamp_py.runtime_utils.process_logger import ProcessLogger
 
+
 def test_unstarted_log(caplog: pytest.LogCaptureFixture) -> None:
     "It logs unraised validation errors with the correct type and message."
 
@@ -11,15 +12,19 @@ def test_unstarted_log(caplog: pytest.LogCaptureFixture) -> None:
     process_logger.log_failure(Exception("test"))
     process_logger.log_complete()
 
-    with caplog.at_level(logging.ERROR):
-        assert type(Exception).__name__ in caplog.text
+    with caplog.at_level(logging.INFO):
+        assert "status=complete" in caplog.text
 
-def test_no_metadata(caplog: pytest.LogCaptureFixture) -> None:
-    "It gracefully handles a lack of metadata."
 
-    process_logger = ProcessLogger("test_no_metadata")
+def test_unraised_exception(caplog: pytest.LogCaptureFixture) -> None:
+    "It doesn't output `NoneType: None` when the exception has no traceback."
+
+    process_logger = ProcessLogger("test_not_none")
     process_logger.log_start()
-    process_logger.log_failure(Exception())
 
-    assert not process_logger.metadata
+    exception = Exception("foo")
+
+    process_logger.log_failure(Exception(exception))
+
+    assert not exception.__traceback__
     assert "NoneType: None" not in caplog.text.splitlines()

--- a/tests/runtime_utils/test_process_logger.py
+++ b/tests/runtime_utils/test_process_logger.py
@@ -28,3 +28,10 @@ def test_unraised_exception(caplog: pytest.LogCaptureFixture) -> None:
 
     assert not exception.__traceback__
     assert "NoneType: None" not in caplog.text.splitlines()
+
+def test_start_logging_explicitly(caplog: pytest.LogCaptureFixture) -> None:
+    "It doesn't start the log when it initializes."
+
+    ProcessLogger("test_not_none", foo="bar")
+
+    assert caplog.text == ""

--- a/tests/runtime_utils/test_process_logger.py
+++ b/tests/runtime_utils/test_process_logger.py
@@ -1,0 +1,26 @@
+import logging
+import dataframely as dy
+import pytest
+
+from lamp_py.runtime_utils.process_logger import ProcessLogger
+
+@pytest.mark.parametrize("exception_message", [("comma,separated,list")])
+def test_failing_validation(exception_message: str, caplog: pytest.LogCaptureFixture) -> None:
+    "It logs unraised validation errors with the correct type and message."
+
+    process_logger = ProcessLogger("test_failing_validation")
+    process_logger.log_failure(dy.exc.ValidationError(exception_message))
+    process_logger.log_complete()
+
+    with caplog.at_level(logging.ERROR):
+        assert exception_message in caplog.text
+        assert type(dy.exc.ValidationError).__name__ in caplog.text
+
+def test_no_metadata(caplog: pytest.LogCaptureFixture) -> None:
+    "It gracefully handles a lack of metadata."
+
+    process_logger = ProcessLogger("test_no_metadata")
+    process_logger.log_failure(Exception())
+
+    assert not process_logger.metadata
+    assert "NoneType: None" not in caplog.text.splitlines()

--- a/tests/runtime_utils/test_process_logger.py
+++ b/tests/runtime_utils/test_process_logger.py
@@ -29,6 +29,7 @@ def test_unraised_exception(caplog: pytest.LogCaptureFixture) -> None:
     assert not exception.__traceback__
     assert "NoneType: None" not in caplog.text.splitlines()
 
+
 def test_start_logging_explicitly(caplog: pytest.LogCaptureFixture) -> None:
     "It doesn't start the log when it initializes."
 

--- a/tests/runtime_utils/test_process_logger.py
+++ b/tests/runtime_utils/test_process_logger.py
@@ -1,25 +1,24 @@
 import logging
-import dataframely as dy
 import pytest
 
 from lamp_py.runtime_utils.process_logger import ProcessLogger
 
-@pytest.mark.parametrize("exception_message", [("comma,separated,list")])
-def test_failing_validation(exception_message: str, caplog: pytest.LogCaptureFixture) -> None:
+def test_unstarted_log(caplog: pytest.LogCaptureFixture) -> None:
     "It logs unraised validation errors with the correct type and message."
 
-    process_logger = ProcessLogger("test_failing_validation")
-    process_logger.log_failure(dy.exc.ValidationError(exception_message))
+    process_logger = ProcessLogger("test_unstarted_log")
+    process_logger.add_metadata(foo="bar")
+    process_logger.log_failure(Exception("test"))
     process_logger.log_complete()
 
     with caplog.at_level(logging.ERROR):
-        assert exception_message in caplog.text
-        assert type(dy.exc.ValidationError).__name__ in caplog.text
+        assert type(Exception).__name__ in caplog.text
 
 def test_no_metadata(caplog: pytest.LogCaptureFixture) -> None:
     "It gracefully handles a lack of metadata."
 
     process_logger = ProcessLogger("test_no_metadata")
+    process_logger.log_start()
     process_logger.log_failure(Exception())
 
     assert not process_logger.metadata


### PR DESCRIPTION
# Why do we need changes?

In the course of writing dataframely exceptions, I realized that `ProcessLogger` assumes that:
1. The logger has not only been initalized but also started
2. Exceptions that are logged are also raised
3. We want to start the logger whenever we initialize it with metadata

I don't see the need for either of these assumptions:
1. `.log_start()` takes no arguments (and, thus, no additional information)
2. Inline comments [suggest](https://github.com/mbta/lamp/blob/638fa4f86e420c26a8bb8e47a8e96863bfbe9841/src/lamp_py/runtime_utils/process_logger.py#L124) that unraised exceptions are okay)
3. Assuming that functions always try to log some event (eg. by invoking `log_start`, `log_failure`, `log_complete`, `add_metadata`), then the init is redundant.

Following the spirit of [poka-yoke](https://en.wikipedia.org/wiki/Poka-yoke), I figure that we could just remove these assumptions from the implementation of `ProcessLogger`.


# What changes does this PR propose?

## Adds
1. Tests that show the behavior we want to pass

## Edits
1. ProcessLogger.__init__ so that it doesn't log the initialization message
2. ProcessLogger.add_metadata and .log_failure so that it starts the logger if it isn't already started
3. ProcessLogger.log_failure so that it only logs tracebacks if they exist (only an issue for unraised exceptions)

# How were these changes validated?

1. I searched through our codebase for matches to `ProcessLogger\([\w="]+,.+[\n\s]+\w+` and saw that each invocation of `ProcessLogger` that included a second argument (ie. a metadata value) was immediately followed by `ProcessLogger.log_start`, resulting in duplicate log messages
4. Testing suite


# What questions should reviewers consider?

1. *Should* we only allow raised exceptions?