### PR TITLE
feat(flashback): deploy in prod, write to public bucket

### DIFF
--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -34,5 +34,6 @@ jobs:
       deploy-bus-pm: true
       deploy-tm-ingestion: true
       deploy-tableau-publisher: true
+      deploy-flashback: true
       deploy-lightswitch: false
     secrets: inherit

--- a/src/lamp_py/runtime_utils/remote_files.py
+++ b/src/lamp_py/runtime_utils/remote_files.py
@@ -279,7 +279,7 @@ compressed_gtfs = GTFSArchive(
 )
 
 stop_events = S3Location(
-    bucket=S3_ARCHIVE,
+    bucket=S3_PUBLIC,
     prefix=f"{LAMP}/stop_events/stop_events_v0.json.gz",
     version="0.1.0",
 )


### PR DESCRIPTION
Asana Task: https://app.asana.com/1/15492006741476/project/1189492770004753/task/1213736160127086

## What changes does this PR propose?

1. Updates the `stop_events` remote files location to use the public bucket variable. In lower envs, this means no change to the location. In prod, it means that we will publish to the public bucket.
2. Adds flashback to the prod deployment GitHub workflow


## How were these changes validated?

Haven't. These changes only affect prod.


## What questions should reviewers consider?

1. Is there any reason we should wait on deploying to prod? I want it to be ready for the API's prod environment when the API is ready but that won't be for another week at least
