### PR TITLE
feat(tableau/lrtp): LRTP vehicle position include terminal and terminal adjacent stops

### DIFF
--- a/src/lamp_py/tableau/conversions/convert_gtfs_rt_vehicle_position.py
+++ b/src/lamp_py/tableau/conversions/convert_gtfs_rt_vehicle_position.py
@@ -1,7 +1,7 @@
 import polars as pl
 import dataframely as dy
 
-from lamp_py.utils.filter_bank import FilterBankRtVehiclePositions
+from lamp_py.utils.filter_bank import FilterBankRtVehiclePositions, LightRailFilter
 from lamp_py.runtime_utils.process_logger import ProcessLogger
 
 
@@ -60,7 +60,7 @@ class LightRailTerminalVehiclePositions(dy.Schema):
     stop_id = dy.String(
         nullable=True,
         alias="vehicle.stop_id",
-        check=lambda x: x.is_in(FilterBankRtVehiclePositions.ParquetFilter.light_rail_terminal_stop_list),
+        check=lambda x: x.is_in(FilterBankRtVehiclePositions.ParquetFilter.light_rail_terminal_adjacent_stop_list),
     )
     trip_id = dy.String(nullable=True, alias="vehicle.trip.trip_id", check=lambda x: x.is_not_null())
     revenue = dy.Bool(nullable=True, alias="vehicle.trip.revenue", check=lambda x: x)
