### PR TITLE
fix(ingestion): hash method only ever returned the new portion of data

### DIFF
--- a/src/lamp_py/ingestion/convert_gtfs_rt.py
+++ b/src/lamp_py/ingestion/convert_gtfs_rt.py
@@ -437,9 +437,9 @@ class GtfsRtConverter(Converter):
             # RT_ALERTS updates are essentially the same throughout a service day so resetting the
             # dataset will have minimal impact on archived data
             try:
-                table = pd.dataset(
+                out_ds = pd.dataset(
                     [
-                        out_ds,
+                        pd.dataset(table),
                         pd.dataset(local_path, schema=table.schema),
                     ],
                 )


### PR DESCRIPTION
from #724 

no backfill for live data required as this had not been deployed to prod