### PR TITLE
fix(workflows): Deploy when updating dependencies

### DIFF
--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -4,8 +4,9 @@ on:
   push:
     branches:
       - main
-    paths:
-      - 'src/**'
+    paths-ignore:
+      - 'runners/**'
+      - 'analysis/**'
 
 permissions:
   contents: read


### PR DESCRIPTION
Merging #768 did not trigger a deploy to staging. The action only deployed when files in `src` are updated but other files also change runtime behavior.

## What changes does this PR propose?

Updates `deploy-staging` to run when [any file](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#example-excluding-paths) is updated outside of `runners/` and `analysis/`, which are not run in production.


## How were these changes validated?

Haven't.


## What questions should reviewers consider?

None.
