### PR TITLE
Streamline chunking logic - allow unique or non-unique chunking

### DIFF
--- a/src/lamp_py/ingestion/convert_gtfs_rt.py
+++ b/src/lamp_py/ingestion/convert_gtfs_rt.py
@@ -118,10 +118,12 @@ class TableData:
 
     tables: list of pyarrow tables that will joined together for final table yield
     files: list of files that make up tables
+    yielded: bool indicating if this table has been yielded (and written to disk)
     """
 
     table: Optional[pyarrow.Table] = None
     files: List[str] = field(default_factory=list)
+    yielded: bool = False
 
 
 class GtfsRtConverter(Converter):

--- a/src/lamp_py/ingestion/convert_gtfs_rt_fullset.py
+++ b/src/lamp_py/ingestion/convert_gtfs_rt_fullset.py
@@ -2,7 +2,7 @@
 
 from concurrent.futures import ThreadPoolExecutor
 import os
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 from queue import Queue
 from typing import Dict, Iterable, List, Optional, Tuple
@@ -36,6 +36,7 @@ class GtfsRtFullPartitionConverter(GtfsRtConverter):
         max_workers: int = 8,
         time_chunk_minutes: int = 15,
         move_source_on_completion: bool = False,
+        unique_config: tuple[bool, int] = (True, 3),
     ) -> None:
         """
         Initialize GTFS-RT fullset converter with time-chunked partitioning.
@@ -48,6 +49,7 @@ class GtfsRtFullPartitionConverter(GtfsRtConverter):
             polars_filter: Polars expression to filter data at conversion time; defaults to no filtering.
             max_workers: Number of worker threads for parallel processing.
             time_chunk_minutes: Minutes for time-based partitioning (e.g., 15 min intervals).
+            unique_config: Tuple indicating whether uniqueness is enforced and the lookback chunk count.
             move_source_on_completion: If True, move source files to archive after completion.
                 For the LAMP usecase, `source` in this context refers to the `delta` or `archive`
                 bucket, for ingestion or backfill respectively. The output is uploaded regardless,
@@ -71,6 +73,7 @@ class GtfsRtFullPartitionConverter(GtfsRtConverter):
         self.filter = polars_filter
         self.move_source_on_completion = move_source_on_completion
         self.time_chunk_minutes = time_chunk_minutes
+        self.unique_config = unique_config
 
     def convert(self) -> None:
         """
@@ -243,6 +246,21 @@ class GtfsRtFullPartitionConverter(GtfsRtConverter):
             ("trip_update.vehicle.id", "ascending"),
         ]
 
+    def interval_keys(self, anchor: datetime, lookback_count: int) -> List[datetime]:
+        """
+        Return the anchor interval key followed by lookback_count prior interval keys.
+
+        The first element (index 0) is the anchor's own binned interval.
+        Subsequent elements step backwards by self.time_chunk_minutes each.
+        """
+        return [
+            assign_datetime_to_binned_interval(
+                anchor - timedelta(minutes=self.time_chunk_minutes * i),
+                self.time_chunk_minutes,
+            )
+            for i in range(lookback_count + 1)
+        ]
+
     def yield_check_periodic(
         self,
         process_logger: ProcessLogger,
@@ -279,6 +297,31 @@ class GtfsRtFullPartitionConverter(GtfsRtConverter):
                 process_logger.add_metadata(file_count=0, number_of_rows=0, print_log=False)
                 process_logger.log_start()
 
+                if self.unique_config[0]:
+                    keys = self.interval_keys(iter_ts, self.unique_config[1])
+                    lookback_tables = [
+                        self.data_parts[k].table
+                        for k in keys
+                        if k in self.data_parts and self.data_parts[k].table is not None
+                    ]
+
+                    if lookback_tables:
+                        combined = pl.from_arrow(pyarrow.concat_tables(lookback_tables))
+                        dedup_cols = [c for c in combined.columns if c != "feed_timestamp"]
+                        combined = combined.unique(subset=dedup_cols, keep="first")
+                        table = (
+                            combined.filter(pl.col("feed_timestamp") >= int(iter_ts.timestamp()))
+                            .to_arrow()
+                            .cast(table.schema)
+                        )
+
+                    # evict chunks that have fallen out of the lookback window
+                    oldest_keep = keys[-1]
+                    for old_key in [k for k in self.data_parts if k < oldest_keep]:
+                        del self.data_parts[old_key]
+
                 yield (table, iter_ts, flush)
 
-                del self.data_parts[iter_ts]
+                # only delete the yielded chunk immediately when uniqueing is off
+                if not self.unique_config[0]:
+                    del self.data_parts[iter_ts]

--- a/src/lamp_py/ingestion/convert_gtfs_rt_fullset.py
+++ b/src/lamp_py/ingestion/convert_gtfs_rt_fullset.py
@@ -311,7 +311,7 @@ class GtfsRtFullPartitionConverter(GtfsRtConverter):
                         for k in keys
                         if k in self.data_parts and self.data_parts[k].table is not None
                     ]
-                    combined = pl.from_arrow(pyarrow.concat_tables(lookback_tables))
+                    combined = pl.DataFrame(pyarrow.concat_tables(lookback_tables))
                     dedup_cols = [c for c in combined.columns if c != "feed_timestamp"]
 
                     # keep="first" is very important here to keep the chunks stable

--- a/src/lamp_py/ingestion/convert_gtfs_rt_fullset.py
+++ b/src/lamp_py/ingestion/convert_gtfs_rt_fullset.py
@@ -36,7 +36,8 @@ class GtfsRtFullPartitionConverter(GtfsRtConverter):
         max_workers: int = 8,
         time_chunk_minutes: int = 15,
         move_source_on_completion: bool = False,
-        unique_config: tuple[bool, int] = (True, 3),
+        unique_config: bool = True,
+        lookback_count: int = 0,
     ) -> None:
         """
         Initialize GTFS-RT fullset converter with time-chunked partitioning.
