### PR TITLE
feat(flashback): downgrade expected errors to warnings

### DIFF
--- a/src/lamp_py/flashback/io.py
+++ b/src/lamp_py/flashback/io.py
@@ -52,7 +52,7 @@ async def get_vehicle_positions(
                     data = await response.read()
                     break
             except ClientError as e:
-                process_logger.log_failure(e)
+                process_logger.log_warning(e)
                 if attempt == max_retries:
                     raise ClientError(f"Maximum retries ({max_retries}) exceeded") from e
                 sleep(sleep_interval)

--- a/tests/flashback/test_io.py
+++ b/tests/flashback/test_io.py
@@ -143,25 +143,19 @@ async def test_get_vehicle_positions(
     vp = VehiclePositions.sample(generator=dy_gen)
     success_response, _ = mock_vp_response(vp)
 
-    # Create mock error response
     error_response = AsyncMock()
     error_response.raise_for_status = lambda: (_ for _ in ()).throw(ClientError("Non-200 response"))
 
     mock_get.return_value.__aenter__.side_effect = [error_response] * num_failures + [success_response]
 
-    # If too many retries, expect ClientError
-    if num_failures >= max_retries:
-        with pytest.raises(ClientError):
-            await get_vehicle_positions(max_retries=max_retries)
-    else:
+    context_handler = pytest.raises(ClientError) if num_failures >= max_retries else nullcontext()
+    with context_handler:
         df = await get_vehicle_positions(max_retries=max_retries)
-
-        assert df.height == 1
+        # if no error, then check the following
+        assert_frame_equal(df, vp)
         assert mock_sleep.call_count == num_failures
-        # Check that failures were logged (status=failed appears in log message)
         assert "ClientError" in caplog.text
-        failure_logs = [record for record in caplog.record_tuples if "status=failed" in record[2]]
-        assert len(failure_logs) == num_failures
+        assert "status=failed" not in caplog.text
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
[📸 alerting for flashback](https://app.asana.com/1/15492006741476/project/1189492770004753/task/1213903179294815)

## What changes does this PR propose?

Downgrades `ClientError`s (most networking errors fall into this class) from errors to warnings unless successive errors exceed the `max_retries` parameter. This change reduces noise in our flashback alerting.


## How were these changes validated?

1. Updated test


## What questions should reviewers consider?

1. Is 10 successive retries the appropriate amount? With the `sleep_interval` set at 3s, 10 successive retries represents 30s of unavailability. Looking [in Splunk](https://mbta.splunkcloud.com/en-US/app/search/search?earliest=0&latest=&q=%7C%20%40spl2%20search%20index%3Dlamp-staging%20%22Maximum%20retries%22&display.page.search.mode=fast&dispatch.sample_ratio=1&workload_pool=&display.page.search.showFields=0&sid=1775142358.85009), that condition has never triggered.
