### PR TITLE
fix(actions): Grant Python CI permissions to write to PRs

### DIFF
--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -13,6 +13,9 @@ permissions:
 jobs:
   python-ci:
     uses: ./.github/workflows/ci_python.yaml
+    permissions:
+      contents: read
+      pull-requests: write
   deploy:
     name: Deploy to Staging
     needs: python-ci


### PR DESCRIPTION
https://github.com/mbta/lamp/actions/runs/25757549846/workflow failed needing more permisisons (which were clarified in #735.

## What changes does this PR propose?

Grants Python CI permissions when deploying to staging.


## How were these changes validated?

Not. I hope it's trivial.


## What questions should reviewers consider?

None.
