### PR TITLE
fix(actions): Require calling workflows to pass AWS_ROLE_ARN

### DIFF
--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -57,3 +57,5 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    secrets:
+      AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -47,3 +47,5 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    secrets:
+      AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}

--- a/.github/workflows/run-task.yaml
+++ b/.github/workflows/run-task.yaml
@@ -32,6 +32,9 @@ on:
         type: string
         required: false
         default: main
+    secrets:
+      AWS_ROLE_ARN:
+        required: true
 
 concurrency:
   group: run-task-${{ inputs.environment }}-${{ inputs.task }}


### PR DESCRIPTION
Another follow up from #735: `deploy-staging` and `deploy-prod` [need](https://github.com/mbta/lamp/actions/runs/25862301992) to delegate credentials to `run-task` but `run-task` doesn't define credentials as a secret.

## What changes does this PR propose?

1. Defines `AWS_ROLE_ARN` as an input secret when calling `run-task`
2. Binds `secrets.AWS_ROLE_ARN` to `AWS_ROLE_ARN` in calling workflows


## How were these changes validated?

Weren't. This deploy will validate.


## What questions should reviewers consider?

None.
