### PR TITLE
Improve primary keys in GTFSEvents, BusEvents

### DIFF
--- a/src/lamp_py/bus_performance_manager/events_gtfs_rt.py
+++ b/src/lamp_py/bus_performance_manager/events_gtfs_rt.py
@@ -21,7 +21,7 @@ class GTFSEvents(BusTrips):
     stop_count = dy.UInt32(nullable=True)
     direction_id = dy.Int8(nullable=True)
     vehicle_id = dy.String(nullable=True)
-    vehicle_label = dy.String(nullable=True)
+    vehicle_label = dy.String(primary_key=True)
     gtfs_travel_to_dt = dy.Datetime(nullable=True, time_zone="UTC")
     gtfs_arrival_dt = dy.Datetime(nullable=True, time_zone="UTC")
     latitude = dy.Float64(nullable=True)

--- a/src/lamp_py/bus_performance_manager/events_joined.py
+++ b/src/lamp_py/bus_performance_manager/events_joined.py
@@ -245,7 +245,6 @@ def join_rt_to_schedule(
         gtfs_arrival_dt -> Datetime(time_unit='us', time_zone='UTC')
         latitude -> Float64
         longitude -> Float64
-        index -> UInt32
         tm_stop_sequence -> Int64
         timepoint_order -> UInt32
         tm_planned_sequence_start -> Int64


### PR DESCRIPTION
Asana Task: https://app.asana.com/1/15492006741476/project/1189492770004753/task/1211333937876384?focus=true

# Why do we need changes?

1. Users rely on primary keys to understand the granularity of a table
2. `dataframely` assumes keys will not be null and enforces uniqueness, filtering out thousands of records from `GTFSEvents` and `BusEvents`


# What changes does this PR propose?

## Adds
1. `stop_index`, a concatenation of `tm_stop_sequence`, `stop_sequence`, and `vehicle_label` as a primary key in `BusEvents`

## Edits
1. `GTFSEvents.vehicle_label` to be a primary key
2. How `join_tm_schedule_to_gtfs_schedule` logs `ValidationErrors` to provide more information

## Removes
1. `index` from `CombinedSchedule` and its descendants

# How were these changes validated?

1. Ran `run_recent_bus_events` successfully without any `ValidationError`s
3. Testing suite


# What questions should reviewers consider?

1. Is this primary key too clunky? Not supporting nullable primary keys is a limitation of dataframely.