### PR TITLE
fix(bus): Bump bus version to pick up schema change

### DIFF
--- a/src/lamp_py/runtime_utils/remote_files.py
+++ b/src/lamp_py/runtime_utils/remote_files.py
@@ -145,7 +145,7 @@ tm_pattern_geo_node_xref_file = S3Location(
 )
 
 # published by LAMP
-bus_events = S3Location(bucket=S3_PUBLIC, prefix=os.path.join(LAMP, "bus_vehicle_events"), version="1.2")
+bus_events = S3Location(bucket=S3_PUBLIC, prefix=os.path.join(LAMP, "bus_vehicle_events"), version="1.3")
 bus_operator_mapping = S3Location(bucket=S3_ARCHIVE, prefix=os.path.join(LAMP, "bus_operator_mapping"), version="1.0")
 
 # Kinesis stream glides events

--- a/src/lamp_py/runtime_utils/remote_files.py
+++ b/src/lamp_py/runtime_utils/remote_files.py
@@ -185,8 +185,12 @@ tableau_rail_vehicle_trips = S3Location(
 )
 
 
-tableau_bus_recent = S3Location(bucket=S3_PUBLIC, prefix=os.path.join(TABLEAU, "bus", "LAMP_RECENT_Bus_Events.parquet"))
-tableau_bus_all = S3Location(bucket=S3_PUBLIC, prefix=os.path.join(TABLEAU, "bus", "LAMP_ALL_Bus_Events.parquet"))
+tableau_bus_recent = S3Location(
+    bucket=S3_PUBLIC, prefix=os.path.join(TABLEAU, "bus", "LAMP_RECENT_Bus_Events.parquet"), version="1.1.0"
+)
+tableau_bus_all = S3Location(
+    bucket=S3_PUBLIC, prefix=os.path.join(TABLEAU, "bus", "LAMP_ALL_Bus_Events.parquet"), version="1.1.0"
+)
 
 # archive to archive_pii
 tableau_bus_operator_mapping_recent = S3Location(

--- a/src/lamp_py/tableau/jobs/lamp_jobs.py
+++ b/src/lamp_py/tableau/jobs/lamp_jobs.py
@@ -168,7 +168,7 @@ Prod_BusMetrics_Fall2025Rating = FilteredHyperJob(
     remote_output_location=S3Location(
         bucket=S3_ARCHIVE,
         prefix=os.path.join(LAMP, "bus_rating_datasets", "year=2025", "Fall2025_BusMetrics.parquet"),
-        version="1.0.1",
+        version="1.1.0",
     ),
     start_date=date(2025, 8, 24),
     end_date=date(2025, 12, 13),


### PR DESCRIPTION
BPM Fall Rating dataset has been [failing](https://mbta.slack.com/files/U099GJ78T7S/F0BKE7EMEKT/splunk_alert__lamp_staging_bus_performance_manager_failure) this week. Upon investigation, the schema changes weren't detected so I bumped the bus version.

## What changes does this PR propose?

Bumps version of bus assets.


## How were these changes validated?

[Deployed to `dev`](https://github.com/mbta/lamp/actions/runs/29945957421) and [saw errors disappear](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dlamp-dev%20parent%3Dbus_performance_manager%20ValueError&display.page.search.mode=verbose&dispatch.sample_ratio=1&workload_pool=&earliest=1784419200&latest=1784819581&display.page.search.showFields=0&sid=1784819591.82885)


## What questions should reviewers consider?

1. Focus on this thing, even though it seems minor!