@@ -49,7 +50,10 @@ class GtfsRtFullPartitionConverter(GtfsRtConverter):
             polars_filter: Polars expression to filter data at conversion time; defaults to no filtering.
             max_workers: Number of worker threads for parallel processing.
             time_chunk_minutes: Minutes for time-based partitioning (e.g., 15 min intervals).
-            unique_config: Tuple indicating whether uniqueness is enforced and the lookback chunk count.
+            unique_config: Boolean indicating whether uniqueness is enforced.
+            lookback_count: Number of previous time chunks to maintain for uniqueness checks; used with unique_config
+                - if set to zero, does not apply unique
+                - if set to 1, applies unique to the current chunk and the previous chunk, etc.
             move_source_on_completion: If True, move source files to archive after completion.
                 For the LAMP usecase, `source` in this context refers to the `delta` or `archive`
                 bucket, for ingestion or backfill respectively. The output is uploaded regardless,
@@ -73,7 +77,8 @@ class GtfsRtFullPartitionConverter(GtfsRtConverter):
         self.filter = polars_filter
         self.move_source_on_completion = move_source_on_completion
         self.time_chunk_minutes = time_chunk_minutes
-        self.unique_config = unique_config
+        self.unique_output_flag = unique_config
+        self.lookback_count = lookback_count
 
     def convert(self) -> None:
         """
@@ -210,6 +215,7 @@ class GtfsRtFullPartitionConverter(GtfsRtConverter):
                 if dt_part not in self.data_parts:
                     self.data_parts[dt_part] = TableData()
                     self.data_parts[dt_part].table = self.detail.transform_for_write(rt_data)
+                    self.data_parts[dt_part].yielded = False
                 else:
                     self.data_parts[dt_part].table = pyarrow.concat_tables(
                         [self.data_parts[dt_part].table, self.detail.transform_for_write(rt_data)]
@@ -222,7 +228,10 @@ class GtfsRtFullPartitionConverter(GtfsRtConverter):
                 # can start yielding tables for the intervals that are complete.
                 # this relies on self.files being sorted - enforced by add_files(),
                 # and ThreadPoolExecutor/map yields __next__ iterator, i.e. returns in the right order
-                if len(self.data_parts) > 1:
+
+                needs_yield = any(not self.data_parts[k].yielded for k in self.data_parts)
+
+                if len(self.data_parts) > 1 and needs_yield:
                     yield from self.yield_check_periodic(process_logger, result_dt)
 
         # at the end of the executor, there are no files remaining. we flush=true
@@ -278,50 +287,57 @@ class GtfsRtFullPartitionConverter(GtfsRtConverter):
         Returns an iterable of tuples: (table, interval_start, flush)
         """
         current_interval = assign_datetime_to_binned_interval(current_ts, self.time_chunk_minutes)
