### PR TITLE
fix(ingestion): Don't treat GTFS_ARCHIVE as parquet

### DIFF
--- a/src/lamp_py/aws/s3.py
+++ b/src/lamp_py/aws/s3.py
@@ -768,6 +768,8 @@ def replace_remote_parquet(
 
     try:
         if object_exists(object_path):
+            if not object_path.endswith(".parquet"):
+                raise LampInvalidReplacementError(f"Existing object {object_path} is not a parquet file")
             existing_row_count = pq.read_metadata(object_path, filesystem=fs.S3FileSystem()).num_rows
             new_row_count = pq.read_metadata(file_name).num_rows
             if new_row_count < existing_row_count:

--- a/src/lamp_py/ingestion/compress_gtfs/gtfs_to_parquet.py
+++ b/src/lamp_py/ingestion/compress_gtfs/gtfs_to_parquet.py
@@ -220,9 +220,9 @@ def compress_gtfs_file(gtfs_table_file: str, schedule_details: ScheduleDetails) 
         pl.concat(
             (old_records, same_records, new_records),
             how="diagonal",
-        ).filter(pl.col("gtfs_end_date") > pl.col("gtfs_active_date")).write_parquet(
-            export_path, use_pyarrow=True, statistics=True
-        )
+        ).filter(
+            pl.col("gtfs_end_date") > pl.col("gtfs_active_date")
+        ).write_parquet(export_path, use_pyarrow=True, statistics=True)
     else:
         #
         # no partition file exists (current or last)

--- a/src/lamp_py/ingestion/compress_gtfs/gtfs_to_parquet.py
+++ b/src/lamp_py/ingestion/compress_gtfs/gtfs_to_parquet.py
@@ -1,25 +1,24 @@
 import os
-import time
 import tempfile
+import time
 from typing import Tuple
 
 import polars as pl
-import pyarrow.parquet as pq
 import pyarrow.compute as pc
 import pyarrow.dataset as pd
+import pyarrow.parquet as pq
 
-from lamp_py.runtime_utils.process_logger import ProcessLogger
-
+from lamp_py.aws.s3 import replace_remote_parquet, upload_file
 from lamp_py.ingestion.compress_gtfs.gtfs_schema_map import (
-    gtfs_schema_list,
     gtfs_schema,
+    gtfs_schema_list,
 )
+from lamp_py.ingestion.compress_gtfs.pq_to_sqlite import pq_folder_to_sqlite
 from lamp_py.ingestion.compress_gtfs.schedule_details import (
     ScheduleDetails,
     schedules_to_compress,
 )
-from lamp_py.ingestion.compress_gtfs.pq_to_sqlite import pq_folder_to_sqlite
-from lamp_py.aws.s3 import replace_remote_parquet, upload_file
+from lamp_py.runtime_utils.process_logger import ProcessLogger
 from lamp_py.runtime_utils.remote_files import compressed_gtfs
 
 
@@ -30,7 +29,7 @@ def frame_parquet_diffs(
     filter_date: int,
 ) -> Tuple[pl.DataFrame, pl.DataFrame, pl.DataFrame]:
     """
-    compare new_frame records to applicable records from an existing parquet file
+    Compare new_frame records to applicable records from an existing parquet file
 
     creates 3 frames based on diffs:
         - new_records -> records in new_frame that are not found in parquet file
@@ -79,7 +78,7 @@ def frame_parquet_diffs(
 
 def merge_frame_with_parquet(merge_df: pl.DataFrame, export_path: str, filter_date: int) -> None:
     """
-    merge merge_df with existing parqut file (export_path) and over-write with results
+    Merge merge_df with existing parqut file (export_path) and over-write with results
 
     all parquet read/write operations are done in batches to constrain memory usage
 
