### PR TITLE
feat(tests): randomize pytest order and seed

### DIFF
--- a/analysis/flashback_performance.py
+++ b/analysis/flashback_performance.py
@@ -25,6 +25,7 @@ def _():
 
     from lamp_py.flashback.events import StopEvents
     from lamp_py.aws.s3 import file_list_from_s3_with_details
+
     return StopEvents, alt, datetime, mo, pl, timedelta
 
 
@@ -326,15 +327,15 @@ def _(event_lag):
 def _(alt, event_lag, pl):
     (
         alt.Chart(
-            event_lag
-                .with_columns(pl.col("event_lag").dt.total_seconds())
-                .filter(pl.col("event_lag").is_between(0, 100))
+            event_lag.with_columns(pl.col("event_lag").dt.total_seconds()).filter(
+                pl.col("event_lag").is_between(0, 100)
+            )
         )
         .mark_bar()
         .encode(
-            alt.X('event_lag:Q').bin(maxbins = 30).title("Lag (seconds)"),
-            alt.Y('count()'),
-            alt.Color('most_recent_event')
+            alt.X("event_lag:Q").bin(maxbins=30).title("Lag (seconds)"),
+            alt.Y("count()"),
+            alt.Color("most_recent_event"),
         )
     )
     return

--- a/poetry.lock
+++ b/poetry.lock
@@ -3432,6 +3432,40 @@ pytest = ">=6.2.5"
 dev = ["pre-commit", "pytest-asyncio", "tox"]
 
 [[package]]
+name = "pytest-order"
+version = "1.4.0"
+description = "pytest plugin to run tests in a specific order"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "pytest_order-1.4.0-py3-none-any.whl", hash = "sha256:05b1710cf16bb2123294eec5bdfaee513322ff1926c0dfa86eb8be632eb264a1"},
+    {file = "pytest_order-1.4.0.tar.gz", hash = "sha256:327fb6eee1ae771051da13d2a0d9306d947e87f9ab8f4d6302e5d122c7472691"},
+]
+
+[package.dependencies]
+pytest = [
+    {version = ">=6.2.4", markers = "python_version < \"3.14\""},
+    {version = ">=7.4", markers = "python_version >= \"3.14\""},
+]
+
+[package.extras]
+dev = ["pytest-dependency (>=0.5.1)", "pytest-mock (>=1.11.0)", "pytest-xdist (>=1.29.0)"]
+
+[[package]]
+name = "pytest-randomly"
+version = "4.1.0"
+description = "Pytest plugin to randomly order tests and control random.seed."
+optional = false
+python-versions = ">=3.10"
+files = [
+    {file = "pytest_randomly-4.1.0-py3-none-any.whl", hash = "sha256:f55e89e53367b090c0c053697d7f9d77595543d0e0516c93978b50c0f6b252f9"},
+    {file = "pytest_randomly-4.1.0.tar.gz", hash = "sha256:47f1d9746c3bc3efabd53ae1ebfb8bb385cf3d4df4b505b6d58d9c97a3dfe70f"},
+]
+
+[package.dependencies]
+pytest = "*"
+
+[[package]]
 name = "pytest-xdist"
 version = "3.8.0"
 description = "pytest xdist plugin for distributed testing, most importantly across multiple CPUs"
@@ -4338,4 +4372,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "55c3ecc76f4564a5f61a223c92a89cd77ee5a4465406096f8f79d8d3e080a82c"
+content-hash = "c05a7a05e026148b1efeea002b63f96966caeee0c735afa5a2595134a7e3d481"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,8 @@ ruff = "^0.14.11"
 pytest-mock = "^3.15.1"
 ty = "^0.0.14"
 pytest-asyncio = "^1.3.0"
+pytest-randomly = "^4.1.0"
+pytest-order = "^1.4.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/src/lamp_py/ingestion/convert_gtfs_rt.py
+++ b/src/lamp_py/ingestion/convert_gtfs_rt.py
@@ -107,7 +107,7 @@ class VehiclePositions(dy.Schema):
             },
             alias="vehicle",
         ),
-        nullable=False,
+        min_length=1,
     )
 
 

--- a/src/lamp_py/ingestion/glides.py
+++ b/src/lamp_py/ingestion/glides.py
@@ -13,7 +13,7 @@ import pyarrow.parquet as pq
 from lamp_py.aws.s3 import download_file, upload_file
 from lamp_py.aws.kinesis import KinesisReader
 from lamp_py.ingestion.utils import explode_table_column, flatten_table_schema
