### PR TITLE
fix(lightswitch): don't use periods when creating parquet views

### DIFF
--- a/src/lamp_py/publishing/lightswitch.py
+++ b/src/lamp_py/publishing/lightswitch.py
@@ -82,17 +82,17 @@ def build_view(
     pl.add_metadata(view_name=view_name, view_target=view_target)
 
     try:
-
+        column_aliases = connection.sql(f"""
+            SELECT string_agg(path_in_schema || ' AS ' || REPLACE(path_in_schema, '.', '_'), ', ') 
+            FROM parquet_metadata('{view_target}')
+        """).pl().item(0, 0)
         connection.execute(
             # Rename columns to replace period with underscore.
             # Period is a reserved character in SQL, which would force users to quote column names
-            # See comment in register_read_ymd.
             f"""
             CREATE VIEW {view_name} AS
             SELECT
-                COLUMNS('^.*?(\\w+)\\.(\\w+)\\.(\\w+)$') AS '\\1_\\2_\\3',
-                COLUMNS('^(\\w+)\\.(\\w+)$') AS '\\1_\\2',
-                COLUMNS('^[^.]*$') AS '\\1'
+                {column_aliases}
             FROM read_parquet('{view_target}', hive_partitioning=True)
             """
         )
@@ -131,21 +131,36 @@ def register_read_ymd(
     pl = ProcessLogger("register_read_ymd")
     pl.log_start()
 
-    # WARNING: The dynamic column aliasing here replaces periods (.) with underscores (_) in field names.
-    # There's a limitation in the COLUMNS function where you can't run REPLACE (or any function) on the
-    # column alias (the "AS clause"), so I had to hardcode each case of columns with no periods (foo),
-    # columns with one period (foo.bar) and columns with 2 or more periods (foo.bar.baz, foo.bar.baz.bop).
-    # Because of how binding works in DuckDB, this function will also blow up if there is any parquet dataset
-    # that doesn't have columns with zero periods, one period, and 2 or more periods.
+
+    # Rename columns to replace period with underscore.
+    # Period is a reserved character in SQL, which would force users to quote column names
+    column_aliases = connection.sql("""
+        SELECT string_agg(path_in_schema || ' AS ' || REPLACE(path_in_schema, '.', '_'), ', ') FROM parquet_metadata(
+                list_transform(
+                    range(
+                        start_date,
+                        end_date,
+                        INTERVAL 1 DAY
+                    ),
+                    lambda x : strftime(
+                        concat_ws(
+                            '/',
+                            bucket,
+                            'lamp',
+                            directory_name,
+                            'year=%Y/month=%-m/day=%-d/%xT%H:%M:%S.parquet'
+                        ),
+                        x
+                    )
+                )
+            )""").pl().item(0, 0)
     connection.sql(
-        """
+        f"""
         CREATE OR REPLACE MACRO read_ymd
 
             (directory_name, start_date, end_date, bucket := 's3://mbta-ctd-dataplatform-springboard') AS TABLE (
              SELECT 
-                COLUMNS('^.*?(\\w+)\\.(\\w+)\\.(\\w+)$') AS '\\1_\\2_\\3',
-                COLUMNS('^(\\w+)\\.(\\w+)$') AS '\\1_\\2',
-                COLUMNS('^[^.]*$') AS '\\1'
+                {column_aliases}
              FROM read_parquet(
                 list_transform(
                     range(

--- a/src/lamp_py/publishing/lightswitch.py
+++ b/src/lamp_py/publishing/lightswitch.py
@@ -189,7 +189,7 @@ def register_effective_gtfs_timestamps(
     try:
         connection.sql(
             f"""
-            CREATE OR REPLACE TABLE {schema_name}.effective_timestamps AS
+            CREATE OR REPLACE TABLE {schema_name}_effective_timestamps AS
             SELECT
                 service_date,
                 split_part(rating, ' ', 2) as rating_year,

--- a/src/lamp_py/publishing/lightswitch.py
+++ b/src/lamp_py/publishing/lightswitch.py
@@ -83,7 +83,7 @@ def build_view(
 
     try:
         column_aliases = connection.sql(f"""
-            SELECT string_agg(path_in_schema || ' AS ' || REPLACE(path_in_schema, '.', '_'), ', ') 
+            SELECT DISTINCT string_agg('"' || STR_SPLIT(path_in_schema, ',')[1] || '" AS ' || REPLACE(STR_SPLIT(path_in_schema, ',')[1], '.', '_'), ', ') 
             FROM parquet_metadata('{view_target}')
         """).pl().item(0, 0)
         connection.execute(
@@ -134,33 +134,15 @@ def register_read_ymd(
 
     # Rename columns to replace period with underscore.
     # Period is a reserved character in SQL, which would force users to quote column names
-    column_aliases = connection.sql("""
-        SELECT string_agg(path_in_schema || ' AS ' || REPLACE(path_in_schema, '.', '_'), ', ') FROM parquet_metadata(
-                list_transform(
-                    range(
-                        start_date,
-                        end_date,
-                        INTERVAL 1 DAY
-                    ),
-                    lambda x : strftime(
-                        concat_ws(
-                            '/',
-                            bucket,
-                            'lamp',
-                            directory_name,
-                            'year=%Y/month=%-m/day=%-d/%xT%H:%M:%S.parquet'
-                        ),
-                        x
-                    )
-                )
-            )""").pl().item(0, 0)
     connection.sql(
-        f"""
+        """
         CREATE OR REPLACE MACRO read_ymd
 
             (directory_name, start_date, end_date, bucket := 's3://mbta-ctd-dataplatform-springboard') AS TABLE (
              SELECT 
-                {column_aliases}
+                COLUMNS('^.*?(\\w+)\\.(\\w+)\\.(\\w+)$') AS '\\1_\\2_\\3',
+                COLUMNS('^(\\w+)\\.(\\w+)$') AS '\\1_\\2',
+                COLUMNS('^[^.]*$') AS '\\1'
              FROM read_parquet(
                 list_transform(
                     range(

--- a/src/lamp_py/publishing/lightswitch.py
+++ b/src/lamp_py/publishing/lightswitch.py
@@ -2,7 +2,6 @@ import os
 from typing import List
 
 import duckdb
-import polars as plr
 from lamp_py.runtime_utils import remote_files as rf
 from lamp_py.runtime_utils.env_validation import validate_environment
 from lamp_py.runtime_utils.lamp_exception import EmptyDataStructureException
@@ -83,7 +82,21 @@ def build_view(
     pl.add_metadata(view_name=view_name, view_target=view_target)
 
     try:
-        connection.from_parquet(view_target, hive_partitioning=True).create_view(view_name)
+
+        connection.execute(
+            # Rename columns to replace period with underscore.
+            # Period is a reserved character in SQL, which would force users to quote column names
+            # See comment in register_read_ymd.
+            f"""
+            CREATE VIEW {view_name} AS
+            SELECT
+                COLUMNS('^.*?(\\w+)\\.(\\w+)\\.(\\w+)$') AS '\\1_\\2_\\3',
+                COLUMNS('^(\\w+)\\.(\\w+)$') AS '\\1_\\2',
+                COLUMNS('^[^.]*$') AS '\\1'
+            FROM read_parquet('{view_target}', hive_partitioning=True)
+            """
+        )
+
         return True
     except Exception as e:
         pl.log_failure(e)
@@ -225,37 +238,7 @@ def add_views_to_local_metastore(
     return built_views
 
 
-def alter_columns_with_periods(
-    conn: duckdb.DuckDBPyConnection, pl: ProcessLogger, table_name: str, column_names: plr.Series
-) -> None:
-    """Alters columns in the views to replace periods with underscores"""
-    statement = ""
-    for column_name in column_names:
-        statement += (
-            f"ALTER TABLE {table_name} RENAME COLUMN \"{column_name}\" TO \"{column_name.replace('.', '_')}\"; "
-        )
 
-    try:
-        conn.sql(statement)
-    except duckdb.Error as e:
-        pl.log_failure(e)
-
-
-def rename_columns_with_periods(conn: duckdb.DuckDBPyConnection) -> None:
-    """
-    Rename columns to replace period with underscore.
-    Period is a reserved character in SQL, which would force users to quote column names
-    """
-    pl = ProcessLogger("rename_columns_with_periods")
-    pl.log_start()
-    try:
-        all_tables = conn.sql("SELECT name, column_names FROM (SHOW ALL TABLES)").pl()
-
-        for row in all_tables.iter_rows():
-            alter_columns_with_periods(conn, pl, row[0], row[1])
-    except duckdb.Error as e:
-        pl.log_failure(e)
-    pl.log_complete()
 
 
 def pipeline(  # pylint: disable=dangerous-default-value
@@ -283,7 +266,6 @@ def pipeline(  # pylint: disable=dangerous-default-value
         add_views_to_local_metastore(con, views)
         register_read_ymd(con)
         register_effective_gtfs_timestamps(con)
-        rename_columns_with_periods(con)
 
     if remote_location:
         pl.add_metadata(remote_location=remote_location.s3_uri)

--- a/src/lamp_py/publishing/lightswitch.py
+++ b/src/lamp_py/publishing/lightswitch.py
@@ -82,10 +82,18 @@ def build_view(
     pl.add_metadata(view_name=view_name, view_target=view_target)
 
     try:
-        column_aliases = connection.sql(f"""
-            SELECT DISTINCT string_agg('"' || STR_SPLIT(path_in_schema, ',')[1] || '" AS ' || REPLACE(STR_SPLIT(path_in_schema, ',')[1], '.', '_'), ', ') 
-            FROM parquet_metadata('{view_target}')
-        """).pl().item(0, 0)
+        column_aliases = (
+            connection.sql(
+                f"""
+            SELECT DISTINCT string_agg('"' || column_name || '" AS ' || REPLACE(column_name, '.', '_'), ', ') 
+            FROM (
+                DESCRIBE SELECT * FROM read_parquet('{view_target}')
+            )
+        """
+            )
+            .pl()
+            .item(0, 0)
+        )
         connection.execute(
             # Rename columns to replace period with underscore.
             # Period is a reserved character in SQL, which would force users to quote column names
@@ -130,7 +138,6 @@ def register_read_ymd(
     """Register function in DuckDB using SQL text."""
     pl = ProcessLogger("register_read_ymd")
     pl.log_start()
-
 
     # Rename columns to replace period with underscore.
     # Period is a reserved character in SQL, which would force users to quote column names

--- a/src/lamp_py/publishing/lightswitch.py
+++ b/src/lamp_py/publishing/lightswitch.py
@@ -238,9 +238,6 @@ def add_views_to_local_metastore(
     return built_views
 
 
-
-
-
 def pipeline(  # pylint: disable=dangerous-default-value
     views: dict[str, List[rf.S3Location]] = HIVE_VIEWS,
     local_location: str = "/tmp/lamp.db",

--- a/tests/publishing/test_lightswitch.py
+++ b/tests/publishing/test_lightswitch.py
@@ -14,7 +14,6 @@ from lamp_py.publishing.lightswitch import (
     register_read_ymd,
     register_effective_gtfs_timestamps,
     create_schemas,
-    rename_columns_with_periods,
 )
 from lamp_py.runtime_utils.remote_files import S3Location
 from tests.test_resources import rt_vehicle_positions, tm_route_file
@@ -145,10 +144,3 @@ def test_create_schemas(
     assert (ERROR in [t[1] for t in caplog.record_tuples]) == error_expected
     assert resultant_schemas == output_schemas
 
-
-def test_rename_columns_with_periods(duckdb_con: duckdb.DuckDBPyConnection) -> None:
-    with duckdb_con:
-        duckdb_con.sql('CREATE TABLE foo ("col.with.dots" INT, "other.col.with.dots" INT, no_dots INT)')
-        rename_columns_with_periods(duckdb_con)
-        new_col_names = list(duckdb_con.sql("SHOW foo").to_df()["column_name"])
-        assert set(new_col_names) == set(["col_with_dots", "other_col_with_dots", "no_dots"])

--- a/tests/publishing/test_lightswitch.py
+++ b/tests/publishing/test_lightswitch.py
@@ -143,4 +143,3 @@ def test_create_schemas(
     resultant_schemas = create_schemas(duckdb_con, schema_list)
     assert (ERROR in [t[1] for t in caplog.record_tuples]) == error_expected
     assert resultant_schemas == output_schemas
-

--- a/tests/publishing/test_lightswitch.py
+++ b/tests/publishing/test_lightswitch.py
@@ -43,8 +43,12 @@ def fixture_duckdb_con(
 def test_build_view(
     duckdb_con: duckdb.DuckDBPyConnection, partition_strategy: str, data_location: S3Location, result: pytest.RaisesExc
 ) -> None:
-    """It gracefully creates the view using the specified partition strategy."""
+    """It gracefully creates the view using the specified partition strategy, and replaces periods with underscores in column names"""
     assert result == build_view(duckdb_con, "test", data_location, partition_strategy)
+    select_result = duckdb_con.sql("SELECT * FROM test").pl().columns()
+
+    # no columns with periods
+    assert len([col for col in select_result.pl().columns if col.contains(".")]) == 0
 
 
 # test if all views get built
@@ -89,7 +93,7 @@ def test_register_read_ymd(
     directory_name: str,
     raises: pytest.RaisesExc,
 ) -> None:
-    """It raises errors on directories that don't exist."""
+    """It raises errors on directories that don't exist, and renames columns to have underscores instead of periods"""
     file_path = tmp_path.joinpath("lamp/RT_VEHICLE_POSITIONS/year=2024/month=6/day=1/2024-06-01T00:00:00.parquet")
     file_path.parent.mkdir(parents=True)
     pl.read_parquet("tests/test_files/SPRINGBOARD/RT_VEHICLE_POSITIONS/year=2024").write_parquet(file_path)
@@ -97,9 +101,14 @@ def test_register_read_ymd(
     with raises:
         with duckdb_con:
             register_read_ymd(duckdb_con)
-            assert duckdb_con.sql(
+            res = duckdb_con.sql(
                 f"SELECT * FROM read_ymd('{directory_name}', '2024-06-01' :: DATE, '2024-06-02' :: DATE, '{tmp_path.resolve()}')"
             )
+
+            assert res
+
+            # no columns with periods
+            assert len([col for col in res.pl().columns if col.contains(".")]) == 0
 
 
 def test_register_effective_gtfs_timestamps(
@@ -115,9 +124,9 @@ def test_register_effective_gtfs_timestamps(
 
     with duckdb_con:
         register_effective_gtfs_timestamps(duckdb_con, tmp_path.as_posix())
-        assert duckdb_con.sql("SELECT * FROM gtfs_schedule.effective_timestamps")
+        assert duckdb_con.sql("SELECT * FROM gtfs_schedule_effective_timestamps")
         result = duckdb_con.sql(
-            "SELECT count(*) FROM gtfs_schedule.effective_timestamps WHERE rating_season IS NULL"
+            "SELECT count(*) FROM gtfs_schedule_effective_timestamps WHERE rating_season IS NULL"
         ).fetchone()
         assert isinstance(result, tuple)
         assert result[0] == 0

--- a/tests/publishing/test_lightswitch.py
+++ b/tests/publishing/test_lightswitch.py
@@ -45,10 +45,11 @@ def test_build_view(
 ) -> None:
     """It gracefully creates the view using the specified partition strategy, and replaces periods with underscores in column names"""
     assert result == build_view(duckdb_con, "test", data_location, partition_strategy)
-    select_result = duckdb_con.sql("SELECT * FROM test").pl().columns()
 
-    # no columns with periods
-    assert len([col for col in select_result.pl().columns if col.contains(".")]) == 0
+    period_columns = duckdb_con.sql(
+        "SELECT * FROM duckdb_columns() WHERE table_name = 'test' AND column_name LIKE '%.%'"
+    )
+    assert len(period_columns) == 0
 
 
 # test if all views get built
@@ -107,8 +108,9 @@ def test_register_read_ymd(
 
             assert res
 
-            # no columns with periods
-            assert len([col for col in res.pl().columns if col.contains(".")]) == 0
+            if len(res) > 0:
+                # no columns with periods
+                assert len([col for col in res.pl().columns if "." in col]) == 0
 
 
 def test_register_effective_gtfs_timestamps(


### PR DESCRIPTION
Asana Task: n/a

## What changes does this PR propose?

Ensures that we don't create views of parquet with periods in the column names, and also fixes an error that was preventing us from using the parquet views.


## How were these changes validated?
Existing tests - new tests are no longer needed. 

## What questions should reviewers consider?

1. Is it alright to run two queries when creating all the views? 