@@ -100,12 +100,12 @@ def lrtp(polars_df: pl.DataFrame) -> dy.DataFrame[LightRailTerminalVehiclePositi
     process_logger.log_start()
 
     polars_df = restrict_vp_to_only_terminal_stop_ids(
-        polars_df, FilterBankRtVehiclePositions.ParquetFilter.light_rail_terminal_stop_list
+        polars_df, FilterBankRtVehiclePositions.ParquetFilter.light_rail_terminal_adjacent_stop_list + LightRailFilter.terminal_stop_ids
     )
     polars_df = apply_gtfs_rt_vehicle_positions_timezone_conversions(polars_df)
     valid = LightRailTerminalVehiclePositions.validate(polars_df)
 
-    process_logger.log_start()
+    process_logger.log_complete()
 
     return valid
 

--- a/src/lamp_py/tableau/conversions/convert_gtfs_rt_vehicle_position.py
+++ b/src/lamp_py/tableau/conversions/convert_gtfs_rt_vehicle_position.py
@@ -46,17 +46,13 @@ class VehiclePositions(dy.Schema):
 class LightRailTerminalVehiclePositions(dy.Schema):
     "Analytical VehiclePositions dataset for light rail terminal predictions."
     id = VehiclePositions.id
-    trip_id = VehiclePositions.trip_id
     route_id = VehiclePositions.route_id
     direction_id = VehiclePositions.direction_id
     start_time = VehiclePositions.start_time
     start_date = VehiclePositions.start_date
-    revenue = VehiclePositions.revenue
     vehicle_id = VehiclePositions.vehicle_id
     vehicle_label = VehiclePositions.vehicle_label
     timestamp = VehiclePositions.timestamp
-    feed_timestamp = VehiclePositions.feed_timestamp
-    stop_id = VehiclePositions.stop_id
     stop_id = dy.String(
         nullable=True,
         alias="vehicle.stop_id",

--- a/src/lamp_py/tableau/conversions/convert_gtfs_rt_vehicle_position.py
+++ b/src/lamp_py/tableau/conversions/convert_gtfs_rt_vehicle_position.py
@@ -100,7 +100,9 @@ def lrtp(polars_df: pl.DataFrame) -> dy.DataFrame[LightRailTerminalVehiclePositi
     process_logger.log_start()
 
     polars_df = restrict_vp_to_only_terminal_stop_ids(
-        polars_df, FilterBankRtVehiclePositions.ParquetFilter.light_rail_terminal_adjacent_stop_list + LightRailFilter.terminal_stop_ids
+        polars_df,
+        FilterBankRtVehiclePositions.ParquetFilter.light_rail_terminal_adjacent_stop_list
+        + LightRailFilter.terminal_stop_ids,
     )
     polars_df = apply_gtfs_rt_vehicle_positions_timezone_conversions(polars_df)
     valid = LightRailTerminalVehiclePositions.validate(polars_df)

--- a/src/lamp_py/tableau/conversions/convert_gtfs_rt_vehicle_position.py
+++ b/src/lamp_py/tableau/conversions/convert_gtfs_rt_vehicle_position.py
@@ -60,7 +60,10 @@ class LightRailTerminalVehiclePositions(dy.Schema):
     stop_id = dy.String(
         nullable=True,
         alias="vehicle.stop_id",
-        check=lambda x: x.is_in(FilterBankRtVehiclePositions.ParquetFilter.light_rail_terminal_adjacent_stop_list),
+        check=lambda x: x.is_in(
+            FilterBankRtVehiclePositions.ParquetFilter.light_rail_terminal_adjacent_stop_list
+            + LightRailFilter.terminal_stop_ids
+        ),
     )
     trip_id = dy.String(nullable=True, alias="vehicle.trip.trip_id", check=lambda x: x.is_not_null())
     revenue = dy.Bool(nullable=True, alias="vehicle.trip.revenue", check=lambda x: x)

--- a/src/lamp_py/tableau/jobs/bus_performance.py
+++ b/src/lamp_py/tableau/jobs/bus_performance.py
@@ -20,7 +20,7 @@ from lamp_py.aws.s3 import file_list_from_s3_with_details
 from lamp_py.aws.s3 import object_exists
 
 # temporary - ticket in backlog to implement this split as per-rating instead
-BUS_ALL_NDAYS = (datetime.now().date() - datetime(2025, 8, 1).date()).days
+BUS_ALL_NDAYS = (datetime.now().date() - datetime(2025, 12, 14).date()).days
 BUS_RECENT_NDAYS = 7
 # this schema and the order of this schema SHOULD match what comes out
 # of the polars version from bus_performance_manager.

--- a/src/lamp_py/tableau/pipeline.py
+++ b/src/lamp_py/tableau/pipeline.py
@@ -137,7 +137,7 @@ def start_bus_parquet_updates() -> None:
     parquet_update_jobs: List[HyperJob] = [
         HyperBusPerformanceRecent(),
         Prod_BusOperatorMapping_Recent,
-        HyperBusPerformanceAll(),
+        # HyperBusPerformanceAll(),
         Prod_BusOperatorMapping_LongTerm,
         Prod_BusMetrics_Fall2025Rating,
         Prod_BusOperatorMapping_Fall2025Rating,

--- a/src/lamp_py/tableau/pipeline.py
+++ b/src/lamp_py/tableau/pipeline.py
@@ -108,7 +108,7 @@ def start_hyper_updates() -> None:
         HyperStaticStopTimes(),
         HyperStaticTrips(),
         HyperRtAlerts(),
-        # HyperBusPerformanceAll(),
+        HyperBusPerformanceAll(),
         HyperBusPerformanceRecent(),
         Prod_BusOperatorMapping_Recent,
         Prod_BusOperatorMapping_LongTerm,

--- a/src/lamp_py/tableau/pipeline.py
+++ b/src/lamp_py/tableau/pipeline.py
@@ -137,7 +137,7 @@ def start_bus_parquet_updates() -> None:
     parquet_update_jobs: List[HyperJob] = [
         HyperBusPerformanceRecent(),
         Prod_BusOperatorMapping_Recent,
-        # HyperBusPerformanceAll(),
+        HyperBusPerformanceAll(),
         Prod_BusOperatorMapping_LongTerm,
         Prod_BusMetrics_Fall2025Rating,
         Prod_BusOperatorMapping_Fall2025Rating,

--- a/src/lamp_py/tableau/pipeline.py
+++ b/src/lamp_py/tableau/pipeline.py
@@ -108,7 +108,7 @@ def start_hyper_updates() -> None:
         HyperStaticStopTimes(),
         HyperStaticTrips(),
         HyperRtAlerts(),
-        HyperBusPerformanceAll(),
+        # HyperBusPerformanceAll(),
         HyperBusPerformanceRecent(),
         Prod_BusOperatorMapping_Recent,
         Prod_BusOperatorMapping_LongTerm,

--- a/src/lamp_py/utils/filter_bank.py
+++ b/src/lamp_py/utils/filter_bank.py
@@ -74,11 +74,11 @@ class FilterBankRtVehiclePositions:
         blue = pc.field("vehicle.trip.route_id") == "Blue"
         red = pc.field("vehicle.trip.route_id") == "Red"
 
-        light_rail_terminal_stop_list = list(map(str, [70110, 70162, 70236, 70274, 70502, 70510]))
+        light_rail_terminal_adjacent_stop_list = list(map(str, [70110, 70162, 70236, 70274, 70502, 70510]))
         heavy_rail_terminal_stop_list = list(map(str, [70003, 70034, 70040, 70057, 70063, 70092, 70104]))
         # don't filter with these IDs - do this in Polars.
         # this is significantly slower
-        light_rail_terminal_stop_ids = pa.array(light_rail_terminal_stop_list)
+        light_rail_terminal_stop_ids = pa.array(light_rail_terminal_adjacent_stop_list)
         heavy_rail_terminal_stop_ids = pa.array(heavy_rail_terminal_stop_list)
         light_rail_terminal_by_stop_id = pc.is_in(pc.field("vehicle.stop_id"), light_rail_terminal_stop_ids)
         heavy_rail_terminal_by_stop_id = pc.is_in(pc.field("vehicle.stop_id"), heavy_rail_terminal_stop_ids)


### PR DESCRIPTION
Asana Task: <[ticket](https://app.asana.com/1/15492006741476/project/1189492770004753/task/1215177791709944?focus=true)>

## What changes does this PR propose?

Tableau Vehicle positions for LRTP used to only be for the terminals adjacent to the terminals. to detect when the vehicle is coming in or leaving the terminal (I think..). Now we're also getting VP that report at the terminals

Applied to prod and dev green

- renamed existing vehicle position stop ids to accurately reflect what stops they are 

## How were these changes validated?

- very simple change, low risk.
- manual deploy in staging at risk to see it go to tableau - update (10am): see the changes in S3, have to just wait for the tableau job to kick off and see it go to tableau..but I think that'll work fine. 


## What questions should reviewers consider?