@@ -119,8 +118,7 @@ def merge_frame_with_parquet(merge_df: pl.DataFrame, export_path: str, filter_da
 
 def compress_gtfs_file(gtfs_table_file: str, schedule_details: ScheduleDetails) -> None:
     """
-    compress an indivdual gtfs_table_file (ie. stop_times.txt) into yearly parquet
-    partitioned parquet file(s)
+    Compress an indivdual gtfs_table_file (ie. stop_times.txt) into yearly parquet partitioned parquet file(s)
 
     yearly partition is based on ScheduleDetals.active_from_int value (1 day after published_dt)
 
@@ -149,7 +147,7 @@ def compress_gtfs_file(gtfs_table_file: str, schedule_details: ScheduleDetails) 
     )
     last_export_path = os.path.join(
         schedule_details.tmp_folder,
-        f"{partition_year-1}",
+        f"{partition_year - 1}",
         f"{gtfs_table}.parquet",
     )
 
@@ -186,7 +184,7 @@ def compress_gtfs_file(gtfs_table_file: str, schedule_details: ScheduleDetails) 
         #
         # new year merge operation (with last_export_path)
         #
-        end_last_year = int(f"{partition_year-1}1231")
+        end_last_year = int(f"{partition_year - 1}1231")
         start_current_year = int(f"{partition_year}0101")
         old_records, same_records, new_records = frame_parquet_diffs(
             new_frame=new_frame,
@@ -222,9 +220,9 @@ def compress_gtfs_file(gtfs_table_file: str, schedule_details: ScheduleDetails) 
         pl.concat(
             (old_records, same_records, new_records),
             how="diagonal",
-        ).filter(
-            pl.col("gtfs_end_date") > pl.col("gtfs_active_date")
-        ).write_parquet(export_path, use_pyarrow=True, statistics=True)
+        ).filter(pl.col("gtfs_end_date") > pl.col("gtfs_active_date")).write_parquet(
+            export_path, use_pyarrow=True, statistics=True
+        )
     else:
         #
         # no partition file exists (current or last)
@@ -238,7 +236,7 @@ def compress_gtfs_file(gtfs_table_file: str, schedule_details: ScheduleDetails) 
 
 def compress_gtfs_schedule(schedule_details: ScheduleDetails) -> None:
     """
-    compress all table files of gtfs schedule into parquet files partitioned by year
+    Compress all table files of gtfs schedule into parquet files partitioned by year
 
     this process is currently configured to run sequentially (oldest -> newest)
 
@@ -271,7 +269,7 @@ def compress_gtfs_schedule(schedule_details: ScheduleDetails) -> None:
 
 def gtfs_to_parquet() -> None:
     """
-    run gtfs -> parquet schedule compression process locally and then sync with S3 bucket
+    Run gtfs -> parquet schedule compression process locally and then sync with S3 bucket
 
     maximum process memory usage for this operation peaked at 5440MB
     while processing Feb-2018 to April-2024

--- a/src/lamp_py/ingestion/compress_gtfs/gtfs_to_parquet.py
+++ b/src/lamp_py/ingestion/compress_gtfs/gtfs_to_parquet.py
@@ -19,7 +19,7 @@ from lamp_py.ingestion.compress_gtfs.schedule_details import (
     schedules_to_compress,
 )
 from lamp_py.ingestion.compress_gtfs.pq_to_sqlite import pq_folder_to_sqlite
-from lamp_py.aws.s3 import replace_remote_parquet
+from lamp_py.aws.s3 import replace_remote_parquet, upload_file
 from lamp_py.runtime_utils.remote_files import compressed_gtfs
 
 
@@ -297,9 +297,15 @@ def gtfs_to_parquet() -> None:
         year_path = os.path.join(gtfs_tmp_folder, year)
         pq_folder_to_sqlite(year_path)
         for file in os.listdir(year_path):
-            replace_remote_parquet(
-                file_name=os.path.join(year_path, file),
-                object_path=os.path.join(compressed_gtfs.s3_uri, year, file),
-            )
+            if os.path.splitext(file)[1] == ".parquet":
+                replace_remote_parquet(
+                    file_name=os.path.join(year_path, file),
+                    object_path=os.path.join(compressed_gtfs.s3_uri, year, file),
+                )
+            else:
+                upload_file(
+                    file_name=os.path.join(year_path, file),
+                    object_path=os.path.join(compressed_gtfs.s3_uri, year, file),
+                )
 
     logger.log_complete()

--- a/tests/aws/test_s3_utils.py
+++ b/tests/aws/test_s3_utils.py
@@ -156,25 +156,28 @@ def test_move_bad_objects(s3_stub, caplog):  # type: ignore
 
 
 @pytest.mark.parametrize(
-    ["remote_file_exists", "local_records", "upload_succeeds", "log_text"],
+    ["remote_file_path", "local_records", "upload_succeeds", "log_text", "expected_result"],
     [
-        (True, 10, True, "uploaded=True"),
-        (True, 5, True, "LampInvalidReplacementError"),
-        (False, 5, True, "uploaded=True"),
-        (True, 10, False, "uploaded=False"),
+        ("remote_foo.parquet", 10, True, "uploaded=True", True),
+        ("remote_foo.parquet", 5, True, "LampInvalidReplacementError", False),
+        ("remote_bar.parquet", 5, True, "uploaded=True", True),
+        ("remote_foo.parquet", 10, False, "uploaded=False", False),
+        ("remote_foo.xyz", 10, True, "LampInvalidReplacementError", False),
     ],
     ids=[
         "replace-existing",
         "fewer-records-than-existing",
         "no-existing",
         "upload-fails",
+        "existing-not-parquet",
     ],
 )
 def test_replace_remote_parquet(
-    remote_file_exists: bool,
+    remote_file_path: str,
     local_records: int,
     upload_succeeds: bool,
     log_text: str,
+    expected_result: bool,
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -182,8 +185,10 @@ def test_replace_remote_parquet(
     local_file = tmp_path / "foo.parquet"
     pl.int_range(0, local_records, eager=True).to_frame().write_parquet(local_file.as_posix())
 
-    remote_file = tmp_path / "remote_foo.parquet"
+    remote_file = tmp_path / remote_file_path
     pl.int_range(0, 10, eager=True).to_frame().write_parquet(remote_file.as_posix())
+
+    remote_file_exists = "remote_" + local_file.stem == remote_file.stem
 
     with patch("lamp_py.aws.s3.object_exists", return_value=remote_file_exists):
         with patch("pyarrow.fs.S3FileSystem", return_value=LocalFileSystem()):
@@ -191,4 +196,4 @@ def test_replace_remote_parquet(
                 result = replace_remote_parquet(local_file.as_posix(), "s3://" + remote_file.as_posix())
                 assert_frame_equal(pl.int_range(0, 10, eager=True).to_frame(), pl.read_parquet(remote_file.as_posix()))
                 assert log_text in caplog.text
-                assert result == (upload_succeeds and ((not remote_file_exists) or (local_records >= 10)))
+                assert result == expected_result


### PR DESCRIPTION
#744 caused a [prod ingestion failure](https://mbta.splunkcloud.com/en-US/app/search/show_source?sid=1779372643.126561&offset=0&latest_time=1779332400) when it treated `GTFS_ARCHIVE.db.gz` as a parquet file.

## What changes does this PR propose?

Uses `upload_file` for `GTFS_ARCHIVE.db.gz`.


## How were these changes validated?

Didn't. Seems pretty clear from the error.


## What questions should reviewers consider?

1. Is there an easy unit test that you see I could add here? The only way I see to do it would be to create a bunch more test files and directories