-from lamp_py.utils.dataframely import unnest_columns, with_nullable
+from lamp_py.utils.dataframely import unnest_columns
 from lamp_py.runtime_utils.process_logger import ProcessLogger
 from lamp_py.runtime_utils.remote_files import (
     LAMP,
@@ -86,7 +86,7 @@ class EditorChangesRecord(GlidesRecord):
                     {
                         "type": dy.String(regex=r"start|stop"),
                         "location": location,
-                        "editor": with_nullable(user, True),
+                        "editor": user,
                     }
                 ),
                 min_length=1,

--- a/src/lamp_py/ingestion/glides.py
+++ b/src/lamp_py/ingestion/glides.py
@@ -13,7 +13,7 @@ import pyarrow.parquet as pq
 from lamp_py.aws.s3 import download_file, upload_file
 from lamp_py.aws.kinesis import KinesisReader
 from lamp_py.ingestion.utils import explode_table_column, flatten_table_schema
-from lamp_py.utils.dataframely import unnest_columns
+from lamp_py.utils.dataframely import unnest_columns, with_nullable
 from lamp_py.runtime_utils.process_logger import ProcessLogger
 from lamp_py.runtime_utils.remote_files import (
     LAMP,
@@ -86,7 +86,7 @@ class EditorChangesRecord(GlidesRecord):
                     {
                         "type": dy.String(regex=r"start|stop"),
                         "location": location,
-                        "editor": user.with_nullable(True),
+                        "editor": with_nullable(user, True),
                     }
                 ),
                 min_length=1,

--- a/src/lamp_py/ingestion/glides.py
+++ b/src/lamp_py/ingestion/glides.py
@@ -28,7 +28,7 @@ GTFS_TIME_REGEX = r"^([0-9]{2}):([0-5][0-9]):([0-5][0-9])$"  # clock can be grea
 
 user = dy.Struct(
     {
-        "emailAddress": dy.String(metadata={"reader_roles": ["GlidesUserEmail"]}),
+        "emailAddress": dy.String(metadata={"reader_roles": ["GlidesUserEmail"]}, nullable=True),
         "badgeNumber": dy.String(nullable=True),
     },
     nullable=True,
@@ -86,7 +86,7 @@ class EditorChangesRecord(GlidesRecord):
                     {
                         "type": dy.String(regex=r"start|stop"),
                         "location": location,
-                        "editor": user,
+                        "editor": user.with_nullable(True),
                     }
                 ),
                 min_length=1,
@@ -131,8 +131,9 @@ class TripUpdatesRecord(GlidesRecord):
                         "revenue": dy.String(nullable=True),
                         "dropped": dy.String(nullable=True),
                         "scheduled": dy.String(),  # an object with an array of objects
-                    }
-                )
+                    },
+                ),
+                min_length=1,
             ),
         }
     )

--- a/src/lamp_py/utils/dataframely.py
+++ b/src/lamp_py/utils/dataframely.py
@@ -1,17 +1,19 @@
+from copy import deepcopy
 import dataframely as dy
 
 
 def with_alias(column: dy.Column, new_alias: str) -> dy.Column:
     """Return the input column with a new alias."""
-    column.alias = new_alias
-
-    return column
+    new_column = deepcopy(column)
+    new_column.alias = new_alias
+    return new_column
 
 
 def with_nullable(column: dy.Column, nullable: bool) -> dy.Column:
     """Return the input column and set its nullability."""
-    column.nullable = nullable
-    return column
+    new_column = deepcopy(column)
+    new_column.nullable = nullable
+    return new_column
 
 
 def unnest_columns(columns: dict[str, dy.Column]) -> dict[str, dy.Column]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,7 +70,7 @@ def fixture_remote_file_locations_patch(
     yield
 
 
-@pytest.fixture(name="dy_gen", params=[1], scope="session")
-def fixture_dataframely_random_generator(request: pytest.FixtureRequest) -> Iterator:
+@pytest.fixture(name="dy_gen", scope="session")
+def fixture_dataframely_random_generator() -> Iterator:
     "Fixture wrapper around dataframely random data generator."
-    yield dy.random.Generator(request.param)
+    yield dy.random.Generator()

--- a/tests/flashback/test_events.py
+++ b/tests/flashback/test_events.py
@@ -83,15 +83,10 @@ from lamp_py.ingestion.convert_gtfs_rt import VehiclePositions
             ],
             0,
         ),
-        (
-            [],
-            0,
-        ),
     ],
     ids=[
         "complete-data",
         "missing-trip-id",
-        "empty-entity",
     ],
 )
 def test_unnest_vehicle_positions(entity: list[dict], valid_records: int) -> None:

