### PR TITLE
feat(flashback): Use current time for new/updated event timestamps

### DIFF
--- a/analysis/flashback_performance.py
+++ b/analysis/flashback_performance.py
@@ -22,10 +22,12 @@ def _():
     import marimo as mo
     import polars as pl
     import altair as alt
+
     alt.data_transformers.enable("vegafusion")
 
     from lamp_py.flashback.events import StopEvents
     from lamp_py.aws.s3 import file_list_from_s3_with_details
+
     return StopEvents, alt, datetime, mo, pl, timedelta
 
 
@@ -43,7 +45,7 @@ def _(refresher):
 
 @app.cell
 def _(mo):
-    env = mo.ui.dropdown(options={"staging": "staging-", "dev": "dev-", "prod":""}, value="staging")
+    env = mo.ui.dropdown(options={"staging": "staging-", "dev": "dev-", "prod": ""}, value="staging")
     return (env,)
 
 

--- a/analysis/flashback_performance.py
+++ b/analysis/flashback_performance.py
@@ -22,28 +22,40 @@ def _():
     import marimo as mo
     import polars as pl
     import altair as alt
+    alt.data_transformers.enable("vegafusion")
 
     from lamp_py.flashback.events import StopEvents
     from lamp_py.aws.s3 import file_list_from_s3_with_details
-
     return StopEvents, alt, datetime, mo, pl, timedelta
 
 
 @app.cell
 def _(mo):
     refresher = mo.ui.refresh(options=[5, 10, 60], default_interval=10)
+    return (refresher,)
+
+
+@app.cell
+def _(refresher):
+    refresher
     return
 
 
 @app.cell
 def _(mo):
-    env = mo.ui.dropdown(options=["staging", "dev"], value="staging")
+    env = mo.ui.dropdown(options={"staging": "staging-", "dev": "dev-", "prod":""}, value="staging")
     return (env,)
 
 
 @app.cell
 def _(env):
-    bucket_name = f"mbta-ctd-dataplatform-{env.value}-archive"
+    env
+    return
+
+
+@app.cell
+def _(env):
+    bucket_name = f"mbta-ctd-dataplatform-{env.value}archive"
     return (bucket_name,)
 
 

--- a/src/lamp_py/flashback/events.py
+++ b/src/lamp_py/flashback/events.py
@@ -1,5 +1,4 @@
 from datetime import datetime, timedelta
-from zoneinfo import ZoneInfo
 
 import dataframely as dy
 import polars as pl
@@ -73,6 +72,7 @@ def unnest_vehicle_positions(vp: dy.DataFrame[VehiclePositions]) -> dy.DataFrame
 def update_records(
     existing_records: dy.DataFrame[StopEvents],
     new_records: dy.DataFrame[StopEvents],
+    publication_timestamp: datetime,
     max_record_age: timedelta,
 ) -> dy.DataFrame[StopEvents]:
     """Return a DataFrame of recent stops using VehiclePositions."""
