### PR TITLE
fix(rail): Interleave Tableau jobs

### DIFF
--- a/analysis/flashback_performance.py
+++ b/analysis/flashback_performance.py
@@ -25,6 +25,7 @@ def _():
 
     from lamp_py.flashback.events import StopEvents
     from lamp_py.aws.s3 import file_list_from_s3_with_details
+
     return StopEvents, alt, datetime, mo, pl, timedelta
 
 
@@ -326,15 +327,15 @@ def _(event_lag):
 def _(alt, event_lag, pl):
     (
         alt.Chart(
-            event_lag
-                .with_columns(pl.col("event_lag").dt.total_seconds())
-                .filter(pl.col("event_lag").is_between(0, 100))
+            event_lag.with_columns(pl.col("event_lag").dt.total_seconds()).filter(
+                pl.col("event_lag").is_between(0, 100)
+            )
         )
         .mark_bar()
         .encode(
-            alt.X('event_lag:Q').bin(maxbins = 30).title("Lag (seconds)"),
-            alt.Y('count()'),
-            alt.Color('most_recent_event')
+            alt.X("event_lag:Q").bin(maxbins=30).title("Lag (seconds)"),
+            alt.Y("count()"),
+            alt.Color("most_recent_event"),
         )
     )
     return

--- a/src/lamp_py/performance_manager/pipeline.py
+++ b/src/lamp_py/performance_manager/pipeline.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from lamp_py.tableau.hyper import HyperJob
 
 import argparse
 import logging
@@ -95,8 +96,8 @@ def main(args: argparse.Namespace) -> None:
     def reads() -> None:
         """Update parquet files with the latest data."""
         check_for_sigterm()
-        job = next(tableau_cycle)
-        process_logger = ProcessLogger("reads", job_name=str(job))
+        job: HyperJob = next(tableau_cycle)
+        process_logger = ProcessLogger("reads", output_path=job.remote_parquet_path)
         process_logger.log_start()
         try:
             job.run_parquet(rpm_db_manager)

--- a/src/lamp_py/performance_manager/pipeline.py
+++ b/src/lamp_py/performance_manager/pipeline.py
@@ -72,10 +72,10 @@ def main(args: argparse.Namespace) -> None:
     # schedule object that will control the "event loop"
     scheduler = sched.scheduler(time.monotonic, time.sleep)
 
-    def fast_iter() -> None:
+    def writes() -> None:
         """function to invoke a fast scheduled routine"""
         check_for_sigterm()
-        process_logger = ProcessLogger("fast_event_loop")
+        process_logger = ProcessLogger("writes")
         process_logger.log_start()
         try:
             process_static_tables(rpm_db_manager, md_db_manager)
@@ -87,7 +87,7 @@ def main(args: argparse.Namespace) -> None:
         except Exception as exception:
             process_logger.log_failure(exception)
         finally:
-            scheduler.enter(int(args.interval), 2, fast_iter)
+            scheduler.enter(int(args.interval), 2, writes)
 
     def slow_iter() -> None:
         """function to invoke a slow scheduled routine"""

--- a/src/lamp_py/performance_manager/pipeline.py
+++ b/src/lamp_py/performance_manager/pipeline.py
@@ -101,8 +101,8 @@ def main(args: argparse.Namespace) -> None:
         except Exception as exception:
             process_logger.log_failure(exception)
         finally:
-            # re-schedule every 2 minutes
-            scheduler.enter(60 * 2, 1, reads, (job + 1,))
+            # re-schedule every 60 seconds
+            scheduler.enter(60, 1, reads, (job + 1,))
 
     # schedule the initial loop and start the scheduler
     scheduler.enter(0, 1, writes)

--- a/src/lamp_py/performance_manager/pipeline.py
+++ b/src/lamp_py/performance_manager/pipeline.py
@@ -7,6 +7,7 @@ import sched
 import sys
 import time
 import signal
+from itertools import cycle
 from typing import List
 
 from lamp_py.aws.ecs import handle_ecs_sigterm, check_for_sigterm
@@ -72,8 +73,10 @@ def main(args: argparse.Namespace) -> None:
     # schedule object that will control the "event loop"
     scheduler = sched.scheduler(time.monotonic, time.sleep)
 
+    tableau_cycle = cycle(PERFORMANCE_MANAGER_JOBS)
+
     def writes() -> None:
-        """function to invoke a fast scheduled routine"""
+        """Write new data to the database."""
         check_for_sigterm()
         process_logger = ProcessLogger("writes")
         process_logger.log_start()
@@ -89,24 +92,25 @@ def main(args: argparse.Namespace) -> None:
         finally:
             scheduler.enter(int(args.interval), 2, writes)
 
-    def reads(job: int) -> None:
-        """function to invoke a slow scheduled routine"""
+    def reads() -> None:
+        """Update parquet files with the latest data."""
         check_for_sigterm()
-        process_logger = ProcessLogger("reads", job_counter=job)
+        job = next(tableau_cycle)
+        process_logger = ProcessLogger("reads", job_name=str(job))
         process_logger.log_start()
         try:
