### PR TITLE
fix(rail): Remove unused import

### DIFF
--- a/tests/performance_manager/test_alerts.py
+++ b/tests/performance_manager/test_alerts.py
@@ -10,7 +10,6 @@ import polars as pl
 import pytest
 
 from lamp_py.ingestion.config_rt_alerts import AlertsTable
-from lamp_py.ingestion.gtfs_rt_structs import translated_string
 from lamp_py.performance_manager.alerts import (
     explode_active_periods,
     explode_informed_entity,


### PR DESCRIPTION
[🔔 update Performance Manager Alerts feed to expect new data types](https://app.asana.com/1/15492006741476/project/1189492770004753/task/1215214638711739)

## What changes does this PR propose?

Technically, this only removes an import that [blocked deployment](https://github.com/mbta/lamp/actions/runs/27984579253) of 77b9494e6df638b1e99990ceb960e6c8b3c1ff50.

Really, this is to create a checkpoint for 77b9494e6df638b1e99990ceb960e6c8b3c1ff50 and 8d5b0282b5248f65a25d472aa1009abd57286963. Those commits:

* coalesced `cause_detail` and `effect_detail` with `cause_detail.translation` and `effect_detail.translation`, respectively, in Performance Manager
* updated the alerts spec to conform closer to the GTFS spec


## How were these changes validated?

1. Updated `test_transform_translations` to keep the spirit of its tests but change the test mechanics to allow 


## What questions should reviewers consider?

1. Should the alerts code move out of PM and into Tableau Publisher?
