### PR TITLE
fix(aws): do not overwrite remote parquets if fewer records

### DIFF
--- a/src/lamp_py/ad_hoc/pipeline.py
+++ b/src/lamp_py/ad_hoc/pipeline.py
@@ -6,7 +6,7 @@ import os
 from lamp_py.aws.ecs import check_for_parallel_tasks
 from lamp_py.runtime_utils.env_validation import validate_environment
 
-from lamp_py.ad_hoc.runner_003 import runner
+from lamp_py.ad_hoc.runner_004 import runner
 
 logging.getLogger().setLevel("INFO")
 DESCRIPTION = """Entry Point For Ad-Hoc Runner"""
@@ -31,7 +31,7 @@ def start() -> None:
     check_for_parallel_tasks()
 
     # run the main method
-    runner()
+    runner(dry_run=True)
 
 
 if __name__ == "__main__":

--- a/src/lamp_py/ad_hoc/runner_004.py
+++ b/src/lamp_py/ad_hoc/runner_004.py
@@ -1,0 +1,47 @@
+import tempfile
+from datetime import datetime
+
+import polars as pl
+from pyarrow.parquet import read_metadata
+
+from lamp_py.aws.s3 import replace_remote_parquet, download_file
+from lamp_py.ingestion.glides import TripUpdatesTable
+from lamp_py.runtime_utils.process_logger import ProcessLogger
+from lamp_py.runtime_utils.remote_files import glides_trips_updated
+
+
+def runner(dry_run: bool = True) -> None:
+    """Add staging dataset to Glides springboard data."""
+    ad_hoc_logger = ProcessLogger(process_name="ad_hoc_runner", dry_run=str(dry_run))
+    ad_hoc_logger.log_start()
+
+    incident_datetime = datetime.fromisoformat("2026-04-27T02:55:00")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        download_file(
+            "mbta-ctd-dataplatform-staging-springboard/" + glides_trips_updated.prefix, f"{tmpdir}/staging.parquet"
+        )
+        staging_file = pl.scan_parquet(f"{tmpdir}/staging.parquet")
+
+        download_file(glides_trips_updated.s3_uri, f"{tmpdir}/existing.parquet")
+        existing_file = pl.scan_parquet(f"{tmpdir}/existing.parquet")
+
+        new_frame = pl.concat(
+            [
+                staging_file.filter(pl.col("time") <= pl.lit(incident_datetime)),
+                existing_file.filter(pl.col("time") > pl.lit(incident_datetime)),
+            ]
+        )
+
+        TripUpdatesTable.validate(new_frame, cast=True, eager=False).sink_parquet(
+            f"{tmpdir}/new_glides_trips_updated.parquet"
+        )
+
+        if not dry_run:
+            replace_remote_parquet(f"{tmpdir}/new_glides_trips_updated.parquet", glides_trips_updated.s3_uri)
+        else:
+            existing_rows = read_metadata(glides_trips_updated.s3_uri).num_rows
+            new_rows = read_metadata(f"{tmpdir}/new_glides_trips_updated.parquet").num_rows
+            ad_hoc_logger.add_metadata(existing_rows=existing_rows, new_rows=new_rows)
+
+    ad_hoc_logger.log_complete()