+
         for iter_ts in list(self.data_parts.keys()):
             table = self.data_parts[iter_ts].table
 
-            # yield if we've moved past this interval
-            # or if flushing all remaining data
+            if self.data_parts[iter_ts].yielded:
+                continue
+
+            # yield if we've moved past this interval or flushing
             if flush or current_interval > iter_ts:
-                # only populate archive_files if we're in live ingestion mode
-                if self.move_source_on_completion:
-                    self.archive_files += self.data_parts[iter_ts].files
 
                 process_logger.add_metadata(
                     file_count=len(self.data_parts[iter_ts].files),
                     number_of_rows=table.num_rows,
                     interval_start=iter_ts.isoformat(),
                 )
-                process_logger.log_complete()
                 process_logger.add_metadata(file_count=0, number_of_rows=0, print_log=False)
-                process_logger.log_start()
 
-                if self.unique_config[0]:
-                    keys = self.interval_keys(iter_ts, self.unique_config[1])
+                if self.unique_output_flag and self.lookback_count > 0:
+                    keys = self.interval_keys(iter_ts, self.lookback_count)
                     lookback_tables = [
                         self.data_parts[k].table
                         for k in keys
                         if k in self.data_parts and self.data_parts[k].table is not None
                     ]
+                    combined = pl.from_arrow(pyarrow.concat_tables(lookback_tables))
+                    dedup_cols = [c for c in combined.columns if c != "feed_timestamp"]
 
-                    if lookback_tables:
-                        combined = pl.from_arrow(pyarrow.concat_tables(lookback_tables))
-                        dedup_cols = [c for c in combined.columns if c != "feed_timestamp"]
-                        combined = combined.unique(subset=dedup_cols, keep="first")
-                        table = (
-                            combined.filter(pl.col("feed_timestamp") >= int(iter_ts.timestamp()))
-                            .to_arrow()
-                            .cast(table.schema)
-                        )
+                    # keep="first" is very important here to keep the chunks stable
+                    # otherwise we will delete non-deterministic records from the
+                    # current chunk or previous chunks, changing the record that is
+                    # stored off between calls.
+                    combined = combined.unique(subset=dedup_cols, keep="first")
 
+                    table = (
+                        combined.filter(pl.col("feed_timestamp") >= int(iter_ts.timestamp()))
+                        .to_arrow()
+                        .cast(table.schema)
+                    )
+
+                yield (table, iter_ts, flush)
+                self.data_parts[iter_ts].yielded = True
+
+                if self.unique_output_flag and self.lookback_count > 0:
                     # evict chunks that have fallen out of the lookback window
                     oldest_keep = keys[-1]
                     for old_key in [k for k in self.data_parts if k < oldest_keep]:
+                        if self.move_source_on_completion:
+                            self.archive_files += self.data_parts[old_key].files
                         del self.data_parts[old_key]
-
-                yield (table, iter_ts, flush)
-
-                # only delete the yielded chunk immediately when uniqueing is off
-                if not self.unique_config[0]:
+                else:
+                    # no lookback needed — delete immediately after yield
+                    if self.move_source_on_completion:
+                        self.archive_files += self.data_parts[iter_ts].files
                     del self.data_parts[iter_ts]

--- a/src/lamp_py/ingestion/convert_gtfs_rt_fullset.py
+++ b/src/lamp_py/ingestion/convert_gtfs_rt_fullset.py
@@ -229,7 +229,7 @@ class GtfsRtFullPartitionConverter(GtfsRtConverter):
                 # this relies on self.files being sorted - enforced by add_files(),
                 # and ThreadPoolExecutor/map yields __next__ iterator, i.e. returns in the right order
 
-                needs_yield = any(not self.data_parts[k].yielded for k in self.data_parts)
+                needs_yield = any(not v.yielded for v in self.data_parts.values())
 
                 if len(self.data_parts) > 1 and needs_yield:
                     yield from self.yield_check_periodic(process_logger, result_dt)

