### PR TITLE
fix(bus): Stop imputing `last_in_transit_dt`

### DIFF
--- a/src/lamp_py/bus_performance_manager/events_gtfs_rt.py
+++ b/src/lamp_py/bus_performance_manager/events_gtfs_rt.py
@@ -263,9 +263,9 @@ def positions_to_events(vehicle_positions: pl.DataFrame) -> dy.DataFrame[GTFSEve
         .with_columns(
             (pl.col("service_date").cast(pl.Datetime) + pl.duration(seconds=pl.col("start_time"))).alias("start_dt"),
             pl.col("gtfs_stop_sequence").count().over(partition_by=["trip_id", "vehicle_id"]).alias("stop_count"),
-            pl.min_horizontal("gtfs_last_in_transit_dt", "gtfs_arrival_dt").alias(
-                "gtfs_last_in_transit_dt"
-            ),  # cap last_in_transit_dt at arrival_dt
+            pl.when(pl.col("gtfs_last_in_transit_dt").is_not_null()).then(
+                pl.min_horizontal("gtfs_last_in_transit_dt", "gtfs_arrival_dt")
+            ).alias("gtfs_last_in_transit_dt"),  # cap last_in_transit_dt at arrival_dt
         )
         .select(GTFSEvents.column_names())
     )

--- a/src/lamp_py/runtime_utils/remote_files.py
+++ b/src/lamp_py/runtime_utils/remote_files.py
@@ -145,7 +145,7 @@ tm_pattern_geo_node_xref_file = S3Location(
 )
 
 # published by LAMP
-bus_events = S3Location(bucket=S3_PUBLIC, prefix=os.path.join(LAMP, "bus_vehicle_events"), version="1.2")
+bus_events = S3Location(bucket=S3_PUBLIC, prefix=os.path.join(LAMP, "bus_vehicle_events"), version="1.2.1")
 bus_operator_mapping = S3Location(bucket=S3_ARCHIVE, prefix=os.path.join(LAMP, "bus_operator_mapping"), version="1.0")
 
 # Kinesis stream glides events


### PR DESCRIPTION
We and Ops Analytics realized that this calculation imputes values when `last_in_transit_dt` is `null`.

## What changes does this PR propose?

Adds an if-else to prevent imputing `null` values.


## How were these changes validated?

Trivial.


## What questions should reviewers consider?

None.
