### PR TITLE
feat(ingestion): Add `automaticStartTime` and `automaticEndTime` to Glides trip updates

### DIFF
--- a/src/lamp_py/ingestion/glides.py
+++ b/src/lamp_py/ingestion/glides.py
@@ -127,6 +127,8 @@ class TripUpdatesRecord(GlidesRecord):
                         "endLocation": location,
                         "startTime": dy.String(nullable=True),  # can be "unset" string :(
                         "endTime": dy.String(nullable=True),  # can be "unset" string :(
+                        "automaticStartTime": dy.String(nullable=True, regex=r"unset|" + GTFS_TIME_REGEX),
+                        "automaticEndTime": dy.String(nullable=True, regex=r"unset|" + GTFS_TIME_REGEX),
                         "cars": dy.String(nullable=True),  # an array of objects
                         "revenue": dy.String(nullable=True),
                         "dropped": dy.String(nullable=True),

--- a/src/lamp_py/ingestion/glides.py
+++ b/src/lamp_py/ingestion/glides.py
@@ -61,6 +61,8 @@ trip_key = dy.Struct(
     nullable=True,
 )
 
+start_end_time = dy.String(nullable=True, regex=r"unset|" + GTFS_TIME_REGEX)
+
 
 class GlidesRecord(dy.Schema):
     """Base schema for all Glides records."""
@@ -125,10 +127,10 @@ class TripUpdatesRecord(GlidesRecord):
                         "comment": dy.String(nullable=True),
                         "startLocation": location,
                         "endLocation": location,
-                        "startTime": dy.String(nullable=True),  # can be "unset" string :(
-                        "endTime": dy.String(nullable=True),  # can be "unset" string :(
-                        "automaticStartTime": dy.String(nullable=True, regex=r"unset|" + GTFS_TIME_REGEX),
-                        "automaticEndTime": dy.String(nullable=True, regex=r"unset|" + GTFS_TIME_REGEX),
+                        "startTime": start_end_time,
+                        "endTime": start_end_time,
+                        "automaticStartTime": start_end_time,
+                        "automaticEndTime": start_end_time,
                         "cars": dy.String(nullable=True),  # an array of objects
                         "revenue": dy.String(nullable=True),
                         "dropped": dy.String(nullable=True),


### PR DESCRIPTION
Asana Task: [🚋 add automaticStartTime/EndTime to Glides TripUpdates](https://app.asana.com/1/15492006741476/project/1189492770004753/task/1212437463053858?focus=true)

## What changes does this PR propose?

Adds 2 new fields following https://github.com/mbta/schemas/pull/19 and https://github.com/mbta/glides/pull/3319.


## How were these changes validated?

1. Ran Glides ingestion locally using `ctd-glides-prod`, saw 0 errors


## What questions should reviewers consider?

1. Should the Tableau runner transform this field out of a string format? We could transform to an [Interval](https://tableau.github.io/hyper-db/lang_docs/py/tableauhyperapi.html#tableauhyperapi.TypeTag.INTERVAL)