-            PERFORMANCE_MANAGER_JOBS[job % len(PERFORMANCE_MANAGER_JOBS)].run_parquet(rpm_db_manager)
+            job.run_parquet(rpm_db_manager)
 
             process_logger.log_complete()
         except Exception as exception:
             process_logger.log_failure(exception)
         finally:
-            # re-schedule every 60 seconds
-            scheduler.enter(60, 1, reads, (job + 1,))
+            # schedule next job in 10 seconds
+            scheduler.enter(10, 1, reads)
 
     # schedule the initial loop and start the scheduler
     scheduler.enter(0, 1, writes)
-    scheduler.enter(0, 2, reads, (0,))
+    scheduler.enter(0, 2, reads)
     scheduler.run()
 
 

--- a/src/lamp_py/performance_manager/pipeline.py
+++ b/src/lamp_py/performance_manager/pipeline.py
@@ -15,7 +15,7 @@ from lamp_py.runtime_utils.alembic_migration import alembic_upgrade_to_head
 from lamp_py.runtime_utils.env_validation import validate_environment
 from lamp_py.runtime_utils.process_logger import ProcessLogger
 
-from lamp_py.tableau.pipeline import start_parquet_updates
+from lamp_py.tableau.pipeline import PERFORMANCE_MANAGER_JOBS
 
 from lamp_py.publishing.performancedata import publish_performance_index
 from lamp_py.utils.clear_folder import clear_folder
@@ -89,24 +89,24 @@ def main(args: argparse.Namespace) -> None:
         finally:
             scheduler.enter(int(args.interval), 2, writes)
 
-    def slow_iter() -> None:
+    def reads(job: int) -> None:
         """function to invoke a slow scheduled routine"""
         check_for_sigterm()
-        process_logger = ProcessLogger("slow_event_loop")
+        process_logger = ProcessLogger("reads", job_counter=job)
         process_logger.log_start()
         try:
-            start_parquet_updates(rpm_db_manager)
+            PERFORMANCE_MANAGER_JOBS[job % len(PERFORMANCE_MANAGER_JOBS)].run_parquet()
 
             process_logger.log_complete()
         except Exception as exception:
             process_logger.log_failure(exception)
         finally:
-            # re-schedule every 30 minutes
-            scheduler.enter(60 * 30, 1, slow_iter)
+            # re-schedule every 2 minutes
+            scheduler.enter(60 * 2, 1, reads, (job + 1,))
 
     # schedule the initial loop and start the scheduler
-    scheduler.enter(0, 1, fast_iter)
-    scheduler.enter(0, 2, slow_iter)
+    scheduler.enter(0, 1, writes)
+    scheduler.enter(0, 2, reads, (0,))
     scheduler.run()
 
 

--- a/src/lamp_py/performance_manager/pipeline.py
+++ b/src/lamp_py/performance_manager/pipeline.py
@@ -1,31 +1,28 @@
 #!/usr/bin/env python
-from lamp_py.tableau.hyper import HyperJob
-
 import argparse
 import logging
 import os
 import sched
+import signal
 import sys
 import time
-import signal
 from itertools import cycle
 from typing import List
 
-from lamp_py.aws.ecs import handle_ecs_sigterm, check_for_sigterm
-from lamp_py.postgres.postgres_utils import DatabaseManager, DatabaseIndex
+from lamp_py.aws.ecs import check_for_sigterm, handle_ecs_sigterm
+from lamp_py.postgres.postgres_utils import DatabaseIndex, DatabaseManager
+from lamp_py.publishing.performancedata import publish_performance_index
 from lamp_py.runtime_utils.alembic_migration import alembic_upgrade_to_head
 from lamp_py.runtime_utils.env_validation import validate_environment
 from lamp_py.runtime_utils.process_logger import ProcessLogger
-
+from lamp_py.tableau.hyper import HyperJob
 from lamp_py.tableau.pipeline import PERFORMANCE_MANAGER_JOBS
-
-from lamp_py.publishing.performancedata import publish_performance_index
 from lamp_py.utils.clear_folder import clear_folder
 
+from .alerts import process_alerts
 from .flat_file import write_flat_files
 from .l0_gtfs_rt_events import process_gtfs_rt_files
 from .l0_gtfs_static_load import process_static_tables
-from .alerts import process_alerts
 
 logging.getLogger().setLevel("INFO")
 

--- a/src/lamp_py/performance_manager/pipeline.py
+++ b/src/lamp_py/performance_manager/pipeline.py
@@ -95,7 +95,7 @@ def main(args: argparse.Namespace) -> None:
         process_logger = ProcessLogger("reads", job_counter=job)
         process_logger.log_start()
         try:
-            PERFORMANCE_MANAGER_JOBS[job % len(PERFORMANCE_MANAGER_JOBS)].run_parquet()
+            PERFORMANCE_MANAGER_JOBS[job % len(PERFORMANCE_MANAGER_JOBS)].run_parquet(rpm_db_manager)
 
             process_logger.log_complete()
         except Exception as exception:

