### PR TITLE
Fix: Bump mbta/actions version for Tasks Tag propagation

### DIFF
--- a/.github/actions/tools/action.yaml
+++ b/.github/actions/tools/action.yaml
@@ -21,4 +21,4 @@ runs:
       if: steps.asdf-cache.outputs.cache-hit != 'true'
 
     - name: Re-shim ASDF Install
-      uses: mbta/actions/reshim-asdf@20a677d22e01056a0ea63ff3b996bbc774188770  # v2.17
+      uses: mbta/actions/reshim-asdf@62db3e5c547c3c7f439c4a7fb98e69fc79c1a9cc  # v2.21

--- a/.github/workflows/deploy-base.yaml
+++ b/.github/workflows/deploy-base.yaml
@@ -90,7 +90,7 @@ jobs:
           echo "version=${FULL_VERSION}" >> $GITHUB_ENV
       - name: Build and Push Docker Image
         id: build-push
-        uses: mbta/actions/build-push-ecr@87d6b0891d9a26493f05f5803ec855387179f183  # v2
+        uses: mbta/actions/build-push-ecr@62db3e5c547c3c7f439c4a7fb98e69fc79c1a9cc  # v2.21
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           docker-repo: ${{ secrets.DOCKER_REPO }}
@@ -98,7 +98,7 @@ jobs:
       - name: Deploy Ingestion Application
         id: deploy-ingestion
         if: ${{ inputs.deploy-ingestion }}
-        uses: mbta/actions/deploy-ecs@87d6b0891d9a26493f05f5803ec855387179f183  # v2
+        uses: mbta/actions/deploy-ecs@62db3e5c547c3c7f439c4a7fb98e69fc79c1a9cc  # v2.21
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           ecs-cluster: lamp
@@ -108,7 +108,7 @@ jobs:
       - name: Deploy Rail Performance Manager Application
         id: deploy-rail-performance-manager
         if: ${{ inputs.deploy-rail-pm }}
-        uses: mbta/actions/deploy-ecs@87d6b0891d9a26493f05f5803ec855387179f183  # v2
+        uses: mbta/actions/deploy-ecs@62db3e5c547c3c7f439c4a7fb98e69fc79c1a9cc  # v2.21
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           ecs-cluster: lamp
@@ -118,7 +118,7 @@ jobs:
       - name: Deploy Bus Performance Manager Application
         id: deploy-bus-performance-manager
         if: ${{ inputs.deploy-bus-pm }}
-        uses: mbta/actions/deploy-ecs@87d6b0891d9a26493f05f5803ec855387179f183  # v2
+        uses: mbta/actions/deploy-ecs@62db3e5c547c3c7f439c4a7fb98e69fc79c1a9cc  # v2.21
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           ecs-cluster: lamp
@@ -128,7 +128,7 @@ jobs:
       - name: Deploy TransitMaster Ingestion Application
         id: deploy-tm-ingestion
         if: ${{ inputs.deploy-tm-ingestion && inputs.environment != 'dev' }}
-        uses: mbta/actions/deploy-scheduled-ecs@87d6b0891d9a26493f05f5803ec855387179f183  # v2
+        uses: mbta/actions/deploy-scheduled-ecs@62db3e5c547c3c7f439c4a7fb98e69fc79c1a9cc  # v2.21
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           ecs-cluster: lamp
@@ -138,7 +138,7 @@ jobs:
       - name: Deploy Tableau Publisher Application
         id: deploy-tableau-publisher
         if: ${{ inputs.deploy-tableau-publisher && inputs.environment != 'dev' }}
-        uses: mbta/actions/deploy-scheduled-ecs@87d6b0891d9a26493f05f5803ec855387179f183  # v2
+        uses: mbta/actions/deploy-scheduled-ecs@62db3e5c547c3c7f439c4a7fb98e69fc79c1a9cc  # v2.21
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           ecs-cluster: lamp
@@ -148,7 +148,7 @@ jobs:
       - name: Deploy Flashback service
         id: deploy-flashback
         if: ${{ inputs.deploy-flashback }}
-        uses: mbta/actions/deploy-ecs@87d6b0891d9a26493f05f5803ec855387179f183  # v2
+        uses: mbta/actions/deploy-ecs@62db3e5c547c3c7f439c4a7fb98e69fc79c1a9cc  # v2.21
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           ecs-cluster: lamp
@@ -158,7 +158,7 @@ jobs:
       - name: Deploy Lightswitch catalog
         id: deploy-lightswitch
         if: ${{ inputs.deploy-lightswitch }}
-        uses: mbta/actions/deploy-ecs@87d6b0891d9a26493f05f5803ec855387179f183  # v2
+        uses: mbta/actions/deploy-ecs@62db3e5c547c3c7f439c4a7fb98e69fc79c1a9cc  # v2.21
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           ecs-cluster: lamp
@@ -169,7 +169,7 @@ jobs:
       - name: Deploy Ad-Hoc Process
         id: deploy-ad-hoc
         if: ${{ inputs.deploy-ad-hoc }}
-        uses: mbta/actions/deploy-ecs@87d6b0891d9a26493f05f5803ec855387179f183  # v2
+        uses: mbta/actions/deploy-ecs@62db3e5c547c3c7f439c4a7fb98e69fc79c1a9cc  # v2.21
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           ecs-cluster: lamp
@@ -177,7 +177,7 @@ jobs:
           ecs-task-definition: lamp-ad-hoc-${{ inputs.environment }}
           docker-tag: ${{ steps.build-push.outputs.docker-tag }}
           allow-zero-desired: true
-      - uses: mbta/actions/notify-slack-deploy@87d6b0891d9a26493f05f5803ec855387179f183  # v2
+      - uses: mbta/actions/notify-slack-deploy@62db3e5c547c3c7f439c4a7fb98e69fc79c1a9cc  # v2.21
         if: ${{ !cancelled() }}
         with:
           webhook-url: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
Asana Task: [review lamp kill task permissions](https://app.asana.com/1/15492006741476/project/1113545750913664/task/1215201872692863?focus=true)

## What changes does this PR propose?

This PR bumps the `mbta/actions` commit hash so that it will be able to consume the new deploy-ecs actions that will include the ability to add Tags to tasks in ECS. Once the tags are propagated and IAM policies are amended to have access to the new Tags being given, the issue in the Asana task will be resolved.

See ECS tag PR in the actions repo here: https://github.com/mbta/actions/pull/79

## How were these changes validated?

~~1. New tests?~~
~~2. Used a runner?~~
~~3. Doesn't need validation? Maybe it's just documentation.~~

PR is a Bump in the actions repo. Other teams have used it except for this notable bump with the tagging functionality which shouldn't break any deployment.

## What questions should reviewers consider?

Feel free to ping me on slack for any questions not answered through the Asana task
