### PR TITLE
feat(lightswitch): add helper function for converting unix epoch seconds to timestamp with timezone

### DIFF
--- a/src/lamp_py/publishing/lightswitch.py
+++ b/src/lamp_py/publishing/lightswitch.py
@@ -52,7 +52,7 @@ HIVE_VIEWS = {
 
 
 def authenticate(connection: duckdb.DuckDBPyConnection) -> bool:
-    "Register IAM credentials with duckdb."
+    """Register IAM credentials with duckdb."""
     connection.install_extension("aws")
     connection.load_extension("aws")
     return connection.sql(  # type: ignore[index]
@@ -145,6 +145,22 @@ def register_read_ymd(
     pl.log_complete()
 
 
+def register_to_timestamptz(
+    connection: duckdb.DuckDBPyConnection,
+) -> None:
+    """Register function in DuckDB for converting unix timestamp to datetime with time zone"""
+    pl = ProcessLogger("register_to_timestamptz")
+    pl.log_start()
+    connection.sql(
+        """
+        CREATE OR REPLACE MACRO to_timestamptz(unix_timestamp, tz := 'America/New_York')
+            AS (TO_TIMESTAMP(unix_timestamp) AT TIME ZONE tz)::TIMESTAMPTZ
+        """
+    )
+
+    pl.log_complete()
+
+
 def register_effective_gtfs_timestamps(
     connection: duckdb.DuckDBPyConnection,
     bucket: str = "s3://mbta-ctd-dataplatform-springboard",
@@ -195,8 +211,7 @@ def register_effective_gtfs_timestamps(
 def add_views_to_local_metastore(
     connection: duckdb.DuckDBPyConnection, views: dict[str, List[rf.S3Location]]
 ) -> List[str]:
-    "Add views of remote Parquet files to duckdb database."
-
+    """Add views of remote Parquet files to duckdb database."""
     built_views: List[str] = []
     for k in views.keys():
         for item in views[k]:
@@ -235,6 +250,7 @@ def pipeline(  # pylint: disable=dangerous-default-value
         pl.add_metadata(authenticated=auth)
         add_views_to_local_metastore(con, views)
         register_read_ymd(con)
+        register_to_timestamptz(con)
         register_effective_gtfs_timestamps(con)
 
     if remote_location:

--- a/tests/publishing/test_lightswitch.py
+++ b/tests/publishing/test_lightswitch.py
@@ -110,7 +110,7 @@ def test_totimestamptz(duckdb_con: duckdb.DuckDBPyConnection) -> None:
     with duckdb_con:
         register_to_timestamptz(duckdb_con)
         timestamp_tz = duckdb_con.execute("SELECT to_timestamptz(0, 'Etc/UTC')").pl().row(0)[0]
-        assert timestamp_tz == datetime.fromtimestamp(0, tz=ZoneInfo('Etc/UTC'))
+        assert timestamp_tz == datetime.fromtimestamp(0, tz=ZoneInfo("Etc/UTC"))
 
 
 def test_register_effective_gtfs_timestamps(

--- a/tests/publishing/test_lightswitch.py
+++ b/tests/publishing/test_lightswitch.py
@@ -1,8 +1,10 @@
+from zoneinfo import ZoneInfo
 import os
 from contextlib import nullcontext
 from logging import ERROR
 from pathlib import Path
 from typing import Generator
+from datetime import datetime
 
 import polars as pl
 import pytest
@@ -14,6 +16,7 @@ from lamp_py.publishing.lightswitch import (
     register_read_ymd,
     register_effective_gtfs_timestamps,
     create_schemas,
+    register_to_timestamptz,
 )
 from lamp_py.runtime_utils.remote_files import S3Location
 from tests.test_resources import rt_vehicle_positions, tm_route_file
@@ -100,6 +103,14 @@ def test_register_read_ymd(
             assert duckdb_con.sql(
                 f"SELECT * FROM read_ymd('{directory_name}', '2024-06-01' :: DATE, '2024-06-02' :: DATE, '{tmp_path.resolve()}')"
             )
+
+
+def test_totimestamptz(duckdb_con: duckdb.DuckDBPyConnection) -> None:
+    """It converts unix timestamp to datetime with timezone"""
+    with duckdb_con:
+        register_to_timestamptz(duckdb_con)
+        timestamp_tz = duckdb_con.execute("SELECT to_timestamptz(0, 'Etc/Utc')").pl().row(0)[0]
+        assert timestamp_tz == datetime.fromtimestamp(0, tz=ZoneInfo('Etc/Utc'))
 
 
 def test_register_effective_gtfs_timestamps(

--- a/tests/publishing/test_lightswitch.py
+++ b/tests/publishing/test_lightswitch.py
@@ -109,8 +109,8 @@ def test_totimestamptz(duckdb_con: duckdb.DuckDBPyConnection) -> None:
     """It converts unix timestamp to datetime with timezone"""
     with duckdb_con:
         register_to_timestamptz(duckdb_con)
-        timestamp_tz = duckdb_con.execute("SELECT to_timestamptz(0, 'Etc/Utc')").pl().row(0)[0]
-        assert timestamp_tz == datetime.fromtimestamp(0, tz=ZoneInfo('Etc/Utc'))
+        timestamp_tz = duckdb_con.execute("SELECT to_timestamptz(0, 'Etc/UTC')").pl().row(0)[0]
+        assert timestamp_tz == datetime.fromtimestamp(0, tz=ZoneInfo('Etc/UTC'))
 
 
 def test_register_effective_gtfs_timestamps(

--- a/tests/publishing/test_lightswitch.py
+++ b/tests/publishing/test_lightswitch.py
@@ -109,8 +109,8 @@ def test_totimestamptz(duckdb_con: duckdb.DuckDBPyConnection) -> None:
     """It converts unix timestamp to datetime with timezone"""
     with duckdb_con:
         register_to_timestamptz(duckdb_con)
-        timestamp_tz = duckdb_con.execute("SELECT to_timestamptz(0, 'Etc/UTC')").pl().row(0)[0]
-        assert timestamp_tz == datetime.fromtimestamp(0, tz=ZoneInfo("Etc/UTC"))
+        timestamp_tz = duckdb_con.execute("LOAD icu; SELECT to_timestamptz(0)").pl().row(0)[0]
+        assert timestamp_tz == datetime.fromtimestamp(0, tz=ZoneInfo("America/New_York"))
 
 
 def test_register_effective_gtfs_timestamps(


### PR DESCRIPTION

Asana Task: [🔮 Don't filter out light rail trains that have been stopped for more than 10 minutes](https://app.asana.com/1/15492006741476/project/584764604969369/task/1207658140982515?focus=true)

## What changes does this PR propose?

Problem: 

As demonstrated by the macro I created in this PR, the DuckDB syntax for converting unix seconds since  epoch to a datetime with timezone is not very ergonomic. I spend a lot of time recreating this logic in my notebook. 

Solution:

Add a `to_timestamptz` macro, similar to `to_timestamp`, which converts unix seconds since epoch to a datetime with timezone information. Default to using `America/New_York` as the IANA time zone. 


## How were these changes validated?

Added new tests for Lightswitch


## What questions should reviewers consider?

1. Is this something that should be contributed upstream to DuckDB?