--- a/tests/flashback/test_io.py
+++ b/tests/flashback/test_io.py
@@ -196,7 +196,12 @@ async def test_invalid_vehicle_positions_schema(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """It filters out events that don't comply with the schema."""
-    vp = VehiclePositions.sample(generator=dy_gen).with_columns(**overrides)
+    vp = VehiclePositions.sample(
+        generator=dy_gen,
+        overrides={
+            "entity": VehiclePositions.entity.inner.sample(generator=dy_gen, n=2).implode()
+        },  # need at least 2 entities to test duplicate primary keys
+    ).with_columns(**overrides)
     mock_response, _ = mock_vp_response(vp)  # type: ignore[arg-type]
     mock_get.return_value.__aenter__.return_value = mock_response
 

--- a/tests/ingestion/test_glides.py
+++ b/tests/ingestion/test_glides.py
@@ -39,9 +39,10 @@ def test_convert_records(dy_gen: dy.random.Generator, converter: GlidesConverter
         num_rows=num_rows,
         generator=dy_gen,
         overrides={
+            "id": [str(i) for i in range(num_rows)],
             "time": dy_gen.sample_datetime(
                 num_rows, min=datetime(2024, 1, 1), max=datetime(2039, 12, 31), time_unit="us"
-            ).cast(pl.Datetime(time_unit="ms"))
+            ).cast(pl.Datetime(time_unit="ms")),
         },
     ).to_dicts()
 
@@ -101,9 +102,10 @@ def test_append_records(
             num_rows=num_rows,
             generator=dy_gen,
             overrides={
+                "id": [str(i) for i in range(num_rows)],
                 "time": dy_gen.sample_datetime(
                     num_rows, min=datetime(2024, 1, 1), max=datetime(2039, 12, 31), time_unit="us"
-                ).cast(pl.Datetime(time_unit="ms"))
+                ).cast(pl.Datetime(time_unit="ms")),
             },
         )
         .with_columns(**new_records_transformations)
@@ -120,9 +122,10 @@ def test_append_records(
             num_rows,
             generator=dy_gen,
             overrides={
+                "id": [str(i) for i in range(num_rows)],
                 "time": dy_gen.sample_datetime(
                     num_rows, min=datetime(2024, 1, 1), max=datetime(2039, 12, 31), time_unit="us"
-                ).cast(pl.Datetime(time_unit="ms"))
+                ).cast(pl.Datetime(time_unit="ms")),
             },
         ).with_columns(**remote_records_transformations)
         remote_records.write_parquet(converter.local_path)
