### PR TITLE
fix(bus): Continue processing when encountering common, flaky error types

### DIFF
--- a/src/lamp_py/bus_performance_manager/events_tm_schedule.py
+++ b/src/lamp_py/bus_performance_manager/events_tm_schedule.py
@@ -122,7 +122,10 @@ def generate_tm_schedule(service_date: date) -> dy.DataFrame[TransitMasterSchedu
     )
 
     stop_crossings = (
-        pl.scan_parquet(os.path.join(tm_stop_crossing.s3_uri, f"1{service_date.strftime('%Y%m%d')}.parquet"))
+        pl.scan_parquet(
+            os.path.join(tm_stop_crossing.s3_uri, f"1{service_date.strftime('%Y%m%d')}.parquet"),
+            storage_options={"max_retries": 5},
+        )
         .filter(
             pl.col("ROUTE_ID").is_not_null(),
             pl.col("GEO_NODE_ID").is_not_null(),

--- a/src/lamp_py/bus_performance_manager/write_events.py
+++ b/src/lamp_py/bus_performance_manager/write_events.py
@@ -2,6 +2,7 @@ from datetime import date, timedelta
 import os
 import tempfile
 from typing import Optional
+from polars.exceptions import ComputeError
 
 import pyarrow.parquet as pq
 
@@ -110,6 +111,10 @@ def write_bus_metrics(
         except LampInvalidProcessingError as exception:
             # num service date > 1 = InvalidProcessing (this should never happen)
             day_logger.log_failure(exception)
+        except (OSError, ComputeError) as exception:
+            # common errors related to processing remote files
+            day_logger.log_failure(exception)
+            continue
         except Exception as exception:
             day_logger.log_failure(exception)
 


### PR DESCRIPTION
Asana Task: [[spike, rca] 🚌🐞 bus version bumping is broken](https://app.asana.com/1/15492006741476/project/1189492770004753/task/1213535298442276?focus=true)

I'm not sure if this PR will solve this issue but it'll rule out one possible source of failure: networking issues. When `write_bus_metrics` encounters any error besides `LampExpectedNotFoundError`, it logs the failure and doesn't proceed to the next service date. So, networking errors—which are likely since we call `scan_parquet` 16 times per service date—halt the function. It runs in order from most recent date to oldest date, meaning the oldest dates are less and less likely to be executed.

## What changes does this PR propose?

1. Retries scanning the object with the most common errors (20 out of 21 failures in `write_bus_metrics`)
2. Continues if encounters `polars.exceptions.ComputeError` or `OSError`


## How were these changes validated?

Didn't; seems trivial.


## What questions should reviewers consider?

1. Do you think this is possibly the cause of the issue? The most recent error, on 2026-05-06, aligns with the last time that the oldest relevant service date (2025-08-01) was last updated.
