### PR TITLE
fix(glides): Copy staging data to other environments

### DIFF
--- a/src/lamp_py/ad_hoc/pipeline.py
+++ b/src/lamp_py/ad_hoc/pipeline.py
@@ -31,7 +31,7 @@ def start() -> None:
     check_for_parallel_tasks()
 
     # run the main method
-    runner(dry_run=True)
+    runner(dry_run=False)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Asana Task: [🐞 Glides trip updates truncated in prod](https://app.asana.com/1/15492006741476/project/1189492770004753/task/1214494536112678)

## What changes does this PR propose?

1. Appends staging Glides trip updates data from before incident to existing data from after incident


## How were these changes validated?

- [x] dry run [successful in prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dlamp-prod%20parent%3Dad_hoc&display.page.search.mode=verbose&dispatch.sample_ratio=1&workload_pool=&earliest=1779290809&latest=1779290817&display.page.search.showFields=0&sid=1779296369.123933)
- [x] overwrite [successful in dev](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dlamp-dev%20parent%3Dad_hoc&display.page.search.mode=verbose&dispatch.sample_ratio=1&workload_pool=&earliest=1779294647&latest=1779294657&display.page.search.showFields=0&sid=1779296226.123921)
- [x] dev data shows
    - [x] data as far back as 2024 and as late as today
    ```sql
    select
      min(time) as EarliestRecordDt,
      max(time) as LatestRecordDt,
      count(*)
    from
      read_parquet('s3://mbta-ctd-dataplatform-dev-springboard/lamp/GLIDES/trip_updates.parquet')
    ```
    - [x] no duplicates
    ```sql
    select
      count(*)
    from
      (select distinct * from read_parquet('s3://mbta-ctd-dataplatform-dev-springboard/lamp/GLIDES/trip_updates.parquet'))
    ```


## What questions should reviewers consider?

None.