@@ -155,9 +158,10 @@ def test_ingest_glides_events(
             num_rows=events_per_converter,
             generator=dy_gen,
             overrides={
+                "id": [str(i) for i in range(events_per_converter)],
                 "time": dy_gen.sample_datetime(
                     events_per_converter, min=datetime(2024, 1, 1), max=datetime(2039, 12, 31), time_unit="us"
-                ).cast(pl.Datetime(time_unit="ms"))
+                ).cast(pl.Datetime(time_unit="ms")),
             },
         )
         .with_columns(

--- a/tests/performance_manager/test_performance_manager.py
+++ b/tests/performance_manager/test_performance_manager.py
@@ -406,6 +406,7 @@ def check_logs(caplog: pytest.LogCaptureFixture) -> None:
 
 
 @pytest.mark.xdist_group(name="rdb_group")
+@pytest.mark.order(1)
 def test_static_tables(
     rpm_db_manager: DatabaseManager,
     md_db_manager: DatabaseManager,
@@ -471,6 +472,7 @@ def test_static_tables(
 
 
 @pytest.mark.xdist_group(name="rdb_group")
+@pytest.mark.order(2)
 def test_good_empty_static_table(caplog: pytest.LogCaptureFixture) -> None:
     """
     test that empty/missing static calendar_dates can be turned into dataframe
@@ -483,6 +485,7 @@ def test_good_empty_static_table(caplog: pytest.LogCaptureFixture) -> None:
 
 
 @pytest.mark.xdist_group(name="rdb_group")
+@pytest.mark.order(3)
 def test_bad_empty_static_table() -> None:
     """
     test that empty/missing static parquet (that should have data) raises KeyError
@@ -497,6 +500,7 @@ def test_bad_empty_static_table() -> None:
 # pylint: disable=R0915
 # pylint Too many statements (51/50) (too-many-statements)
 @pytest.mark.xdist_group(name="rdb_group")
+@pytest.mark.order(4)
 def test_gtfs_rt_processing(
     rpm_db_manager: DatabaseManager,
     md_db_manager: DatabaseManager,
@@ -611,6 +615,7 @@ def test_gtfs_rt_processing(
     "lamp_py.performance_manager.l1_cte_statements.GTFS_ARCHIVE", "https://performancedata.mbta.com/lamp/gtfs_archive"
 )
 @pytest.mark.xdist_group(name="rdb_group")
+@pytest.mark.order(5)
 def test_vp_only(
     rpm_db_manager: DatabaseManager,
     md_db_manager: DatabaseManager,
@@ -637,6 +642,7 @@ def test_vp_only(
     "lamp_py.performance_manager.l1_cte_statements.GTFS_ARCHIVE", "https://performancedata.mbta.com/lamp/gtfs_archive"
 )
 @pytest.mark.xdist_group(name="rdb_group")
+@pytest.mark.order(6)
 def test_tu_only(
     rpm_db_manager: DatabaseManager,
     md_db_manager: DatabaseManager,
@@ -663,6 +669,7 @@ def test_tu_only(
     "lamp_py.performance_manager.l1_cte_statements.GTFS_ARCHIVE", "https://performancedata.mbta.com/lamp/gtfs_archive"
 )
 @pytest.mark.xdist_group(name="rdb_group")
+@pytest.mark.order(7)
 def test_vp_and_tu(
     rpm_db_manager: DatabaseManager,
     md_db_manager: DatabaseManager,
@@ -689,6 +696,7 @@ def test_vp_and_tu(
     "lamp_py.performance_manager.l1_cte_statements.GTFS_ARCHIVE", "https://performancedata.mbta.com/lamp/gtfs_archive"
 )
 @pytest.mark.xdist_group(name="rdb_group")
+@pytest.mark.order(8)
 def test_missing_start_time(
     rpm_db_manager: DatabaseManager,
     md_db_manager: DatabaseManager,
@@ -745,6 +753,7 @@ def test_missing_start_time(
 
 
 @pytest.mark.xdist_group(name="rdb_group")
+@pytest.mark.order(9)
 def test_process_vp_files(
     rpm_db_manager: DatabaseManager,
     caplog: pytest.LogCaptureFixture,

--- a/tests/utils/test_dataframely.py
+++ b/tests/utils/test_dataframely.py
@@ -1,4 +1,4 @@
-from typing import Type, Callable
+from typing import Type
 
 import dataframely as dy
 import pytest
@@ -22,10 +22,12 @@ from lamp_py.utils.dataframely import with_alias, with_nullable, unnest_columns
     ],
 )
 def test_with_alias(alias: str) -> None:
-    """It replaces the alias with the specified string."""
-    new_col = with_alias(dy.Struct(inner={"test": dy.String()}), alias)
+    """It replaces the alias with the specified string but does not modify the original column."""
+    col = dy.Struct(inner={"test": dy.String()})
+    new_col = with_alias(col, alias)
 
     assert alias == new_col.alias
+    assert col.alias is None
 
 
 @pytest.mark.parametrize(
@@ -69,9 +71,10 @@ def test_with_alias(alias: str) -> None:
     ],
 )
 def test_with_nullable(dtype: Type[dy.Column], input_nullability: bool, desired_nullability: bool) -> None:
-    """It always sets the specified nullability."""
+    """It always sets the specified nullability without modifying the original column."""
     new_column = dtype(nullable=input_nullability)
     assert desired_nullability == with_nullable(new_column, desired_nullability).nullable
+    assert new_column.nullable == input_nullability
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
In this PR, I avoided updating dataframely. Turns out there's a regression that caused the errors I saw and I just assumed they were intentional.

I noticed CI failures that were unrelated to the changes I wanted to make. I think the issue is that the random data created by dataframely changed because of OS or their RNG. That told me that we have some tests which succeed simply because we picked the right seed rather than setting the code or the schemas appropriately.

## What changes does this PR propose?

1. Adds `pytest-randomly`, which randomizes the order that tests run as well as the seed
2. Adds`pytest-order`, which allows us to control the order of tests in specific cases (eg. when tests write their state to the test performance manager database and need to retrieve that state later).
3. Updates Glides schemas to pass tests and get closer to reality
4. Updates VehiclePositions schema to require min length of 1 to pass tests and get closer to reality

## How were these changes validated?

1. CI
5. Ran glides ingestion locally to ensure that schema updates aligned with reality


## What questions should reviewers consider?

1. None.