@@ -83,7 +83,7 @@ def update_records(
 
     combined = (
         existing_records.filter(  # remove old records
-            datetime.now(tz=ZoneInfo("America/New_York"))
+            publication_timestamp
             - pl.from_epoch("timestamp").dt.replace_time_zone(
                 "America/New_York", ambiguous="latest", non_existent="null"
             )
@@ -119,9 +119,9 @@ def update_records(
                     .over(["start_date", "route_id", "trip_id", "vehicle_id"])
                     .gt(pl.col("stop_sequence")),
                     pl.col("departed").is_null(),
-                ).then(pl.col("timestamp_right").max().over(["start_date", "route_id", "trip_id", "vehicle_id"])),
+                ).then(publication_timestamp.timestamp()),
                 "timestamp",
-                "timestamp_right",
+                publication_timestamp.timestamp(),
             ).alias("timestamp"),
             pl.coalesce("latest_stopped_timestamp_right", "latest_stopped_timestamp").alias(
                 "latest_stopped_timestamp"

--- a/src/lamp_py/flashback/events.py
+++ b/src/lamp_py/flashback/events.py
@@ -113,14 +113,16 @@ def update_records(
                 "departed",
             ).alias("departed"),
             pl.coalesce(
-                pl.when(  # if departure is updated, then also update timestamp
+                pl.when(  # if trip advances to later stop
                     pl.col("stop_sequence")
                     .max()
                     .over(["start_date", "route_id", "trip_id", "vehicle_id"])
                     .gt(pl.col("stop_sequence")),
                     pl.col("departed").is_null(),
                 ).then(publication_timestamp.timestamp()),
+                # if trip hasn't advanced
                 "timestamp",
+                # else (if trip is new)
                 publication_timestamp.timestamp(),
             ).alias("timestamp"),
             pl.coalesce("latest_stopped_timestamp_right", "latest_stopped_timestamp").alias(

--- a/src/lamp_py/flashback/pipeline.py
+++ b/src/lamp_py/flashback/pipeline.py
@@ -13,7 +13,11 @@ from lamp_py.runtime_utils.env_validation import validate_environment
 from lamp_py.runtime_utils.process_logger import ProcessLogger
 
 
-async def flashback(remote_events: dy.DataFrame[StopEvents], publication_timestamp: datetime = datetime.now(ZoneInfo("America/New_York")), max_record_age: timedelta = timedelta(hours=2)) -> None:
+async def flashback(
+    remote_events: dy.DataFrame[StopEvents],
+    publication_timestamp: datetime = datetime.now(ZoneInfo("America/New_York")),
+    max_record_age: timedelta = timedelta(hours=2),
+) -> None:
     """Fetch, process, and store stop events."""
     existing_events = remote_events
     while True:
@@ -21,7 +25,9 @@ async def flashback(remote_events: dy.DataFrame[StopEvents], publication_timesta
         process_logger.log_start()
         new_records = await get_vehicle_positions()
 
-        stop_events = update_records(existing_events, unnest_vehicle_positions(new_records), publication_timestamp, max_record_age)
+        stop_events = update_records(
+            existing_events, unnest_vehicle_positions(new_records), publication_timestamp, max_record_age
+        )
 
         existing_events = stop_events
 

--- a/src/lamp_py/flashback/pipeline.py
+++ b/src/lamp_py/flashback/pipeline.py
@@ -15,7 +15,6 @@ from lamp_py.runtime_utils.process_logger import ProcessLogger
 
 async def flashback(
     remote_events: dy.DataFrame[StopEvents],
-    publication_timestamp: datetime = datetime.now(ZoneInfo("America/New_York")),
     max_record_age: timedelta = timedelta(hours=2),
 ) -> None:
     """Fetch, process, and store stop events."""
@@ -26,7 +25,10 @@ async def flashback(
         new_records = await get_vehicle_positions()
 
         stop_events = update_records(
-            existing_events, unnest_vehicle_positions(new_records), publication_timestamp, max_record_age
+            existing_events,
+            unnest_vehicle_positions(new_records),
+            datetime.now(ZoneInfo("America/New_York")),
+            max_record_age,
         )
 
         existing_events = stop_events

--- a/src/lamp_py/flashback/pipeline.py
+++ b/src/lamp_py/flashback/pipeline.py
@@ -1,7 +1,8 @@
 import asyncio
-from datetime import timedelta
+from datetime import timedelta, datetime
 from os import environ
 from signal import SIGTERM, signal
+from zoneinfo import ZoneInfo
 
 import dataframely as dy
 
@@ -12,7 +13,7 @@ from lamp_py.runtime_utils.env_validation import validate_environment
 from lamp_py.runtime_utils.process_logger import ProcessLogger
 
 
-async def flashback(remote_events: dy.DataFrame[StopEvents], max_record_age: timedelta = timedelta(hours=2)) -> None:
+async def flashback(remote_events: dy.DataFrame[StopEvents], publication_timestamp: datetime = datetime.now(ZoneInfo("America/New_York")), max_record_age: timedelta = timedelta(hours=2)) -> None:
     """Fetch, process, and store stop events."""
     existing_events = remote_events
     while True:
@@ -20,7 +21,7 @@ async def flashback(remote_events: dy.DataFrame[StopEvents], max_record_age: tim
         process_logger.log_start()
         new_records = await get_vehicle_positions()
 
-        stop_events = update_records(existing_events, unnest_vehicle_positions(new_records), max_record_age)
+        stop_events = update_records(existing_events, unnest_vehicle_positions(new_records), publication_timestamp, max_record_age)
 
         existing_events = stop_events
 

--- a/tests/flashback/test_events.py
+++ b/tests/flashback/test_events.py
@@ -1,5 +1,6 @@
 import time
 from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
 
 import dataframely as dy
 import polars as pl
@@ -252,7 +253,12 @@ def test_update_records(
         generator=dy_gen,
         overrides=new_record_overrides,
     )
-    updated = update_records(existing_records, new_records, timedelta(hours=2))
+    updated = update_records(
+        existing_records,
+        new_records,
+        datetime.fromtimestamp(2_000_000_003, tz=ZoneInfo("America/New_York")),
+        timedelta(hours=2),
+    )
     updated_set = set(
         tuple(i.values())
         for i in updated.select("stop_sequence", "timestamp", "arrived", "departed").to_struct().to_list()
@@ -283,6 +289,6 @@ def test_performance_update_records(dy_gen: dy.random.Generator, num_rows: int =
     )
 
     start = time.time()
-    _ = update_records(existing_records, new_records, timedelta(hours=2))
+    _ = update_records(existing_records, new_records, datetime.now(ZoneInfo("America/New_York")), timedelta(hours=2))
     duration = time.time() - start
     assert duration < 1.0


### PR DESCRIPTION
Asana Task: [📸 update `timestamp` to reflect publishing time](https://app.asana.com/1/15492006741476/project/1189492770004753/task/1213954104994853)

## What changes does this PR propose?

Generates the publication timestamp from the event loop rather than deriving it from the events. This lets us compare when flashback evaluated the event to when the event happened and infer from the difference how long it takes events to reach us.


## How were these changes validated?

1. Updated tests


## What questions should reviewers consider?

None.