### PR TITLE
fix(ingestion): Allow trip_descriptor to be null

### DIFF
--- a/src/lamp_py/ingestion/config_rt_alerts.py
+++ b/src/lamp_py/ingestion/config_rt_alerts.py
@@ -37,7 +37,7 @@ class AlertsRecord(FeedMessage):
                                     "route_id": dy.String(nullable=True),
                                     "route_type": dy.Int32(nullable=True),
                                     "direction_id": dy.UInt8(nullable=True),
-                                    "trip": trip_descriptor,
+                                    "trip": with_nullable(trip_descriptor, nullable=True),
                                     "stop_id": dy.String(nullable=True),
                                     "facility_id": dy.String(nullable=True),
                                     "activities": dy.List(dy.String(), nullable=True),  # MBTA Enhanced field


### PR DESCRIPTION
Splunk [logged](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dlamp-staging%20ArrowInvalid&display.page.search.mode=verbose&dispatch.sample_ratio=1&workload_pool=&earliest=1781035810.67&latest=1781035810.68&sid=1781041265.26494) an error processing an Alert b/c it required the `trip_descriptor` to be not null.

## What changes does this PR propose?

What it says in the title.


## How were these changes validated?

Didn't. Seems trivial.


## What questions should reviewers consider?

None.