--- a/src/lamp_py/aws/s3.py
+++ b/src/lamp_py/aws/s3.py
@@ -7,9 +7,9 @@ from datetime import date, datetime, timezone
 from io import BytesIO
 from threading import current_thread
 from typing import (
+    IO,
     Callable,
     Dict,
-    IO,
     Iterator,
     List,
     Optional,
@@ -20,12 +20,12 @@ from typing import (
 import boto3
 import botocore
 import botocore.exceptions
-from botocore.exceptions import ClientError
 import pandas
 import pyarrow as pa
 import pyarrow.compute as pc
-import pyarrow.parquet as pq
 import pyarrow.dataset as pd
+import pyarrow.parquet as pq
+from botocore.exceptions import ClientError
 from pyarrow import Table, fs
 from pyarrow.util import guid
 
@@ -124,7 +124,7 @@ def download_file(object_path: str, file_name: str) -> bool:
 
 def delete_object(del_obj: str) -> bool:
     """
-    delete s3 object
+    Delete s3 object
 
     :param del_obj - expected as 's3://my_bucket/object' or 'my_bucket/object'
 
@@ -158,7 +158,7 @@ def delete_object(del_obj: str) -> bool:
 
 def object_metadata(obj: str) -> Dict[str, str]:
     """
-    retrieve s3 object Metadata
+    Retrieve s3 object Metadata
 
     Will throw if object does not exist
 
@@ -193,7 +193,7 @@ def object_metadata(obj: str) -> Dict[str, str]:
 
 def object_exists(obj: str) -> bool:
     """
-    check if s3 object exists
+    Check if s3 object exists
 
     will raise on any error other than "NoSuchKey"
 
@@ -221,7 +221,7 @@ def object_exists(obj: str) -> bool:
 
 def version_check(obj: str, version: str) -> bool:
     """
-    compare an s3 file's lamp version to a given version
+    Compare an s3 file's lamp version to a given version
 
     :return True if remote and expected version match, return False if the file
             doesn't exist of or if the versions do not match.
@@ -260,7 +260,7 @@ def file_list_from_s3(
     suppress_logging_below_level: int = logging.NOTSET,
 ) -> List[str]:
     """
-    get a list of s3 objects
+    Get a list of s3 objects
 
     :param bucket_name: the name of the bucket to look inside of
     :param file_prefix: prefix filter for object keys
@@ -302,7 +302,7 @@ def file_list_from_s3(
 
 def file_list_from_s3_with_details(bucket_name: str, file_prefix: str) -> List[Dict]:
     """
-    get a list of s3 objects with additional details
+    Get a list of s3 objects with additional details
 
     :param bucket_name: the name of the bucket to look inside of
     :param file_prefix: prefix filter for object keys
@@ -358,7 +358,7 @@ def file_list_from_s3_date_range(
     end_date: date,
 ) -> List[str]:
     """
-    get a list of s3 objects between two dates
+    Get a list of s3 objects between two dates
 
     :param bucket_name: the name of the bucket to look inside of
     :param path_template: prefix template string for object keys - will be populated with dates
@@ -371,7 +371,6 @@ def file_list_from_s3_date_range(
         object path as s3://bucket-name/object-key
     ]
     """
-
     paths = build_data_range_paths(path_template, start_date, end_date)
     full_list = []
     for search_path in paths:
@@ -414,7 +413,7 @@ def get_last_modified_object(bucket_name: str, file_prefix: str, version: Option
 
 def _move_s3_object(filename: str, to_bucket: str) -> Optional[str]:
     """
-    move a single s3 file to the to_bucket bucket. break the incoming s3 path
+    Move a single s3 file to the to_bucket bucket. break the incoming s3 path
     into parts that are used for copying. each process will have it's own
     boto session and resource available, from the _init_process_session function
     to avoid multi-processing issues
@@ -466,7 +465,7 @@ def _move_s3_object(filename: str, to_bucket: str) -> Optional[str]:
 
 def _init_process_session() -> None:
     """
-    initialization function for any process in multi processing pool needing to
+    Initialization function for any process in multi processing pool needing to
     use a boto session object
 
     this avoids the expensive operation of creating a new session for every unti of work
@@ -636,7 +635,7 @@ def write_parquet_file(
 
 def dt_from_obj_path(path: str) -> datetime:
     """
-    process and return datetime from partitioned s3 path
+    Process and return datetime from partitioned s3 path
 
     handles the following formats:
     - year=YYYY/month=MM/day=DD/hour=HH
@@ -672,7 +671,7 @@ def _get_pyarrow_dataset(
     filters: Optional[pd.Expression] = None,
 ) -> pd.Dataset:
     """
-    internal function to get pyarrow dataset from parquet file(s)
+    Internal function to get pyarrow dataset from parquet file(s)
     """
     active_fs = fs.S3FileSystem()
 
@@ -696,7 +695,7 @@ def read_parquet(
     filters: Optional[pd.Expression] = None,
 ) -> pandas.core.frame.DataFrame:
     """
-    read parquet file or files from s3 and return it as a pandas dataframe
+    Read parquet file or files from s3 and return it as a pandas dataframe
 
     if requested column from "columns" does not exist in parquet file then
     the column will be added as all nulls, this was added to capture
@@ -732,7 +731,7 @@ def read_parquet_chunks(
     filters: Optional[pd.Expression] = None,
 ) -> Iterator[pandas.core.frame.DataFrame]:
     """
-    read parquet file or files from s3 IN CHUNKS
+    Read parquet file or files from s3 IN CHUNKS
     return chunks as pandas dataframes
 
     chunk size attempts to be close to max_rows parameter, but may sometimes
@@ -743,3 +742,40 @@ def read_parquet_chunks(
         batch_size=max_rows,
     ):
         yield batch.to_pandas()
+
+
+def replace_remote_parquet(
+    file_name: str,
+    object_path: str,
+    extra_args: Optional[Dict] = None,
+) -> bool:
+    """
+    Overwrite an existing object with a new file if the new file has at least as many rows as the existing file.
+
+    If the existing file does not exist, the new file will be uploaded.
+
+    :param file_name: local parquet file path to upload
+    :param object_path: S3 object path to upload to (including bucket); if not empty, the existing file must be Parquet
+    :param extra_args: additional arguments passed to upload_file
+
+    :return: None
+    """
+    process_logger = ProcessLogger("replace_remote_parquet", file_name=file_name, object_path=object_path)
+    process_logger.log_start()
+
+    object_path = object_path.replace("s3://", "")
+
+    try:
+        if object_exists(object_path):
+            existing_row_count = pq.read_metadata(object_path, filesystem=fs.S3FileSystem()).num_rows
+            new_row_count = pq.read_metadata(file_name).num_rows
+            assert new_row_count >= existing_row_count, f"{new_row_count} < {existing_row_count}; cancelling upload."
+            process_logger.add_metadata(existing_row_count=existing_row_count, new_row_count=new_row_count)
+
+        result = upload_file(file_name, object_path, extra_args)
+        assert result, "upload_file failed"
+    except Exception as e:
+        process_logger.log_failure(e)
+        return False
+    process_logger.log_complete()
+    return result

--- a/src/lamp_py/aws/s3.py
+++ b/src/lamp_py/aws/s3.py
@@ -29,6 +29,7 @@ from botocore.exceptions import ClientError
 from pyarrow import Table, fs
 from pyarrow.util import guid
 
+from lamp_py.runtime_utils.lamp_exception import LampInvalidReplacementError
 from lamp_py.runtime_utils.process_logger import ProcessLogger, override_log_level
 from lamp_py.utils.date_range_builder import build_data_range_paths
 
@@ -758,7 +759,7 @@ def replace_remote_parquet(
     :param object_path: S3 object path to upload to (including bucket); if not empty, the existing file must be Parquet
     :param extra_args: additional arguments passed to upload_file
 
-    :return: None
+    :return: True if uploaded; False otherwise
     """
     process_logger = ProcessLogger("replace_remote_parquet", file_name=file_name, object_path=object_path)
     process_logger.log_start()
@@ -769,11 +770,15 @@ def replace_remote_parquet(
         if object_exists(object_path):
             existing_row_count = pq.read_metadata(object_path, filesystem=fs.S3FileSystem()).num_rows
             new_row_count = pq.read_metadata(file_name).num_rows
-            assert new_row_count >= existing_row_count, f"{new_row_count} < {existing_row_count}; cancelling upload."
+            if new_row_count < existing_row_count:
+                raise LampInvalidReplacementError(f"{new_row_count} < {existing_row_count}: cancelling upload")
             process_logger.add_metadata(existing_row_count=existing_row_count, new_row_count=new_row_count)
 
         result = upload_file(file_name, object_path, extra_args)
-        assert result, "upload_file failed"
+        process_logger.add_metadata(uploaded=result)
+    except LampInvalidReplacementError as e:
+        process_logger.log_failure(e)
+        return False
     except Exception as e:
         process_logger.log_failure(e)
         return False

--- a/src/lamp_py/ingestion/compress_gtfs/gtfs_to_parquet.py
+++ b/src/lamp_py/ingestion/compress_gtfs/gtfs_to_parquet.py
@@ -19,7 +19,7 @@ from lamp_py.ingestion.compress_gtfs.schedule_details import (
     schedules_to_compress,
 )
 from lamp_py.ingestion.compress_gtfs.pq_to_sqlite import pq_folder_to_sqlite
-from lamp_py.aws.s3 import upload_file
+from lamp_py.aws.s3 import replace_remote_parquet
 from lamp_py.runtime_utils.remote_files import compressed_gtfs
 
 
@@ -297,7 +297,7 @@ def gtfs_to_parquet() -> None:
         year_path = os.path.join(gtfs_tmp_folder, year)
         pq_folder_to_sqlite(year_path)
         for file in os.listdir(year_path):
-            upload_file(
+            replace_remote_parquet(
                 file_name=os.path.join(year_path, file),
                 object_path=os.path.join(compressed_gtfs.s3_uri, year, file),
             )

--- a/src/lamp_py/ingestion/glides.py
+++ b/src/lamp_py/ingestion/glides.py
@@ -10,7 +10,7 @@ import polars as pl
 import pyarrow
 import pyarrow.parquet as pq
 
-from lamp_py.aws.s3 import download_file, upload_file
+from lamp_py.aws.s3 import download_file, replace_remote_parquet
 from lamp_py.aws.kinesis import KinesisReader
 from lamp_py.ingestion.utils import explode_table_column, flatten_table_schema
 from lamp_py.utils.dataframely import unnest_columns
@@ -250,7 +250,7 @@ class GlidesConverter(ABC):  # pylint: disable=too-many-instance-attributes
 
     def upload_records(self) -> None:
         """Upload local parquet file to remote storage."""
-        upload_file(file_name=self.local_path, object_path=self.remote_path)
+        replace_remote_parquet(file_name=self.local_path, object_path=self.remote_path)
 
 
 class EditorChanges(GlidesConverter):

--- a/src/lamp_py/ingestion_tm/jobs/parition_table.py
+++ b/src/lamp_py/ingestion_tm/jobs/parition_table.py
@@ -21,7 +21,7 @@ from lamp_py.runtime_utils.remote_files import (
 
 from lamp_py.aws.s3 import (
     file_list_from_s3,
-    upload_file,
+    replace_remote_parquet,
     object_metadata,
 )
 
@@ -50,7 +50,7 @@ class TMDailyTable(TMExport):
             with open(local_version, "w", encoding="utf8") as f:
                 f.write(self.lamp_version)
 
-            upload_file(
+            replace_remote_parquet(
                 file_name=local_version,
                 object_path=self.s3_version_path,
                 extra_args={"Metadata": {self.version_key: self.lamp_version}},
@@ -160,7 +160,7 @@ class TMDailyTable(TMExport):
                         last_export_path=s3_export_path,
                         last_export_bytes=os.stat(local_pq).st_size,
                     )
-                    upload_file(local_pq, s3_export_path)
+                    replace_remote_parquet(file_name=local_pq, object_path=s3_export_path)
 
                 self.update_version_file()
                 logger.log_complete()

--- a/src/lamp_py/ingestion_tm/jobs/whole_table.py
+++ b/src/lamp_py/ingestion_tm/jobs/whole_table.py
@@ -21,7 +21,7 @@ from lamp_py.runtime_utils.remote_files import (
     tm_time_point_file,
     tm_pattern_geo_node_xref_file,
 )
-from lamp_py.aws.s3 import upload_file
+from lamp_py.aws.s3 import replace_remote_parquet
 
 
 class TMWholeTable(TMExport):
@@ -49,7 +49,7 @@ class TMWholeTable(TMExport):
                 local_export_path = os.path.join(temp_dir, "out.parquet")
                 tm_db.write_to_parquet(query, local_export_path, self.export_schema)
                 logger.add_metadata(pq_export_bytes=os.stat(local_export_path).st_size)
-                upload_file(local_export_path, self.s3_location.s3_uri)
+                replace_remote_parquet(local_export_path, self.s3_location.s3_uri)
                 logger.log_complete()
 
         except Exception as exception:

--- a/src/lamp_py/performance_manager/alerts.py
+++ b/src/lamp_py/performance_manager/alerts.py
@@ -13,8 +13,8 @@ from dateutil.relativedelta import relativedelta
 from lamp_py.aws.s3 import (
     download_file,
     read_parquet,
-    upload_file,
     version_check,
+    replace_remote_parquet,
 )
 
 from lamp_py.postgres.metadata_schema import MetadataLog
@@ -182,7 +182,7 @@ class AlertParquetHandler:
         upload the local parquet file to s3 if new data was added
         """
         if self.new_data:
-            upload_file(
+            replace_remote_parquet(
                 file_name=self.local_path,
                 object_path=self.s3_path,
                 extra_args={"Metadata": {AlertsS3Info.version_key: AlertsS3Info.file_version}},

--- a/src/lamp_py/runtime_utils/lamp_exception.py
+++ b/src/lamp_py/runtime_utils/lamp_exception.py
@@ -55,3 +55,7 @@ class EmptyDataStructureException(Exception):
     """
     Raised when returning an empty data structure.
     """
+
+
+class LampInvalidReplacementError(Exception):
+    """Existing parquet file has more rows than proposed replacement."""

--- a/tests/aws/test_s3_utils.py
+++ b/tests/aws/test_s3_utils.py
@@ -158,10 +158,16 @@ def test_move_bad_objects(s3_stub, caplog):  # type: ignore
 @pytest.mark.parametrize(
     ["remote_file_exists", "local_records", "upload_succeeds", "log_text"],
     [
-        (True, 10, True, "existing_row_count=10"),
-        (True, 5, True, "<"),
-        (False, 5, True, "status=complete"),
-        (True, 10, False, "upload_file failed"),
+        (True, 10, True, "uploaded=True"),
+        (True, 5, True, "LampInvalidReplacementError"),
+        (False, 5, True, "uploaded=True"),
+        (True, 10, False, "uploaded=False"),
+    ],
+    ids=[
+        "replace-existing",
+        "fewer-records-than-existing",
+        "no-existing",
+        "upload-fails",
     ],
 )
 def test_replace_remote_parquet(

--- a/tests/aws/test_s3_utils.py
+++ b/tests/aws/test_s3_utils.py
@@ -1,30 +1,30 @@
-# pylint: disable=[W0621, W0611]
+# pylint: disable=[W0621, W0611, R0913, R0917]
 # disable these warnings that are triggered by pylint not understanding how test
 # fixtures work. https://stackoverflow.com/q/59664605
 
 import json
 import logging
 import os
-
 from datetime import datetime, timedelta
+from pathlib import Path
 from unittest.mock import patch
 
 import boto3
+import polars as pl
 import pytest
+from botocore.stub import ANY, Stubber
+from polars.testing import assert_frame_equal
+from pyarrow.fs import LocalFileSystem
 
-from botocore.stub import Stubber
-from botocore.stub import ANY
-
-from lamp_py.aws.s3 import file_list_from_s3, file_list_from_s3_date_range
-from lamp_py.aws.s3 import move_s3_objects
-from lamp_py.runtime_utils.remote_files import LAMP, S3_SPRINGBOARD
+from lamp_py.aws.s3 import file_list_from_s3, file_list_from_s3_date_range, move_s3_objects, replace_remote_parquet
+from lamp_py.runtime_utils.remote_files import S3_SPRINGBOARD
 
 from ..test_resources import incoming_dir
 
 
 @pytest.fixture
 def s3_stub():  # type: ignore
-    """test fixture for simulating s3 calls"""
+    """Test fixture for simulating s3 calls"""
     s3_stub = boto3.client("s3")
     with Stubber(s3_stub) as stubber:
         with patch("lamp_py.aws.s3.get_s3_client", return_value=s3_stub):
@@ -34,8 +34,7 @@ def s3_stub():  # type: ignore
 
 @pytest.mark.skip("this wont work in CI without mock...TODO")
 def test_file_list_from_s3_date_range() -> None:
-    """test for s3 date range call - query for all files within a range of dates"""
-
+    """Test for s3 date range call - query for all files within a range of dates"""
     template = "year={yy}/month={mm}/day={dd}/"
     end_date = datetime.now()
     start_date = end_date - timedelta(days=10)
@@ -53,7 +52,7 @@ def test_file_list_from_s3_date_range() -> None:
 
 def test_file_list_s3(s3_stub):  # type: ignore
     """
-    test that list files works as expected given pre-described s3 responses
+    Test that list files works as expected given pre-described s3 responses
     """
     # Process 'list_objects_v2' that returns no files
     page_obj_params = {
@@ -131,7 +130,7 @@ def test_file_list_s3(s3_stub):  # type: ignore
 
 def test_move_bad_objects(s3_stub, caplog):  # type: ignore
     """
-    test that unsuccesful moves are correctly logged
+    Test that unsuccesful moves are correctly logged
     """
     bad_file_list = [
         "bad_file1",
@@ -154,3 +153,36 @@ def test_move_bad_objects(s3_stub, caplog):  # type: ignore
             found_error = True
 
     assert found_error
+
+
+@pytest.mark.parametrize(
+    ["remote_file_exists", "local_records", "upload_succeeds", "log_text"],
+    [
+        (True, 10, True, "existing_row_count=10"),
+        (True, 5, True, "<"),
+        (False, 5, True, "status=complete"),
+        (True, 10, False, "upload_file failed"),
+    ],
+)
+def test_replace_remote_parquet(
+    remote_file_exists: bool,
+    local_records: int,
+    upload_succeeds: bool,
+    log_text: str,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """It replaces a remote parquet or logs an error trying."""
+    local_file = tmp_path / "foo.parquet"
+    pl.int_range(0, local_records, eager=True).to_frame().write_parquet(local_file.as_posix())
+
+    remote_file = tmp_path / "remote_foo.parquet"
+    pl.int_range(0, 10, eager=True).to_frame().write_parquet(remote_file.as_posix())
+
+    with patch("lamp_py.aws.s3.object_exists", return_value=remote_file_exists):
+        with patch("pyarrow.fs.S3FileSystem", return_value=LocalFileSystem()):
+            with patch("lamp_py.aws.s3.upload_file", return_value=upload_succeeds):
+                result = replace_remote_parquet(local_file.as_posix(), "s3://" + remote_file.as_posix())
+                assert_frame_equal(pl.int_range(0, 10, eager=True).to_frame(), pl.read_parquet(remote_file.as_posix()))
+                assert log_text in caplog.text
+                assert result == (upload_succeeds and ((not remote_file_exists) or (local_records >= 10)))

--- a/tests/ingestion/test_glides.py
+++ b/tests/ingestion/test_glides.py
@@ -174,7 +174,7 @@ def test_ingest_glides_events(
     kinesis_reader.get_records.return_value = sample(test_records, len(test_records))
 
     mock_upload = mocker.Mock(return_value=True)
-    mocker.patch("lamp_py.ingestion.glides.upload_file", mock_upload)
+    mocker.patch("lamp_py.ingestion.glides.replace_remote_parquet", mock_upload)
 
     ingest_glides_events(kinesis_reader, Queue(), upload=True)
     assert Path(converter.local_path).exists()


### PR DESCRIPTION
[🐞 Glides trip updates truncated in prod](https://app.asana.com/1/15492006741476/project/1189492770004753/task/1214494536112678)

## What changes does this PR propose?

1. Adds `replace_remote_parquet` which:
* checks if the remote file exists
    * if not, calls `upload_file`
    * if so, checks if the local files has at least as many records as the remote file
        * if so, calls `upload_file`
        * if not, logs error and returns `False`
2. Replaces `upload_file` with `replace_remote_parquet` in Glides ingestion (the guilty party) and alerts ingestion


## How were these changes validated?

1. New unit test for `replace_remote_parquet`
2. Runs on `dev`; I reverted implementing this in GTFS-RT ingestion because currently our ingestion fails this test by uniquing the existing dataset


## What questions should reviewers consider?

1. None.