--- a/tests/ingestion/test_yield_check_periodic.py
+++ b/tests/ingestion/test_yield_check_periodic.py
@@ -15,7 +15,9 @@ from lamp_py.runtime_utils.remote_files import LAMP
 
 
 def make_converter(
-    time_chunk_minutes: int = 15, move_source_on_completion: bool = False
+    time_chunk_minutes: int = 15,
+    move_source_on_completion: bool = False,
+    unique_config: tuple[bool, int] = (True, 3),
 ) -> GtfsRtFullPartitionConverter:
     """Create a converter with periodic yielding enabled."""
     return GtfsRtFullPartitionConverter(
@@ -23,12 +25,13 @@ def make_converter(
         metadata_queue=Queue(),
         move_source_on_completion=move_source_on_completion,
         time_chunk_minutes=time_chunk_minutes,
+        unique_config=unique_config,
     )
 
 
-def make_dummy_table(num_rows: int = 10) -> pyarrow.Table:
+def make_dummy_table(num_rows: int = 10, feed_timestamp: int = 0) -> pyarrow.Table:
     """Create a minimal pyarrow table for testing."""
-    return pyarrow.table({"col": list(range(num_rows))})
+    return pyarrow.table({"col": list(range(num_rows)), "feed_timestamp": [feed_timestamp] * num_rows})
 
 
 @pytest.mark.parametrize(
@@ -59,6 +62,62 @@ def test_assign_datetime_to_binned_interval(chunk_minutes: int, input_ts: dateti
 
 
 @pytest.mark.parametrize(
+    "chunk_minutes, anchor, lookback, expected_keys",
+    [
+        pytest.param(
+            15,
+            datetime(2026, 5, 4, 1, 30),
+            0,
+            [datetime(2026, 5, 4, 1, 30)],
+            id="15m-no-lookback",
+        ),
+        pytest.param(
+            15,
+            datetime(2026, 5, 4, 1, 30),
+            2,
+            [datetime(2026, 5, 4, 1, 30), datetime(2026, 5, 4, 1, 15), datetime(2026, 5, 4, 1, 0)],
+            id="15m-lookback-2",
+        ),
+        pytest.param(
+            15,
+            datetime(2026, 5, 4, 1, 30),
+            3,
+            [
+                datetime(2026, 5, 4, 1, 30),
+                datetime(2026, 5, 4, 1, 15),
+                datetime(2026, 5, 4, 1, 0),
+                datetime(2026, 5, 4, 0, 45),
+            ],
+            id="15m-lookback-3",
+        ),
+        pytest.param(
+            30,
+            datetime(2026, 5, 4, 2, 0),
+            1,
+            [datetime(2026, 5, 4, 2, 0), datetime(2026, 5, 4, 1, 30)],
+            id="30m-lookback-1",
+        ),
+        pytest.param(
+            15,
+            datetime(2026, 5, 4, 0, 0),
+            1,
+            [datetime(2026, 5, 4, 0, 0), datetime(2026, 5, 3, 23, 45)],
+            id="15m-crosses-midnight",
+        ),
+    ],
+)
+def test_interval_keys(
+    chunk_minutes: int,
+    anchor: datetime,
+    lookback: int,
+    expected_keys: List[datetime],
+) -> None:
+    """interval_keys returns the anchor key plus lookback_count prior keys."""
+    c = make_converter(time_chunk_minutes=chunk_minutes)
+    assert c.interval_keys(anchor, lookback) == expected_keys
+
+
+@pytest.mark.parametrize(
     "interval_minutes, current_ts, flush, expected_yield_count, expected_remaining_keys",
     [
         # current_ts in same interval as data: should not yield
@@ -85,25 +144,26 @@ def test_assign_datetime_to_binned_interval(chunk_minutes: int, input_ts: dateti
             datetime(2026, 5, 4, 1, 35),
             False,
             1,
-            [],
-            id="later-interval-yields",
+            [datetime(2026, 5, 4, 1, 15)],
+            id="later-interval-yields-keeps-for-lookback",
         ),
         # flush yields everything regardless of current_ts
+        # with unique=(True, 3), yielded chunks are retained for lookback
         pytest.param(
             [(1, 0), (1, 15)],
             datetime(2026, 5, 4, 23, 59),
             True,
             2,
-            [],
+            [datetime(2026, 5, 4, 1, 0), datetime(2026, 5, 4, 1, 15)],
             id="flush-yields-all",
         ),
-        # selective yield: current at 01:00, should yield 01:15 and 01:30 but not 01:00
+        # selective yield: current at 01:20, should yield 01:00 but not 01:15 or 01:30
         pytest.param(
             [(1, 0), (1, 15), (1, 30)],
             datetime(2026, 5, 4, 1, 20),
             False,
             1,
-            [datetime(2026, 5, 4, 1, 15), datetime(2026, 5, 4, 1, 30)],
+            [datetime(2026, 5, 4, 1, 0), datetime(2026, 5, 4, 1, 15), datetime(2026, 5, 4, 1, 30)],
             id="selective-yield-older-only",
         ),
     ],
@@ -116,32 +176,32 @@ def test_yield_check_periodic(
     expected_remaining_keys: List[datetime],
 ) -> None:
     """yield_check_periodic yields completed intervals based on current_ts position."""
-    c = make_converter(15)
+    c = make_converter(15, unique_config=(True, 3))
     logger = ProcessLogger("test")
     logger.log_start()
 
     for hour, minute in interval_minutes:
         key = datetime(2026, 5, 4, hour, minute)
         c.data_parts[key] = TableData()
-        c.data_parts[key].table = make_dummy_table(1)
+        c.data_parts[key].table = make_dummy_table(1, feed_timestamp=int(key.timestamp()))
         c.data_parts[key].files = [f"file_{hour}_{minute}.json.gz"]
 
     tables = list(c.yield_check_periodic(logger, current_ts, flush=flush))
 
     assert len(tables) == expected_yield_count
-    assert list(c.data_parts.keys()) == expected_remaining_keys
+    assert sorted(c.data_parts.keys()) == sorted(expected_remaining_keys)
 
 
 @pytest.mark.parametrize("move", [True, False])
 def test_yield_check_periodic_archives_files(move: bool) -> None:
     """Yielded intervals should move their files to archive_files."""
-    c = make_converter(15, move_source_on_completion=move)
+    c = make_converter(15, move_source_on_completion=move, unique_config=(False, 0))
     logger = ProcessLogger("test")
     logger.log_start()
 
     key = datetime(2026, 5, 4, 1, 15)
     c.data_parts[key] = TableData()
-    c.data_parts[key].table = make_dummy_table(5)
+    c.data_parts[key].table = make_dummy_table(5, feed_timestamp=int(key.timestamp()))
     c.data_parts[key].files = ["a.json.gz", "b.json.gz"]
 
     list(c.yield_check_periodic(logger, datetime(2026, 5, 4, 1, 40)))
@@ -175,3 +235,107 @@ def test_clean_local_folders_removes_oldest_day(tmp_path: Path) -> None:
     assert not day_folders[0].exists()
     assert day_folders[1].exists()
     assert day_folders[2].exists()
+
+
+def test_no_unique_deletes_immediately() -> None:
+    """With unique disabled, yielded chunks are deleted from data_parts right away."""
+    c = make_converter(15, unique_config=(False, 0))
+    logger = ProcessLogger("test")
+    logger.log_start()
+
+    key = datetime(2026, 5, 4, 1, 0)
+    c.data_parts[key] = TableData()
+    c.data_parts[key].table = make_dummy_table(1)
+    c.data_parts[key].files = ["f.json.gz"]
+
+    tables = list(c.yield_check_periodic(logger, datetime(2026, 5, 4, 1, 20)))
+    assert len(tables) == 1
+    assert key not in c.data_parts
+
+
+def test_unique_retains_within_lookback() -> None:
+    """With unique enabled, yielded chunks stay in data_parts until they fall out of the lookback window."""
+    c = make_converter(15, unique_config=(True, 2))
+    logger = ProcessLogger("test")
+    logger.log_start()
+
+    # populate 4 consecutive 15-min intervals: 01:00, 01:15, 01:30, 01:45
+    for minute in [0, 15, 30, 45]:
+        key = datetime(2026, 5, 4, 1, minute)
+        c.data_parts[key] = TableData()
+        c.data_parts[key].table = make_dummy_table(1, feed_timestamp=int(key.timestamp()))
+        c.data_parts[key].files = [f"f_{minute}.json.gz"]
+
+    # current_ts at 02:05 -> current_interval = 02:00
+    # all four intervals are older than 02:00, so all should be yielded
+    tables = list(c.yield_check_periodic(logger, datetime(2026, 5, 4, 2, 5)))
+    assert len(tables) == 4
+
+    # with lookback=2, the last yielded chunk is 01:45
+    # oldest_keep for 01:45 is 01:45 - 2*15min = 01:15
+    # so 01:00 should be evicted, but 01:15, 01:30, 01:45 retained
+    assert datetime(2026, 5, 4, 1, 0) not in c.data_parts
+    assert datetime(2026, 5, 4, 1, 15) in c.data_parts
+    assert datetime(2026, 5, 4, 1, 30) in c.data_parts
+    assert datetime(2026, 5, 4, 1, 45) in c.data_parts
+
+
+def test_unique_evicts_oldest_chunks_progressively() -> None:
+    """As new intervals are yielded, older chunks beyond lookback are evicted."""
+    c = make_converter(15, unique_config=(True, 1))
+    logger = ProcessLogger("test")
+    logger.log_start()
+
+    # simulate processing 01:00, 01:15, 01:30 sequentially
+    for minute in [0, 15, 30]:
+        key = datetime(2026, 5, 4, 1, minute)
+        c.data_parts[key] = TableData()
+        c.data_parts[key].table = make_dummy_table(1, feed_timestamp=int(key.timestamp()))
+        c.data_parts[key].files = [f"f_{minute}.json.gz"]
+
+    # current at 01:50 -> yields 01:00, 01:15, 01:30
+    # lookback=1 means each yielded chunk keeps itself + 1 prior
+    # last yielded is 01:30, oldest_keep = 01:30 - 15 = 01:15
+    # so 01:00 is evicted
+    tables = list(c.yield_check_periodic(logger, datetime(2026, 5, 4, 1, 50)))
+    assert len(tables) == 3
+    assert datetime(2026, 5, 4, 1, 0) not in c.data_parts
+    assert datetime(2026, 5, 4, 1, 15) in c.data_parts
+    assert datetime(2026, 5, 4, 1, 30) in c.data_parts
+
+
+def test_flush_with_unique_evicts_old_chunks() -> None:
+    """Flush with unique enabled still evicts chunks beyond the lookback window."""
+    c = make_converter(15, unique_config=(True, 1))
+    logger = ProcessLogger("test")
+    logger.log_start()
+
+    for minute in [0, 15, 30]:
+        key = datetime(2026, 5, 4, 1, minute)
+        c.data_parts[key] = TableData()
+        c.data_parts[key].table = make_dummy_table(1, feed_timestamp=int(key.timestamp()))
+        c.data_parts[key].files = [f"f_{minute}.json.gz"]
+
+    tables = list(c.yield_check_periodic(logger, flush=True))
+    assert len(tables) == 3
+    # last yielded is 01:30, lookback=1, oldest_keep = 01:15
+    assert datetime(2026, 5, 4, 1, 0) not in c.data_parts
+    assert datetime(2026, 5, 4, 1, 15) in c.data_parts
+    assert datetime(2026, 5, 4, 1, 30) in c.data_parts
+
+
+def test_flush_without_unique_deletes_all() -> None:
+    """Flush with unique disabled deletes all yielded chunks immediately."""
+    c = make_converter(15, unique_config=(False, 0))
+    logger = ProcessLogger("test")
+    logger.log_start()
+
+    for minute in [0, 15, 30]:
+        key = datetime(2026, 5, 4, 1, minute)
+        c.data_parts[key] = TableData()
+        c.data_parts[key].table = make_dummy_table(1)
+        c.data_parts[key].files = [f"f_{minute}.json.gz"]
+
+    tables = list(c.yield_check_periodic(logger, flush=True))
+    assert len(tables) == 3
+    assert len(c.data_parts) == 0

--- a/tests/ingestion/test_yield_check_periodic.py
+++ b/tests/ingestion/test_yield_check_periodic.py
@@ -17,7 +17,8 @@ from lamp_py.runtime_utils.remote_files import LAMP
 def make_converter(
     time_chunk_minutes: int = 15,
     move_source_on_completion: bool = False,
-    unique_config: tuple[bool, int] = (True, 3),
+    unique_config: bool = True,
+    lookback_count: int = 3,
 ) -> GtfsRtFullPartitionConverter:
     """Create a converter with periodic yielding enabled."""
     return GtfsRtFullPartitionConverter(
@@ -26,6 +27,7 @@ def make_converter(
         move_source_on_completion=move_source_on_completion,
         time_chunk_minutes=time_chunk_minutes,
         unique_config=unique_config,
+        lookback_count=lookback_count,
     )
 
 
@@ -176,7 +178,7 @@ def test_yield_check_periodic(
     expected_remaining_keys: List[datetime],
 ) -> None:
     """yield_check_periodic yields completed intervals based on current_ts position."""
-    c = make_converter(15, unique_config=(True, 3))
+    c = make_converter(15, unique_config=True, lookback_count=3)
     logger = ProcessLogger("test")
     logger.log_start()
 
@@ -195,7 +197,7 @@ def test_yield_check_periodic(
 @pytest.mark.parametrize("move", [True, False])
 def test_yield_check_periodic_archives_files(move: bool) -> None:
     """Yielded intervals should move their files to archive_files."""
-    c = make_converter(15, move_source_on_completion=move, unique_config=(False, 0))
+    c = make_converter(15, move_source_on_completion=move, unique_config=False, lookback_count=0)
     logger = ProcessLogger("test")
     logger.log_start()
 
@@ -239,7 +241,7 @@ def test_clean_local_folders_removes_oldest_day(tmp_path: Path) -> None:
 
 def test_no_unique_deletes_immediately() -> None:
     """With unique disabled, yielded chunks are deleted from data_parts right away."""
-    c = make_converter(15, unique_config=(False, 0))
+    c = make_converter(15, unique_config=False, lookback_count=0)
     logger = ProcessLogger("test")
     logger.log_start()
 
@@ -255,7 +257,7 @@ def test_no_unique_deletes_immediately() -> None:
 
 def test_unique_retains_within_lookback() -> None:
     """With unique enabled, yielded chunks stay in data_parts until they fall out of the lookback window."""
-    c = make_converter(15, unique_config=(True, 2))
+    c = make_converter(15, unique_config=True, lookback_count=2)
     logger = ProcessLogger("test")
     logger.log_start()
 
@@ -282,7 +284,7 @@ def test_unique_retains_within_lookback() -> None:
 
 def test_unique_evicts_oldest_chunks_progressively() -> None:
     """As new intervals are yielded, older chunks beyond lookback are evicted."""
-    c = make_converter(15, unique_config=(True, 1))
+    c = make_converter(15, unique_config=True, lookback_count=1)
     logger = ProcessLogger("test")
     logger.log_start()
 
@@ -306,7 +308,7 @@ def test_unique_evicts_oldest_chunks_progressively() -> None:
 
 def test_flush_with_unique_evicts_old_chunks() -> None:
     """Flush with unique enabled still evicts chunks beyond the lookback window."""
-    c = make_converter(15, unique_config=(True, 1))
+    c = make_converter(15, unique_config=True, lookback_count=1)
     logger = ProcessLogger("test")
     logger.log_start()
 
@@ -326,7 +328,7 @@ def test_flush_with_unique_evicts_old_chunks() -> None:
 
 def test_flush_without_unique_deletes_all() -> None:
     """Flush with unique disabled deletes all yielded chunks immediately."""
-    c = make_converter(15, unique_config=(False, 0))
+    c = make_converter(15, unique_config=False, lookback_count=0)
     logger = ProcessLogger("test")
     logger.log_start()
 
@@ -339,3 +341,105 @@ def test_flush_without_unique_deletes_all() -> None:
     tables = list(c.yield_check_periodic(logger, flush=True))
     assert len(tables) == 3
     assert len(c.data_parts) == 0
+
+
+def test_no_unique_archives_on_delete() -> None:
+    """With unique disabled and move_source_on_completion, files are archived when chunk is deleted."""
+    c = make_converter(15, move_source_on_completion=True, unique_config=False, lookback_count=0)
+    logger = ProcessLogger("test")
+    logger.log_start()
+
+    for minute in [0, 15]:
+        key = datetime(2026, 5, 4, 1, minute)
+        c.data_parts[key] = TableData()
+        c.data_parts[key].table = make_dummy_table(1)
+        c.data_parts[key].files = [f"f_{minute}.json.gz"]
+
+    list(c.yield_check_periodic(logger, datetime(2026, 5, 4, 1, 35)))
+    assert "f_0.json.gz" in c.archive_files
+    assert "f_15.json.gz" in c.archive_files
+    assert len(c.data_parts) == 0
+
+
+def test_lookback_zero_with_unique_deletes_immediately() -> None:
+    """unique_config=True but lookback_count=0 behaves like no-unique (no dedup possible)."""
+    c = make_converter(15, unique_config=True, lookback_count=0)
+    logger = ProcessLogger("test")
+    logger.log_start()
+
+    key = datetime(2026, 5, 4, 1, 0)
+    c.data_parts[key] = TableData()
+    c.data_parts[key].table = make_dummy_table(1, feed_timestamp=int(key.timestamp()))
+    c.data_parts[key].files = ["f.json.gz"]
+
+    tables = list(c.yield_check_periodic(logger, datetime(2026, 5, 4, 1, 20)))
+    assert len(tables) == 1
+    assert key not in c.data_parts
+
+
+def test_yield_only_once_across_calls() -> None:
+    """A chunk is yielded only once even if yield_check_periodic is called multiple times."""
+    c = make_converter(15, unique_config=True, lookback_count=2)
+    logger = ProcessLogger("test")
+    logger.log_start()
+
+    key = datetime(2026, 5, 4, 1, 0)
+    c.data_parts[key] = TableData()
+    c.data_parts[key].table = make_dummy_table(1, feed_timestamp=int(key.timestamp()))
+    c.data_parts[key].files = ["f.json.gz"]
+
+    # first call yields the chunk
+    tables1 = list(c.yield_check_periodic(logger, datetime(2026, 5, 4, 1, 20)))
+    assert len(tables1) == 1
+
+    # second call should NOT yield it again
+    tables2 = list(c.yield_check_periodic(logger, datetime(2026, 5, 4, 1, 35)))
+    assert len(tables2) == 0
+
+    # chunk still retained for lookback
+    assert key in c.data_parts
+    assert c.data_parts[key].yielded is True
+
+
+def test_eviction_archives_files_for_unique_mode() -> None:
+    """In unique mode, files are archived when a chunk is evicted (not when yielded)."""
+    c = make_converter(15, move_source_on_completion=True, unique_config=True, lookback_count=1)
+    logger = ProcessLogger("test")
+    logger.log_start()
+
+    for minute in [0, 15, 30]:
+        key = datetime(2026, 5, 4, 1, minute)
+        c.data_parts[key] = TableData()
+        c.data_parts[key].table = make_dummy_table(1, feed_timestamp=int(key.timestamp()))
+        c.data_parts[key].files = [f"f_{minute}.json.gz"]
+
+    # yields all three; lookback=1, last yielded is 01:30, oldest_keep=01:15
+    # 01:00 evicted -> its files go to archive
+    list(c.yield_check_periodic(logger, datetime(2026, 5, 4, 1, 50)))
+
+    assert "f_0.json.gz" in c.archive_files
+    # 01:15 and 01:30 are still retained, their files are NOT yet archived
+    assert "f_15.json.gz" not in c.archive_files
+    assert "f_30.json.gz" not in c.archive_files
+
+
+def test_data_parts_size_two_yields_older() -> None:
+    """With exactly 2 data_parts, the older one is yielded when current moves past it."""
+    c = make_converter(15, unique_config=True, lookback_count=1)
+    logger = ProcessLogger("test")
+    logger.log_start()
+
+    for minute in [0, 15]:
+        key = datetime(2026, 5, 4, 1, minute)
+        c.data_parts[key] = TableData()
+        c.data_parts[key].table = make_dummy_table(1, feed_timestamp=int(key.timestamp()))
+        c.data_parts[key].files = [f"f_{minute}.json.gz"]
+
+    # current at 01:20 -> interval 01:15; 01:15 > 01:00 so yields 01:00
+    tables = list(c.yield_check_periodic(logger, datetime(2026, 5, 4, 1, 20)))
+    assert len(tables) == 1
+    assert tables[0][1] == datetime(2026, 5, 4, 1, 0)
+
+    # lookback=1 for 01:00: keys=[01:00, 00:45], oldest_keep=00:45, nothing to evict
+    assert datetime(2026, 5, 4, 1, 0) in c.data_parts
+    assert datetime(2026, 5, 4, 1, 15) in c.data_parts


### PR DESCRIPTION
Set it back to default to uniqueing for now - not sure if there's a need to do non-unique output at the moment. Can re-evaluate if the analysis need arises again. 