--- a/src/lamp_py/tableau/pipeline.py
+++ b/src/lamp_py/tableau/pipeline.py
@@ -4,7 +4,6 @@ from typing import List
 from lamp_py.runtime_utils.env_validation import validate_environment
 
 from lamp_py.tableau.hyper import HyperJob
-from lamp_py.postgres.postgres_utils import DatabaseManager
 from lamp_py.tableau.jobs.lamp_jobs import (
     Prod_VehiclePositions_LightRailTerminals_60Day,
     Prod_TripUpdates_LightRailTerminals_60Day,
@@ -38,6 +37,31 @@ from lamp_py.tableau.jobs.bus_performance import HyperBusPerformanceRecent
 from lamp_py.tableau.jobs.glides import HyperGlidesOperatorSignIns
 from lamp_py.tableau.jobs.glides import HyperGlidesTripUpdates
 from lamp_py.aws.ecs import check_for_parallel_tasks
+
+
+PERFORMANCE_MANAGER_JOBS: List[HyperJob] = [
+    HyperGlidesTripUpdates(),  # glides have operational usage, run these first to ensure timely report gen
+    HyperGlidesOperatorSignIns(),  # glides have operational usage, run these first to ensure timely report gen
+    Prod_RailMetrics_Subway_LongTerm,
+    Prod_RailMetrics_CommuterRail_LongTerm,
+    HyperServiceIdByRoute(),
+    HyperStaticCalendar(),
+    HyperStaticCalendarDates(),
+    HyperStaticFeedInfo(),
+    HyperStaticRoutes(),
+    HyperStaticStops(),
+    HyperStaticStopTimes(),
+    HyperStaticTrips(),
+    Prod_TripUpdates_LightRailTerminals_60Day,
+    Prod_VehiclePositions_HeavyRailTerminals_60Day,
+    Prod_TripUpdates_HeavyRailTerminals_30Day,
+    Prod_VehiclePositions_LightRailTerminals_60Day,
+    Prod_VehiclePositions_LightRail_7Day,
+    DevGreen_VehiclePositions_LightRailTerminals_60Day,
+    DevGreen_TripUpdates_LightRailTerminals_60Day,
+    DevGreen_VehiclePositions_HeavyRailTerminals_60Day,
+    DevGreen_TripUpdates_HeavyRailTerminals_60Day,
+]
 
 
 def start_hyper_updates() -> None:
@@ -103,39 +127,6 @@ def start_hyper_updates() -> None:
 
     for job in hyper_jobs:
         job.run_hyper()
-
-
-def start_parquet_updates(db_manager: DatabaseManager) -> None:
-    """Run all Parquet Update jobs
-    called from performance manager
-    """
-
-    parquet_update_jobs: List[HyperJob] = [
-        HyperGlidesTripUpdates(),  # glides have operational usage, run these first to ensure timely report gen
-        HyperGlidesOperatorSignIns(),  # glides have operational usage, run these first to ensure timely report gen
-        Prod_RailMetrics_Subway_LongTerm,
-        Prod_RailMetrics_CommuterRail_LongTerm,
-        HyperServiceIdByRoute(),
-        HyperStaticCalendar(),
-        HyperStaticCalendarDates(),
-        HyperStaticFeedInfo(),
-        HyperStaticRoutes(),
-        HyperStaticStops(),
-        HyperStaticStopTimes(),
-        HyperStaticTrips(),
-        Prod_TripUpdates_LightRailTerminals_60Day,
-        Prod_VehiclePositions_HeavyRailTerminals_60Day,
-        Prod_TripUpdates_HeavyRailTerminals_30Day,
-        Prod_VehiclePositions_LightRailTerminals_60Day,
-        Prod_VehiclePositions_LightRail_7Day,
-        DevGreen_VehiclePositions_LightRailTerminals_60Day,
-        DevGreen_TripUpdates_LightRailTerminals_60Day,
-        DevGreen_VehiclePositions_HeavyRailTerminals_60Day,
-        DevGreen_TripUpdates_HeavyRailTerminals_60Day,
-    ]
-
-    for job in parquet_update_jobs:
-        job.run_parquet(db_manager)
 
 
 def start_bus_parquet_updates() -> None:


### PR DESCRIPTION
Asana Task: [🐞 ensure Rail PM ingestion occurs more frequently](https://app.asana.com/1/15492006741476/project/1189492770004753/task/1214401884186277)

## What changes does this PR propose?

Updates the Rail PM pipeline so that Tableau jobs alternate with metadata & Performance Manager inserts.


## How were these changes validated?

- [x] ran on dev and [saw](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dlamp-dev%20process_name%3Dreads%20OR%20process_name%3Dwrites%20status%3Dcomplete%0A%7C%20stats%20count(_raw)%20as%20job_count%20by%20process_name%0A%7C%20table%20process_name%2C%20job_count&display.page.search.mode=verbose&dispatch.sample_ratio=1&workload_pool=&earliest=1778687400&latest=1778691009&display.page.search.tab=statistics&display.general.type=statistics&sid=1778691170.102027)
    * less time between writes
    * no failures


## What questions should reviewers consider?

1. What kind of overhead does this incur? From my perspective, all I see is more logging though that could be wrong
